### PR TITLE
Bump de l'API à la v1

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -341,6 +341,8 @@ API_ENTREPRISE_TOKEN = env.str("API_ENTREPRISE_TOKEN", "")
 #   if SIAE.is_QPV was update after `today-API_QPV_RELATIVE_DAYS_TO_UPDATE`, we call the API to QPV
 API_QPV_RELATIVE_DAYS_TO_UPDATE = env.int("API_QPV_RELATIVE_DAYS_TO_UPDATE", 60)
 
+API_GOUV_URL = "https://api.gouv.fr/les-api/api-structures-inclusion"
+
 
 # Django REST Framework (DRF)
 # https://www.django-rest-framework.org/
@@ -370,7 +372,7 @@ Plus de détails pour l'obtenir <a href="https://lemarche.inclusion.beta.gouv.fr
 SPECTACULAR_SETTINGS = {
     "TITLE": "API du marché de l'inclusion",
     "DESCRIPTION": API_DESCRIPTION,
-    "VERSION": "0.13",
+    "VERSION": "1.0",
     "CONTACT": {
         "name": "Une question ? Contactez-nous via notre formulaire",
         "url": "https://lemarche.inclusion.beta.gouv.fr/contact/",
@@ -471,7 +473,7 @@ CKEDITOR_CONFIGS = {
 
 
 # External URLs
-# (if you need these settings in the template, add them to the settings_context_processor)
+# (if you need these settings in the template, add them to settings_context_processor.expose_settings)
 # ------------------------------------------------------------------------------
 
 FACILITATOR_SLIDE = "https://docs.google.com/presentation/d/e/2PACX-1vRd5lfQWHNEiUNw8yQqBfBnkGyaud5g440IsBvZm9XLEuawQNOfG91MwBlP24Z66A/pub?start=false&loop=false&delayms=3000&slide=id.p1"  # noqa

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -366,7 +366,7 @@ Une initiative de <a href="https://inclusion.beta.gouv.fr/" target="_blank" rel=
 la Plateforme de l'inclusion</a>
 
 Certaines ressources nécessitent un <strong>token</strong> pour accéder complètement à la donnée.<br />
-Plus de détails pour l'obtenir <a href="https://lemarche.inclusion.beta.gouv.fr/api/">ici</a>.
+Plus de détails pour l'obtenir <a href="https://lemarche.inclusion.beta.gouv.fr/api/#auth">ici</a>.
 """
 
 SPECTACULAR_SETTINGS = {

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -81,6 +81,13 @@
                         </thead>
                         <tbody>
                             <tr>
+                                <td>22/12/2021</td>
+                                <td>1.0</td>
+                                <td>
+                                    - Publication de l'API sur <a href="{{ API_GOUV_URL }}" target="_blank" rel="noopener">api.gouv.fr</a>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td>09/11/2021</td>
                                 <td>0.13</td>
                                 <td>

--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -26,26 +26,24 @@
         <h1>API du marché de l'inclusion</h1>
         <p class="lead">L'API met à disposition le répertoire qualifié des structures d'insertion par l'activité économique.</p>
 
-        <div class="alert alert-warning" role="alert">
-            Service en cours de co-construction.<br />
-            L'API devrait être finalisée et publiée sur <a href="https://api.gouv.fr/" target="_blank" rel="noopener">api.gouv.fr</a> d'ici à la fin de l'année 2021 !
-        </div>
-
         <div class="row mt-5">
             <div class="col-12">
-                <h2>Documentation</h2>
+                <h2 id="doc">Documentation</h2>
                 <p>
-                    Une documentation est disponible pour explorer et tester les possibilités de l'API. Elle liste aussi les dernières nouveautés.
+                    Une documentation est disponible pour explorer et tester les possibilités de l'API.
                 </p>
                 <p>
-                    <a href="{% url 'api:swagger-ui' %}" target="_blank" class="btn btn-outline-primary">📚 Accéder à la documentation</a>
+                    <a href="{% url 'api:swagger-ui' %}" target="_blank" class="btn btn-primary">📚 Accéder à la documentation</a>
+                </p>
+                <p>
+                    L'API est aussi publiée sur <a href="{{ API_GOUV_URL }}" target="_blank" rel="noopener">api.gouv.fr</a>.
                 </p>
             </div>
         </div>
 
         <div class="row mt-5">
             <div class="col-12">
-                <h2>Authentification</h2>
+                <h2 id="auth">Authentification</h2>
 
                 <p>Certaines données nécessitent un <strong>token</strong> (jeton utilisateur).</p>
                 

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -17,4 +17,5 @@ def expose_settings(request):
         "CRISP_ID": settings.CRISP_ID,
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,
         "FACILITATOR_LIST": settings.FACILITATOR_LIST,
+        "API_GOUV_URL": settings.API_GOUV_URL,
     }


### PR DESCRIPTION
### Quoi ?

Après publication de l'API sur api.gouv.fr [ici](https://api.gouv.fr/les-api/api-structures-inclusion), on en profite pour mettre à jour la version de l'API
- passage à la version 1.0
- enlève le message temporaire

