### PR TITLE
API : filtrer les structures par réseau

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Ressources :
     - Mise en avant des partenaires sur la page d'accueil (carrousel)
 - Recherche :
     - Pouvoir filtrer par réseau
-Tech :
+- Tech :
     - Pouvoir faire des review apps à la volée sur des PR ouvertes (donnée de test grâce à des fixtures)
     - Afficher un bandeau pour différencier les environnements
 
@@ -31,13 +31,15 @@ Tech :
     - Clarifié le nom du bouton de réinitialisation de la recherche par secteurs
     - Certaines structures n'apparaissaient pas dans les résultats (is_active=False pendant la migration). C'est réparé. Cela concernait ~1000 structures
     - Réparé la redirection lorsqu'une personne non-connectée souhaite télécharger la liste des résultats
-Inscription/connexion :
+- Inscription/connexion :
     - réparé un bug lorsque le lien de réinitialisation du mot de passe était invalide (déjà cliqué)
     - Redirections additionnelles pour les pages de connexion et d'inscription (Cocorico)
-Formulaire de contact :
+- Formulaire de contact :
     - le reply-to est maintenant l'email fourni par l'utilisateur (pour faciliter la réponse sur Zammad)
-API :
-    - Réorganisé la documentation
+- API :
+    - Pouvoir filtrer les structures par réseau
+    - Renvoyer d'avantage d'information dans les détails d'une structure
+    - Réorganisation de la documentation
 
 ### Supprimé
 

--- a/lemarche/api/networks/serializers.py
+++ b/lemarche/api/networks/serializers.py
@@ -12,3 +12,12 @@ class NetworkSerializer(serializers.ModelSerializer):
             "brand",
             "website",
         ]
+
+
+class NetworkSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Network
+        fields = [
+            "name",
+            "slug",
+        ]

--- a/lemarche/api/siaes/filters.py
+++ b/lemarche/api/siaes/filters.py
@@ -1,5 +1,6 @@
 import django_filters
 
+from lemarche.networks.models import Network
 from lemarche.sectors.models import Sector
 from lemarche.siaes.models import Siae
 
@@ -15,6 +16,12 @@ class SiaeFilter(django_filters.FilterSet):
         field_name="sectors__slug",
         to_field_name="slug",
         queryset=Sector.objects.all(),
+    )
+    networks = django_filters.ModelMultipleChoiceFilter(
+        label="Réseau(x)<br /><br /><i>Mettre le slug de chaque réseau</i>",
+        field_name="networks__slug",
+        to_field_name="slug",
+        queryset=Network.objects.all(),
     )
     updated_at = django_filters.IsoDateTimeFromToRangeFilter(label="Date de dernière mise à jour")
 

--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -1,11 +1,43 @@
 from rest_framework import serializers
 
+from lemarche.api.networks.serializers import NetworkSimpleSerializer
 from lemarche.api.sectors.serializers import SectorSimpleSerializer
-from lemarche.siaes.models import Siae
+from lemarche.siaes.models import Siae, SiaeClientReference, SiaeLabel, SiaeOffer
+
+
+class SiaeOfferSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SiaeOffer
+        fields = [
+            "name",
+            "description",
+        ]
+
+
+class SiaeClientReferenceSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SiaeClientReference
+        fields = [
+            "name",
+            "description",
+            "logo_url",
+        ]
+
+
+class SiaeLabelSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SiaeLabel
+        fields = [
+            "name",
+        ]
 
 
 class SiaeSerializer(serializers.ModelSerializer):
     sectors = SectorSimpleSerializer(many=True)
+    networks = NetworkSimpleSerializer(many=True)
+    offers = SiaeOfferSimpleSerializer(many=True)
+    client_references = SiaeClientReferenceSimpleSerializer(many=True)
+    labels = SiaeLabelSimpleSerializer(many=True)
 
     class Meta:
         model = Siae
@@ -19,13 +51,19 @@ class SiaeSerializer(serializers.ModelSerializer):
             "contact_email",
             "contact_phone",
             "contact_website",
+            "address",
             "city",
             "post_code",
             "department",
             "region",
             "is_qpv",
             "is_cocontracting",
+            "is_active",
             "sectors",
+            "networks",
+            "offers",
+            "client_references",
+            "labels",
             "created_at",
             "updated_at",
         ]
@@ -37,6 +75,7 @@ class SiaeAnonSerializer(SiaeSerializer):
         fields = [
             "name",
             "brand",
+            # "slug"
             "siret",
             "city",
             "post_code",
@@ -56,7 +95,13 @@ class SiaeListSerializer(SiaeSerializer):
             "siret",
             "kind",
             "presta_type",
+            # contact stuff available in detail
+            "city",
+            "post_code",
             "department",
+            "region",
+            # boolean stuff available in detail
+            # M2M stuff available in detail
             "created_at",
             "updated_at",
         ]

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from lemarche.networks.factories import NetworkFactory
 from lemarche.sectors.factories import SectorFactory
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.siaes.models import Siae
@@ -18,13 +19,14 @@ class SiaeListApiTest(TestCase):
         url = reverse("api:siae-list")  # anonymous user
         response = self.client.get(url)
         # self.assertEqual(response.data["count"], 12)
-        self.assertEqual(len(response.data["results"]), 10)
-        self.assertTrue("name" in response.data["results"][0])
-        self.assertTrue("siret" in response.data["results"][0])
-        self.assertTrue("kind" in response.data["results"][0])
-        self.assertTrue("presta_type" in response.data["results"][0])
-        self.assertTrue("department" in response.data["results"][0])
-        self.assertTrue("created_at" in response.data["results"][0])
+        # self.assertEqual(len(response.data["results"]), 10)  # results aren't paginated
+        self.assertEqual(len(response.data), 10)
+        self.assertTrue("name" in response.data[0])
+        self.assertTrue("siret" in response.data[0])
+        self.assertTrue("kind" in response.data[0])
+        self.assertTrue("presta_type" in response.data[0])
+        self.assertTrue("department" in response.data[0])
+        self.assertTrue("created_at" in response.data[0])
 
     def test_should_return_detailed_siae_list_to_authenticated_users(self):
         url = reverse("api:siae-list") + "?token=admin"
@@ -38,6 +40,11 @@ class SiaeListApiTest(TestCase):
         self.assertTrue("department" in response.data["results"][0])
         self.assertTrue("created_at" in response.data["results"][0])
 
+    def test_should_return_401_if_token_unknown(self):
+        url = reverse("api:siae-list") + "?token=wrong"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
 
 class SiaeListFilterApiTest(TestCase):
     @classmethod
@@ -47,26 +54,33 @@ class SiaeListFilterApiTest(TestCase):
         SiaeFactory(kind=Siae.KIND_ETTI, presta_type=[Siae.PRESTA_DISP], department="01")  # siae_with_kind
         SiaeFactory(kind=Siae.KIND_ACI, presta_type=[Siae.PRESTA_BUILD], department="01")  # siae_with_presta_type
         SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_PREST], department="38")  # siae_with_department
-        siae_with_sector_1 = SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
         cls.sector_1 = SectorFactory()
+        cls.sector_2 = SectorFactory()
+        siae_with_sector_1 = SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
         siae_with_sector_1.sectors.add(cls.sector_1)
         siae_with_sector_2 = SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
-        cls.sector_2 = SectorFactory()
         siae_with_sector_2.sectors.add(cls.sector_2)
+        cls.network_1 = NetworkFactory()
+        cls.network_2 = NetworkFactory()
+        siae_with_network_1 = SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
+        siae_with_network_1.networks.add(cls.network_1)
+        siae_with_network_2 = SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
+        siae_with_network_2.networks.add(cls.network_2)
         UserFactory(api_key="admin")
 
     def test_should_return_siae_list(self):
         url = reverse("api:siae-list") + "?token=admin"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 6)
-        self.assertEqual(len(response.data["results"]), 6)
+        self.assertEqual(response.data["count"], 4 + 2 + 2)
+        self.assertEqual(len(response.data["results"]), 4 + 2 + 2)
 
     def test_should_not_filter_siae_list_for_anonmyous_user(self):
         # single
         url = reverse("api:siae-list") + f"?kind={Siae.KIND_ETTI}"  # anonymous user
         response = self.client.get(url)
         # self.assertEqual(response.data["count"], 1)
-        self.assertEqual(len(response.data["results"]), 6)
+        # self.assertEqual(len(response.data["results"]), 4 + 2 + 2)  # results aren't paginated
+        self.assertEqual(len(response.data), 4 + 2 + 2)
 
     def test_should_filter_siae_list_by_kind(self):
         # single
@@ -112,6 +126,18 @@ class SiaeListFilterApiTest(TestCase):
         self.assertEqual(response.data["count"], 1 + 1)
         self.assertEqual(len(response.data["results"]), 1 + 1)
 
+    def test_should_filter_siae_list_by_network(self):
+        # single
+        url = reverse("api:siae-list") + f"?networks={self.network_1.slug}&token=admin"
+        response = self.client.get(url)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(len(response.data["results"]), 1)
+        # multiple
+        url = reverse("api:siae-list") + f"?networks={self.network_1.slug}&networks={self.network_2.slug}&token=admin"
+        response = self.client.get(url)
+        self.assertEqual(response.data["count"], 1 + 1)
+        self.assertEqual(len(response.data["results"]), 1 + 1)
+
 
 class SiaeDetailApiTest(TestCase):
     @classmethod
@@ -127,6 +153,11 @@ class SiaeDetailApiTest(TestCase):
         self.assertTrue("slug" not in response.data)
         self.assertTrue("kind" not in response.data)
         self.assertTrue("presta_type" not in response.data)
+        self.assertTrue("sectors" not in response.data)
+        self.assertTrue("networks" not in response.data)
+        self.assertTrue("offers" not in response.data)
+        self.assertTrue("client_references" not in response.data)
+        self.assertTrue("labels" not in response.data)
 
     def test_should_return_detailed_siae_object_to_authenticated_users(self):
         url = reverse("api:siae-detail", args=[self.siae.id]) + "?token=admin"
@@ -136,6 +167,11 @@ class SiaeDetailApiTest(TestCase):
         self.assertTrue("slug" in response.data)
         self.assertTrue("kind" in response.data)
         self.assertTrue("presta_type" in response.data)
+        self.assertTrue("sectors" in response.data)
+        self.assertTrue("networks" in response.data)
+        self.assertTrue("offers" in response.data)
+        self.assertTrue("client_references" in response.data)
+        self.assertTrue("labels" in response.data)
 
 
 class SiaeRetrieveBySiretApiTest(TestCase):

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -42,7 +42,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
                     many=True,
                 )
                 return Response(serializer.data)
-                # return self.get_paginated_response(serializer.data)
             else:
                 ensure_user_permission(token)
                 return super().list(request, format)

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -17,7 +17,7 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     # ModelViewSet needs 'queryset' to be set otherwise the router won't be
     # able to derive the model Basename. To avoid loading data on object
     # initialisation we load an empty queryset.
-    queryset = Siae.objects.prefetch_related("sectors").all()
+    queryset = Siae.objects.prefetch_related("sectors", "networks").all()
     serializer_class = SiaeListSerializer
     filter_class = SiaeFilter
 
@@ -35,24 +35,17 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
         Un <strong>token</strong> est nécessaire pour l'accès complet à cette ressource.
         """
         if request.method == "GET":
-
-            queryset = self.filter_queryset(self.get_queryset())
-            page = self.paginate_queryset(queryset)
-
             token = request.GET.get("token", None)
             if not token:
                 serializer = SiaeListSerializer(
                     Siae.objects.all()[:10],
                     many=True,
                 )
+                return Response(serializer.data)
+                # return self.get_paginated_response(serializer.data)
             else:
                 ensure_user_permission(token)
-                serializer = SiaeListSerializer(
-                    page,
-                    many=True,
-                )
-
-            return self.get_paginated_response(serializer.data)
+                return super().list(request, format)
 
     @extend_schema(
         summary="Détail d'une structure (par son id)",

--- a/lemarche/api/urls.py
+++ b/lemarche/api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from rest_framework import routers
 
@@ -25,7 +25,12 @@ router.register(r"perimeters", PerimeterViewSet, basename="perimeters")
 urlpatterns = [
     path("", TemplateView.as_view(template_name="api/home.html"), name="home"),
     # Additional API endpoints
-    path("siaes/siret/<str:siret>/", SiaeViewSet.as_view({"get": "retrieve_by_siret"}), name="siae-retrieve-by-siret"),
+    path("siae/siret/<str:siret>/", SiaeViewSet.as_view({"get": "retrieve_by_siret"}), name="siae-retrieve-by-siret"),
+    path(
+        "siaes/siret/<str:siret>/",
+        RedirectView.as_view(pattern_name="api:siae-retrieve-by-siret", permanent=True),
+        name="old_api_siae_siret",
+    ),
     # Swagger / OpenAPI documentation
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path("docs/", SpectacularSwaggerView.as_view(url_name="api:schema"), name="swagger-ui"),

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -277,7 +277,7 @@ class Siae(models.Model):
         "sectors.Sector", verbose_name="Secteurs d'activité", related_name="siaes", blank=True
     )
     networks = models.ManyToManyField("networks.Network", verbose_name="Réseaux", related_name="siaes", blank=True)
-    # ForeignKeys: offers, labels, client_references
+    # ForeignKeys: offers, client_references, labels
 
     is_qpv = models.BooleanField(verbose_name="Zone QPV", blank=False, null=False, default=False)
     qpv_name = models.CharField(max_length=255, blank=True, null=True)
@@ -451,23 +451,6 @@ class SiaeOffer(models.Model):
         return self.name
 
 
-class SiaeLabel(models.Model):
-    name = models.CharField(verbose_name="Nom", max_length=255)
-
-    siae = models.ForeignKey("siaes.Siae", verbose_name="Structure", related_name="labels", on_delete=models.CASCADE)
-
-    created_at = models.DateTimeField("Date de création", default=timezone.now)
-    updated_at = models.DateTimeField("Date de modification", auto_now=True)
-
-    class Meta:
-        verbose_name = "Label & certification"
-        verbose_name_plural = "Labels & certifications"
-        # ordering = ["id"]
-
-    def __str__(self):
-        return self.name
-
-
 class SiaeClientReference(models.Model):
     name = models.CharField(verbose_name="Nom", max_length=255, blank=True, null=True)
     description = models.TextField(verbose_name="Description", blank=True)
@@ -489,3 +472,20 @@ class SiaeClientReference(models.Model):
     # def __str__(self):
     #     if self.name:
     #         return self.name
+
+
+class SiaeLabel(models.Model):
+    name = models.CharField(verbose_name="Nom", max_length=255)
+
+    siae = models.ForeignKey("siaes.Siae", verbose_name="Structure", related_name="labels", on_delete=models.CASCADE)
+
+    created_at = models.DateTimeField("Date de création", default=timezone.now)
+    updated_at = models.DateTimeField("Date de modification", auto_now=True)
+
+    class Meta:
+        verbose_name = "Label & certification"
+        verbose_name_plural = "Labels & certifications"
+        # ordering = ["id"]
+
+    def __str__(self):
+        return self.name

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -69,7 +69,9 @@
                                 <td>02/11/2021</td>
                                 <td>0.12</td>
                                 <td>
-                                    - Nouvelle ressource <code>/perimeters/autocomplete</code> dédiée à l'auto-complétion des périmètres
+                                    - Nouvelle ressource <code>/perimeters/autocomplete</code> dédiée à l'auto-complétion des périmètres<br />
+                                    - Possibilité de filtrer les structures par réseau<br />
+                                    - Ajout de champs supplémentaires dans les détails d'une structure
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
### Quoi ?

- filtrer les structures par réseau
- ajouter des champs supplémentaires dans la réponse
- quelques améliorations