### PR TITLE
Améliore l'ajout d'images sur le formulaire structure

### DIFF
--- a/lemarche/static/itou_marche/components/_forms.scss
+++ b/lemarche/static/itou_marche/components/_forms.scss
@@ -22,5 +22,5 @@ input[type="radio"] {
     position: relative;
     opacity: 1.0;
     margin-top: 0.3rem;
-    margin-left: -1.25rem;
+    // margin-left: -1.25rem;
 }

--- a/lemarche/static/itou_marche/components/_forms.scss
+++ b/lemarche/static/itou_marche/components/_forms.scss
@@ -15,12 +15,3 @@
     font-weight: 900;
     font-size: 1rem;
 }
-
-// strange behavior where input radio where gone in Chrome
-input[type="radio"] {
-    display: inline-block;
-    position: relative;
-    opacity: 1.0;
-    margin-top: 0.3rem;
-    // margin-left: -1.25rem;
-}

--- a/lemarche/templates/dashboard/siae_edit_info_contact.html
+++ b/lemarche/templates/dashboard/siae_edit_info_contact.html
@@ -190,14 +190,15 @@
 {% block extra_js %}
 <script type="text/javascript" src="{% static 'vendor/dropzone-5.9.3/dropzone.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/s3_upload.js' %}"></script>
-{{ s3_form_values|json_script:"s3-form-values" }}
-{{ s3_upload_config|json_script:"s3-upload-config" }}
+{{ s3_form_values_siae_logo|json_script:"s3-form-values-siae-logo" }}
+{{ s3_upload_config_siae_logo|json_script:"s3-upload-config-siae-logo" }}
 <script type="text/javascript">
+// init dropzone
 s3UploadInit({
     dropzoneSelector: "#logo_form",
     callbackLocationSelector: "#{{ form.logo_url.id_for_label }}",
-    s3FormValuesId: "s3-form-values",
-    s3UploadConfigId: "s3-upload-config",
+    s3FormValuesId: "s3-form-values-siae-logo",
+    s3UploadConfigId: "s3-upload-config-siae-logo",
     // Not really nice
     sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
     sentryCsrfToken: "{{ csrf_token }}"

--- a/lemarche/templates/dashboard/siae_edit_other.html
+++ b/lemarche/templates/dashboard/siae_edit_other.html
@@ -87,24 +87,6 @@
 {% endblock %}
 
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'vendor/dropzone-5.9.3/dropzone.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/s3_upload.js' %}"></script>
-{{ s3_form_values|json_script:"s3-form-values" }}
-{{ s3_upload_config|json_script:"s3-upload-config" }}
-<script type="text/javascript">
-// loop on each dropzone
-Array.from(document.querySelectorAll(".dropzone")).forEach(function(element) {
-    s3UploadInit({
-        dropzoneSelector: `#${element.id}`,
-        callbackLocationSelector: `#${element.id.replace('image_form', 'image_url')}`,
-        s3FormValuesId: "s3-form-values",
-        s3UploadConfigId: "s3-upload-config",
-        // Not really nice
-        sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
-        sentryCsrfToken: "{{ csrf_token }}",
-    });
-})
-</script>
 <script type="text/javascript">
 /**
  * Add formset items dynamically
@@ -112,9 +94,11 @@ Array.from(document.querySelectorAll(".dropzone")).forEach(function(element) {
 const prefixRegex = new RegExp('__prefix__', 'g');
 
 // label formset
-const totalLabelFormset = document.getElementById('id_labels-TOTAL_FORMS');
-const labelFormsetEmptyForm = document.getElementById('label-formset-empty-form');
-const labelFormsetAddMoreButton = document.getElementById('label-formset-add-more');
+const labelIdString = 'id_labels';
+const labelFormsetString = 'label-formset';
+const totalLabelFormset = document.getElementById(`${labelIdString}-TOTAL_FORMS`);
+const labelFormsetEmptyForm = document.getElementById(`${labelFormsetString}-empty-form`);
+const labelFormsetAddMoreButton = document.getElementById(`${labelFormsetString}-add-more`);
 
 labelFormsetAddMoreButton.addEventListener('click', function(e) {
     if (e) { e.preventDefault(); }

--- a/lemarche/templates/dashboard/siae_edit_presta.html
+++ b/lemarche/templates/dashboard/siae_edit_presta.html
@@ -308,9 +308,11 @@ offerFormsetAddMoreButton.addEventListener('click', function(e) {
 });
 
 // client reference formset
-const totalClientReferenceFormset = document.getElementById('id_client_references-TOTAL_FORMS');
-const clientReferenceFormsetEmptyForm = document.getElementById('client-reference-formset-empty-form');
-const clientReferenceFormsetAddMoreButton = document.getElementById('client-reference-formset-add-more');
+const clientReferenceIdString = 'id_client_references';
+const clientReferenceFormsetString = 'client-reference-formset';
+const totalClientReferenceFormset = document.getElementById(`${clientReferenceIdString}-TOTAL_FORMS`);
+const clientReferenceFormsetEmptyForm = document.getElementById(`${clientReferenceFormsetString}-empty-form`);
+const clientReferenceFormsetAddMoreButton = document.getElementById(`${clientReferenceFormsetString}-add-more`);
 
 clientReferenceFormsetAddMoreButton.addEventListener('click', function(e) {
     if (e) { e.preventDefault(); }
@@ -323,11 +325,10 @@ clientReferenceFormsetAddMoreButton.addEventListener('click', function(e) {
     copyClientReferenceFormsetEmptyForm.setAttribute('id', '');
     copyClientReferenceFormsetEmptyForm.setAttribute('class', '');
     clientReferenceFormsetEmptyForm.parentNode.insertBefore(copyClientReferenceFormsetEmptyForm, clientReferenceFormsetEmptyForm);
-    console.log(totalClientReferenceFormset.value)
     // add dropzone
     s3UploadInit({
-        dropzoneSelector: `#id_client_references-${totalClientReferenceFormset.value}-logo_form`,
-        callbackLocationSelector: `#id_client_references-${totalClientReferenceFormset.value}-logo_url`,
+        dropzoneSelector: `#${clientReferenceIdString}-${totalClientReferenceFormset.value}-logo_form`,
+        callbackLocationSelector: `#${clientReferenceIdString}-${totalClientReferenceFormset.value}-logo_url`,
         s3FormValuesId: "s3-form-values",
         s3UploadConfigId: "s3-upload-config",
         // Not really nice
@@ -339,9 +340,11 @@ clientReferenceFormsetAddMoreButton.addEventListener('click', function(e) {
 });
 
 // image formset
-const totalImageFormset = document.getElementById('id_images-TOTAL_FORMS');
-const imageFormsetEmptyForm = document.getElementById('image-formset-empty-form');
-const imageFormsetAddMoreButton = document.getElementById('image-formset-add-more');
+const imageIdString = 'id_images';
+const imageFormsetString = 'image-formset';
+const totalImageFormset = document.getElementById(`${imageIdString}-TOTAL_FORMS`);
+const imageFormsetEmptyForm = document.getElementById(`${imageFormsetString}-empty-form`);
+const imageFormsetAddMoreButton = document.getElementById(`${imageFormsetString}-add-more`);
 
 imageFormsetAddMoreButton.addEventListener('click', function(e) {
     if (e) { e.preventDefault(); }
@@ -354,11 +357,10 @@ imageFormsetAddMoreButton.addEventListener('click', function(e) {
     copyImageFormsetEmptyForm.setAttribute('id', '');
     copyImageFormsetEmptyForm.setAttribute('class', '');
     imageFormsetEmptyForm.parentNode.insertBefore(copyImageFormsetEmptyForm, imageFormsetEmptyForm);
-    console.log(totalImageFormset.value)
     // add dropzone
     s3UploadInit({
-        dropzoneSelector: `#id_images-${totalImageFormset.value}-image_form`,
-        callbackLocationSelector: `#id_images-${totalImageFormset.value}-image_url`,
+        dropzoneSelector: `#${imageIdString}-${totalImageFormset.value}-image_form`,
+        callbackLocationSelector: `#${imageIdString}-${totalImageFormset.value}-image_url`,
         s3FormValuesId: "s3-form-values",
         s3UploadConfigId: "s3-upload-config",
         // Not really nice

--- a/lemarche/templates/dashboard/siae_edit_presta.html
+++ b/lemarche/templates/dashboard/siae_edit_presta.html
@@ -268,20 +268,35 @@
 {% block extra_js %}
 <script type="text/javascript" src="{% static 'vendor/dropzone-5.9.3/dropzone.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/s3_upload.js' %}"></script>
-{{ s3_form_values|json_script:"s3-form-values" }}
-{{ s3_upload_config|json_script:"s3-upload-config" }}
+{{ s3_form_values_client_reference_logo|json_script:"s3-form-values-client-reference-logo" }}
+{{ s3_upload_config_client_reference_logo|json_script:"s3-upload-config-client-reference-logo" }}
+{{ s3_form_values_siae_image|json_script:"s3-form-values-siae-image" }}
+{{ s3_upload_config_siae_image|json_script:"s3-upload-config-siae-image" }}
 <script type="text/javascript">
-// loop on each dropzone
+// init dropzones
 Array.from(document.querySelectorAll(".dropzone")).forEach(function(element) {
-    s3UploadInit({
-        dropzoneSelector: `#${element.id}`,
-        callbackLocationSelector: `#${element.id.replace('logo_form', 'logo_url')}`,
-        s3FormValuesId: "s3-form-values",
-        s3UploadConfigId: "s3-upload-config",
-        // Not really nice
-        sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
-        sentryCsrfToken: "{{ csrf_token }}"
-    });
+    if (element.id.includes("logo_form")) {
+        s3UploadInit({
+            dropzoneSelector: `#${element.id}`,
+            callbackLocationSelector: `#${element.id.replace('logo_form', 'logo_url')}`,
+            s3FormValuesId: "s3-form-values-client-reference-logo",
+            s3UploadConfigId: "s3-upload-config-client-reference-logo",
+            // Not really nice
+            sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
+            sentryCsrfToken: "{{ csrf_token }}"
+        });
+    }
+    if (element.id.includes("image_form")) {
+        s3UploadInit({
+            dropzoneSelector: `#${element.id}`,
+            callbackLocationSelector: `#${element.id.replace('image_form', 'image_url')}`,
+            s3FormValuesId: "s3-form-values-siae-image",
+            s3UploadConfigId: "s3-upload-config-siae-image",
+            // Not really nice
+            sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
+            sentryCsrfToken: "{{ csrf_token }}"
+        });
+    }
 })
 </script>
 <script type="text/javascript">
@@ -329,8 +344,8 @@ clientReferenceFormsetAddMoreButton.addEventListener('click', function(e) {
     s3UploadInit({
         dropzoneSelector: `#${clientReferenceIdString}-${totalClientReferenceFormset.value}-logo_form`,
         callbackLocationSelector: `#${clientReferenceIdString}-${totalClientReferenceFormset.value}-logo_url`,
-        s3FormValuesId: "s3-form-values",
-        s3UploadConfigId: "s3-upload-config",
+        s3FormValuesId: "s3-form-values-client-reference-logo",
+        s3UploadConfigId: "s3-upload-config-client-reference-logo",
         // Not really nice
         sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
         sentryCsrfToken: "{{ csrf_token }}"
@@ -361,8 +376,8 @@ imageFormsetAddMoreButton.addEventListener('click', function(e) {
     s3UploadInit({
         dropzoneSelector: `#${imageIdString}-${totalImageFormset.value}-image_form`,
         callbackLocationSelector: `#${imageIdString}-${totalImageFormset.value}-image_url`,
-        s3FormValuesId: "s3-form-values",
-        s3UploadConfigId: "s3-upload-config",
+        s3FormValuesId: "s3-form-values-siae-image",
+        s3UploadConfigId: "s3-upload-config-siae-image",
         // Not really nice
         sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
         sentryCsrfToken: "{{ csrf_token }}"

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -90,12 +90,7 @@
         <section class="mt-3">
             <div class="container">
                 <div class="messages fr-container fr-my-5w">
-                    {% for message in messages %}
-                        <div class="alert alert-{{ message.tags|default:'info' }} alert-dismissible" role="alert">
-                            <button class="close" type="button" data-dismiss="alert" aria-label="close">×</button>
-                            {{ message|safe }}
-                        </div>
-                    {% endfor %}
+                    {% bootstrap_messages %}
                 </div>
             </div>
         </section>
@@ -146,7 +141,5 @@
     {% endblock %}
 
     {% block extra_js %}{% endblock %}
-
-    {% bootstrap_messages %}
 </body>
 </html>

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -111,8 +111,8 @@ class SiaeEditInfoContactView(LoginRequiredMixin, SiaeOwnerRequiredMixin, Succes
         """
         context = super().get_context_data(**kwargs)
         s3_upload = S3Upload(kind="siae_logo")
-        context["s3_form_values"] = s3_upload.form_values
-        context["s3_upload_config"] = s3_upload.config
+        context["s3_form_values_siae_logo"] = s3_upload.form_values
+        context["s3_upload_config_siae_logo"] = s3_upload.config
         return context
 
     def get_success_url(self):
@@ -151,9 +151,12 @@ class SiaeEditPrestaView(LoginRequiredMixin, SiaeOwnerRequiredMixin, SuccessMess
             context["offer_formset"] = SiaeOfferFormSet(instance=self.object)
             context["client_reference_formset"] = SiaeClientReferenceFormSet(instance=self.object)
             context["image_formset"] = SiaeImageFormSet(instance=self.object)
-        s3_upload = S3Upload(kind="client_reference_logo")
-        context["s3_form_values"] = s3_upload.form_values
-        context["s3_upload_config"] = s3_upload.config
+        s3_upload_client_reference_logo = S3Upload(kind="client_reference_logo")
+        context["s3_form_values_client_reference_logo"] = s3_upload_client_reference_logo.form_values
+        context["s3_upload_config_client_reference_logo"] = s3_upload_client_reference_logo.config
+        s3_upload_siae_image = S3Upload(kind="siae_image")
+        context["s3_form_values_siae_image"] = s3_upload_siae_image.form_values
+        context["s3_upload_config_siae_image"] = s3_upload_siae_image.config
         return context
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

Images
- répare le fait que les images "réalisations" n'étaient pas envoyées dans le bon bucket (avant : `client_reference_logo` ; maintenant : `siae_image`)
- légère clarification du code JS de dropzone

Autre
- répare l'alignement des radio buttons
- évite d'afficher les messages d'alerte/success en double
