### PR TITLE
Afficher un bandeau pour différencier les environnements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -425,3 +425,11 @@ CKEDITOR_CONFIGS = {
 
 FACILITATOR_SLIDE = "https://docs.google.com/presentation/d/e/2PACX-1vRd5lfQWHNEiUNw8yQqBfBnkGyaud5g440IsBvZm9XLEuawQNOfG91MwBlP24Z66A/pub?start=false&loop=false&delayms=3000&slide=id.p1"  # noqa
 FACILITATOR_LIST = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQRtavj-NHym5wjgDu9KRTIDPVZtujFlaSL9Z_BYQ7nWrmkcbGRuL12-VxiNctaOTsgdjQURuPLr57R/pubhtml"  # noqa
+
+
+# Misc
+# ------------------------------------------------------------------------------
+
+# header env notice (not displayed in prod)
+ENV_COLOR_MAPPING = {"dev": "#dc3545", "staging": "#dc3545", "prod": ""}
+BITOUBI_ENV_COLOR = ENV_COLOR_MAPPING.get(BITOUBI_ENV, "")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -431,5 +431,10 @@ FACILITATOR_LIST = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQRtavj-NHym
 # ------------------------------------------------------------------------------
 
 # header env notice (not displayed in prod)
-ENV_COLOR_MAPPING = {"dev": "#dc3545", "staging": "#dc3545", "prod": ""}
+ENV_COLOR_MAPPING = {
+    "dev": "#dc3545",  # red
+    "review_app": "#fd7e14",  # orange
+    "staging": "#ffc107",  # yellow
+    "prod": "",
+}
 BITOUBI_ENV_COLOR = ENV_COLOR_MAPPING.get(BITOUBI_ENV, "")

--- a/lemarche/static/itou_marche/base/_custom.scss
+++ b/lemarche/static/itou_marche/base/_custom.scss
@@ -16,15 +16,20 @@
     border-style: solid;
 }
 
-.navbar-migration {
+#header-env-notice {
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    text-align: center;
+    // background-color:
+}
+#header-notice {
     padding: 0.5em;
     text-align: center;
     background-color: #c3e6cb; // alert-success green // $marche-lightest;
 }
 
-
 .slick-list {
     .slick-loading & {
-      background: $white url('/static/itou/images/ajax-loader.gif') center center no-repeat;
+        background: $white url('/static/itou/images/ajax-loader.gif') center center no-repeat;
     }
-  }
+}

--- a/lemarche/templates/admin/base.html
+++ b/lemarche/templates/admin/base.html
@@ -8,7 +8,7 @@
 <link rel="shortcut icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
 <style>
     #header-env-notice {
-        font-size: 2rem;
+        font-size: 1.5rem;
         text-transform: uppercase;
         text-align: center;
         background-color: {{ BITOUBI_ENV_COLOR }};
@@ -24,7 +24,6 @@
 
     let envNoticeHeader = document.createElement("div");
     envNoticeHeader.setAttribute("id", "header-env-notice");
-    envNoticeHeader.classList.add("text-center");
     envNoticeHeader.innerText = "{{ BITOUBI_ENV }}";
 
     headerDiv.parentNode.insertBefore(envNoticeHeader, headerDiv);

--- a/lemarche/templates/admin/base.html
+++ b/lemarche/templates/admin/base.html
@@ -1,0 +1,33 @@
+<!-- https://github.com/django/django/blob/main/django/contrib/admin/templates/admin/base.html -->
+
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="shortcut icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
+<style>
+    #header-env-notice {
+        font-size: 2rem;
+        text-transform: uppercase;
+        text-align: center;
+        background-color: {{ BITOUBI_ENV_COLOR }};
+    }
+</style>
+{% endblock %}
+
+{% block footer %}
+{{ block.super }}
+{% if BITOUBI_ENV not in "prod" %}
+<script>
+    const headerDiv = document.getElementById("header");
+
+    let envNoticeHeader = document.createElement("div");
+    envNoticeHeader.setAttribute("id", "header-env-notice");
+    envNoticeHeader.classList.add("text-center");
+    envNoticeHeader.innerText = "{{ BITOUBI_ENV }}";
+
+    headerDiv.parentNode.insertBefore(envNoticeHeader, headerDiv);
+</script>
+{% endif %}
+{% endblock %}

--- a/lemarche/templates/admin/base.html
+++ b/lemarche/templates/admin/base.html
@@ -8,6 +8,7 @@
 <link rel="shortcut icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
 <style>
     #header-env-notice {
+        line-height: 1.5;
         font-size: 1.5rem;
         text-transform: uppercase;
         text-align: center;

--- a/lemarche/templates/includes/_header_env_notice.html
+++ b/lemarche/templates/includes/_header_env_notice.html
@@ -1,0 +1,5 @@
+{% if BITOUBI_ENV not in "prod" %}
+<div id="header-env-notice" style="background-color:{{ BITOUBI_ENV_COLOR }}">
+    {{ BITOUBI_ENV }}
+</div>
+{% endif %}

--- a/lemarche/templates/includes/_header_notice.html
+++ b/lemarche/templates/includes/_header_notice.html
@@ -1,0 +1,6 @@
+<div id="header-notice">
+    <p class="mb-0">
+        Le marché de l'inclusion <a href="/2021-10-06-le-marche-fait-peau-neuve/">fait peau neuve</a> !
+        N'hésitez pas à <a href="{% url 'pages:contact' %}">nous remonter</a> le moindre problème.
+    </p>
+</div>

--- a/lemarche/templates/includes/_trackers.html
+++ b/lemarche/templates/includes/_trackers.html
@@ -1,4 +1,4 @@
-{% if BITOUBI_ENV in "staging,prod" %}
+{% if BITOUBI_ENV not in "dev" %}
 <!-- Tarteaucitron -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.9.3/tarteaucitron.min.js"></script> 
 <script type="text/javascript">

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -1,11 +1,7 @@
 {% load static %}
 
-<div class="navbar-migration">
-    <p class="mb-0">
-        Le marché de l'inclusion <a href="/2021-10-06-le-marche-fait-peau-neuve/">fait peau neuve</a> !
-        N'hésitez pas à <a href="{% url 'pages:contact' %}">nous remonter</a> le moindre problème.
-    </p>
-</div>
+{% include "includes/_header_env_notice.html" %}
+{% include "includes/_header_notice.html" %}
 <header id="header" class="s-header s-header--marche sticky-top" role="banner">
     <section class="s-header__container container">
         <div class="s-header__row row">

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -9,6 +9,7 @@ def expose_settings(request):
 
     return {
         "BITOUBI_ENV": settings.BITOUBI_ENV,
+        "BITOUBI_ENV_COLOR": settings.BITOUBI_ENV_COLOR,
         "TRACKER_HOST": settings.TRACKER_HOST,
         "HOTJAR_ID": settings.HOTJAR_ID,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,


### PR DESCRIPTION
### Quoi ?

- Affiche un bandeau en haut lorsque l'application est lancée en dev, staging ou review_app
- Idem dans l'interface admin

### Pourquoi ?

Pour bien différencier les environnements, et éviter de faire de fausses manip en prod

### Captures d'écran
![Screenshot from 2021-11-02 09-05-30](https://user-images.githubusercontent.com/7147385/139809233-3c4662a4-278e-4f30-a1db-d8682a9a759e.png)
![Screenshot from 2021-11-02 09-06-37](https://user-images.githubusercontent.com/7147385/139809236-71d4543f-ab15-4407-8850-5d4852081f49.png)
![Screenshot from 2021-11-02 09-06-11](https://user-images.githubusercontent.com/7147385/139809235-da59db4a-0113-4536-a681-9cbbc31b2c64.png)