### PR TITLE
Moteur de recherche : améliorer l'ordre d'apparition des ESI

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 
 from .base import *  # noqa
 
@@ -12,3 +13,11 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 COMPRESS_OFFLINE = False
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# see https://docs.python.org/3/library/platform.html#platform.win32_ver
+is_windows = any(platform.win32_ver())
+
+if is_windows:
+    # Postgis Django needs GDAL
+    # https://trac.osgeo.org/osgeo4w/
+    GDAL_LIBRARY_PATH = "C:/OSGeo4W/bin/gdal304.dll"

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -7,7 +7,6 @@ from django.contrib.gis.measure import D
 from django.contrib.postgres.fields import ArrayField
 from django.db import IntegrityError, models, transaction
 from django.db.models import Q
-from django.db.models.functions import Lower
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 from django.urls import reverse

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -28,6 +28,12 @@ class SiaeQuerySet(models.QuerySet):
     def is_not_live(self):
         return self.filter(Q(is_active=False) | Q(is_delisted=True))
 
+    def search_query_set(self):
+        return self.is_live().prefetch_related("sectors", "networks", "offers")
+
+    def filter_sectors(self, sectors):
+        return self.filter(sectors__in=sectors)
+
     def has_user(self):
         """Only return siaes who have at least 1 User."""
         return self.filter(users__isnull=False).distinct()

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -77,12 +77,12 @@ class SiaeQuerySet(models.QuerySet):
                 & Q(geo_range_custom_distance__lte=Distance("coords", kwargs["city_coords"]) / 1000)
             )
 
-    def in_city(self, perimeter):
+    def in_city_area(self, perimeter):
         return self.filter(
             Q(post_code__in=perimeter.post_codes)
             | (
                 Q(geo_range=GEO_RANGE_CUSTOM)
-                # w / 1000 ? convert from m to km
+                # why distance / 1000 ? because convert from meter to km
                 & Q(geo_range_custom_distance__gte=Distance("coords", perimeter.coords) / 1000)
             )
             | (Q(geo_range=GEO_RANGE_DEPARTMENT) & Q(department=perimeter.department_code))

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -82,7 +82,7 @@ class SiaeQuerySet(models.QuerySet):
             Q(post_code__in=perimeter.post_codes)
             | (
                 Q(geo_range=GEO_RANGE_CUSTOM)
-                # pourquoi / 1000 ?
+                # w / 1000 ? convert from m to km
                 & Q(geo_range_custom_distance__gte=Distance("coords", perimeter.coords) / 1000)
             )
             | (Q(geo_range=GEO_RANGE_DEPARTMENT) & Q(department=perimeter.department_code))

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -120,7 +120,7 @@ class SiaeSearchForm(forms.Form):
         Depending on the type of Perimeter that was chosen, different cases arise:
 
         **CITY**
-        return the Siae in ths city+department
+        return the Siae with the post code in Perimeter.post_codes+department
         OR the Siae with geo_range=GEO_RANGE_CUSTOM and a perimeter radius that overlaps with the search_perimeter
         OR the Siae with geo_range=GEO_RANGE_DEPARTMENT and a department equal to the search_perimeter's
 
@@ -138,7 +138,7 @@ class SiaeSearchForm(forms.Form):
 
         if perimeter.kind == Perimeter.KIND_CITY:
             # qs = qs.in_range_of_point(city_coords=perimeter.coords)
-            qs = qs.in_city(perimeter=perimeter)
+            qs = qs.in_city_area(perimeter=perimeter)
         elif perimeter.kind == Perimeter.KIND_DEPARTMENT:
             qs = qs.in_department(department_code=perimeter.insee_code)
         elif perimeter.kind == Perimeter.KIND_REGION:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -1,12 +1,11 @@
 from django import forms
-from django.contrib.gis.db.models.functions import Distance
 from django.db.models import BooleanField, Case, Exists, OuterRef, Value, When
 from django.db.models.functions import NullIf
 
 from lemarche.networks.models import Network
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.models import Sector
-from lemarche.siaes.models import Siae, SiaeOffer
+from lemarche.siaes.models import Siae
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
 
@@ -162,15 +161,6 @@ class SiaeSearchForm(forms.Form):
         - if the search is on a CITY perimeter, we order by coordinates first
         """
         ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user", "name"]
-        # annotate on distance to siae if CITY searched
-        # TODO: avoid this second Perimeter query...
-        search_perimeter = self.cleaned_data.get("perimeter", None)
-        if search_perimeter:
-            perimeter = Perimeter.objects.get(slug=search_perimeter)
-            if perimeter and perimeter.kind == Perimeter.KIND_CITY:
-                qs = qs.annotate(distance=Distance("coords", perimeter.coords)).order_by("distance")
-                # ORDER_BY_FIELDS = ["-has_offer", "-has_description", "distance", "-has_user", "name"]
-                # ORDER_BY_FIELDS = ["distance"] + ORDER_BY_FIELDS
         # annotate on SiaeOffer FK exists
         qs = qs.annotate(
             has_offer=Case(

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -144,17 +144,20 @@ class SiaeNetworkSearchFilterTest(TestCase):
 
     def test_search_network_empty(self):
         form = SiaeSearchForm({"networks": ""})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 2)
 
     def test_search_network(self):
         form = SiaeSearchForm({"networks": f"{self.network.slug}"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 1)
 
     def test_search_unknown_network_ignores_filter(self):
         form = SiaeSearchForm({"networks": "coucou"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 2)
 
 
@@ -260,17 +263,20 @@ class SiaePerimeterSearchFilterTest(TestCase):
 
     def test_search_perimeter_empty(self):
         form = SiaeSearchForm({"perimeter": "", "perimeter_name": ""})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 14)
 
     def test_search_perimeter_name_empty(self):
         form = SiaeSearchForm({"perimeter": "old-search", "perimeter_name": ""})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 14)
 
     def test_search_perimeter_name_not_empty(self):
         form = SiaeSearchForm({"perimeter": "", "perimeter_name": "Old Search"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 14)
         self.assertFalse(form.is_valid())
         self.assertIn("perimeter_name", form.errors.keys())
@@ -278,12 +284,14 @@ class SiaePerimeterSearchFilterTest(TestCase):
 
     def test_search_perimeter_region(self):
         form = SiaeSearchForm({"perimeter": "auvergne-rhone-alpes", "perimeter_name": "Auvergne-Rhône-Alpes (région)"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 10)
 
     def test_search_perimeter_department(self):
         form = SiaeSearchForm({"perimeter": "isere", "perimeter_name": "Isère (département)"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 6)
 
     def test_search_perimeter_city(self):
@@ -294,7 +302,8 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department=38 (1 SIAE)
         """
         form = SiaeSearchForm({"perimeter": "grenoble-38", "perimeter_name": "Grenoble (38)"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 2 + 2 + 1)
 
     def test_search_perimeter_city_2(self):
@@ -305,7 +314,8 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department=38 (1 SIAE)
         """
         form = SiaeSearchForm({"perimeter": "chamrousse-38", "perimeter_name": "Chamrousse (38)"})
-        qs = form.filter_queryset()
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 0 + 1 + 1)
 
 

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -162,34 +162,55 @@ class SiaePerimeterSearchFilterTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         # create the Perimeters
-        PerimeterFactory(
+        auvergne_rhone_alpes = PerimeterFactory(
+            name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
+        )
+        grenoble_p = PerimeterFactory(
             name="Grenoble",
             kind=Perimeter.KIND_CITY,
             insee_code="38185",
             department_code="38",
             region_code="84",
+            post_codes=[38000, 38100, 38700],
             coords=Point(5.7301, 45.1825),
         )
-        PerimeterFactory(
+        chambrousse_perimeter = PerimeterFactory(
             name="Chamrousse",
             kind=Perimeter.KIND_CITY,
             insee_code="38567",
             department_code="38",
             region_code="84",
+            post_codes=[38410],
             coords=Point(5.8862, 45.1106),
         )
         PerimeterFactory(name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84")
-        PerimeterFactory(name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84")
         # create the Siaes
-        SiaeFactory(city="Grenoble", department="38", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_COUNTRY)
-        SiaeFactory(city="Grenoble", department="38", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_REGION)
         SiaeFactory(
-            city="Grenoble", department="38", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_DEPARTMENT
+            city=grenoble_p.name,
+            department=grenoble_p.department_code,
+            region=auvergne_rhone_alpes.name,
+            post_code=grenoble_p.post_codes[0],
+            geo_range=Siae.GEO_RANGE_COUNTRY,
         )
         SiaeFactory(
-            city="Grenoble",
-            department="38",
-            region="Auvergne-Rhône-Alpes",
+            city=grenoble_p.name,
+            department=grenoble_p.department_code,
+            region=auvergne_rhone_alpes.name,
+            post_code=grenoble_p.post_codes[0],
+            geo_range=Siae.GEO_RANGE_REGION,
+        )
+        SiaeFactory(
+            city=grenoble_p.name,
+            department=grenoble_p.department_code,
+            region=auvergne_rhone_alpes.name,
+            post_code=grenoble_p.post_codes[1],
+            geo_range=Siae.GEO_RANGE_DEPARTMENT,
+        )
+        SiaeFactory(
+            city=grenoble_p.name,
+            department=grenoble_p.department_code,
+            region=auvergne_rhone_alpes.name,
+            post_code=grenoble_p.post_codes[2],
             geo_range=Siae.GEO_RANGE_CUSTOM,
             geo_range_custom_distance=0,
             coords=Point(5.7301, 45.1825),
@@ -198,27 +219,29 @@ class SiaePerimeterSearchFilterTest(TestCase):
         SiaeFactory(
             city="La Tronche",
             department="38",
-            region="Auvergne-Rhône-Alpes",
+            region=auvergne_rhone_alpes.name,
             geo_range=Siae.GEO_RANGE_CUSTOM,
             geo_range_custom_distance=10,
             coords=Point(5.746, 45.2124),
         )
         # Chamrousse is a city located further away from Grenoble
         SiaeFactory(
-            city="Chamrousse",
+            city=chambrousse_perimeter.name,
             department="38",
-            region="Auvergne-Rhône-Alpes",
+            region=auvergne_rhone_alpes.name,
             geo_range=Siae.GEO_RANGE_CUSTOM,
             geo_range_custom_distance=5,
             coords=Point(5.8862, 45.1106),
         )
-        SiaeFactory(city="Lyon", department="69", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_COUNTRY)
-        SiaeFactory(city="Lyon", department="69", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_REGION)
-        SiaeFactory(city="Lyon", department="69", region="Auvergne-Rhône-Alpes", geo_range=Siae.GEO_RANGE_DEPARTMENT)
+        SiaeFactory(city="Lyon", department="69", region=auvergne_rhone_alpes.name, geo_range=Siae.GEO_RANGE_COUNTRY)
+        SiaeFactory(city="Lyon", department="69", region=auvergne_rhone_alpes.name, geo_range=Siae.GEO_RANGE_REGION)
+        SiaeFactory(
+            city="Lyon", department="69", region=auvergne_rhone_alpes.name, geo_range=Siae.GEO_RANGE_DEPARTMENT
+        )
         SiaeFactory(
             city="Lyon",
             department="69",
-            region="Auvergne-Rhône-Alpes",
+            region=auvergne_rhone_alpes.name,
             geo_range=Siae.GEO_RANGE_CUSTOM,
             geo_range_custom_distance=50,
             coords=Point(4.8236, 45.7685),
@@ -367,7 +390,6 @@ class SiaeSearchOrderTest(TestCase):
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 3)
-        self.assertEqual(siaes[0].distance.km, 0)
         self.assertEqual(siaes[0].name, "ZZ GEO Grenoble")
         self.assertEqual(siaes[1].name, "ZZ GEO La Tronche")
         self.assertEqual(siaes[2].name, "ZZ GEO Pontcharra")

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -177,7 +177,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
             post_codes=[38000, 38100, 38700],
             coords=Point(5.7301, 45.1825),
         )
-        chambrousse_perimeter = PerimeterFactory(
+        chamrousse_perimeter = PerimeterFactory(
             name="Chamrousse",
             kind=Perimeter.KIND_CITY,
             insee_code="38567",
@@ -229,7 +229,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         )
         # Chamrousse is a city located further away from Grenoble
         SiaeFactory(
-            city=chambrousse_perimeter.name,
+            city=chamrousse_perimeter.name,
             department="38",
             region=auvergne_rhone_alpes.name,
             geo_range=Siae.GEO_RANGE_CUSTOM,

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -33,8 +33,9 @@ class SiaeSearchResultsView(FormMixin, ListView):
     def get_queryset(self):
         """Filter results."""
         filter_form = SiaeSearchForm(data=self.request.GET)
-        results = filter_form.filter_queryset()
-        results_ordered = filter_form.order_queryset(results)
+        perimeter = filter_form.get_perimeter()
+        results = filter_form.filter_queryset(perimeter)
+        results_ordered = filter_form.order_queryset(results, perimeter)
         return results_ordered
 
     def get_context_data(self, **kwargs):

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -79,7 +79,8 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
     def get_queryset(self):
         """Filter results."""
         filter_form = SiaeSearchForm(data=self.request.GET)
-        results = filter_form.filter_queryset()
+        perimeter = filter_form.get_perimeter()
+        results = filter_form.filter_queryset(perimeter)
         return results
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?
lorsque je fais une recherche par ville , les résultats s'affichent en fonction de la distance avec le centre ville. 

### Pourquoi ?

Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.

### Comment ?

En tant qu'acheteur je souhaite voir les esi qui ont les informations les plus complètes en premier 

### Autre (optionnel)

- [lien de test local](http://127.0.0.1:8000/prestataires/?sectors=apiculture&sectors=boulangerie-patisserie-confiseries-118&sectors=confiturerie&sectors=fromagerie&sectors=location-vente-de-materiels-de-restauration&sectors=paniers-plateaux-repas&sectors=producteurs-fournisseurs&sectors=restaurants-cantines&sectors=traiteur&sectors=autre-63&perimeter=marseille-13&perimeter_name=Marseille+%2813%29&presta_type=&networks=)
- [lien de test prod](https://lemarche.inclusion.beta.gouv.fr/prestataires/?sectors=apiculture&sectors=boulangerie-patisserie-confiseries-118&sectors=confiturerie&sectors=fromagerie&sectors=location-vente-de-materiels-de-restauration&sectors=paniers-plateaux-repas&sectors=producteurs-fournisseurs&sectors=restaurants-cantines&sectors=traiteur&sectors=autre-63&perimeter=marseille-13&perimeter_name=Marseille+%2813%29&presta_type=&networks=)
