### PR TITLE
Fix du script de mise à jours des champs QPV

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -470,3 +470,8 @@ ENV_COLOR_MAPPING = {
     "prod": "",
 }
 BITOUBI_ENV_COLOR = ENV_COLOR_MAPPING.get(BITOUBI_ENV, "")
+
+# controls how many objects are updated in a single query
+# avoid timeout exception
+# https://docs.djangoproject.com/en/4.0/ref/models/querysets/#bulk-update
+BATCH_SIZE_BULK_UPDATE = env.int("BATCH_SIZE_BULK_UPDATE", 200)

--- a/lemarche/siaes/management/commands/update_api_qpv_fields.py
+++ b/lemarche/siaes/management/commands/update_api_qpv_fields.py
@@ -79,7 +79,9 @@ class Command(BaseCommand):
         finally:
             client.close()
             # we still save siaes qpv status
-            Siae.objects.bulk_update(siaes_to_update, self.FIELDS_TO_BULK_UPDATE)
+            Siae.objects.bulk_update(
+                siaes_to_update, self.FIELDS_TO_BULK_UPDATE, batch_size=settings.BATCH_SIZE_BULK_UPDATE
+            )
 
         self.stdout_messages_sucess(
             [


### PR DESCRIPTION
### Quoi ?

Une exception `Read Timeout` est déclenchée dans l'environnement de production car un trop grand nombre d'insertions d'un seul coup (4700).
 
### Comment ?

Mise en place d'une limitation pour le nombre d'update.
