### PR TITLE
Répare la génération de slug des périmètres Région

### DIFF
--- a/lemarche/perimeters/management/commands/import_communes.py
+++ b/lemarche/perimeters/management/commands/import_communes.py
@@ -175,6 +175,9 @@ class Command(BaseCommand):
     def handle(self, dry_run=False, **options):
         self.stdout.write("-" * 80)
         self.stdout.write("Importing Perimeters > communes...")
+        self.stdout.write(
+            f"Before: {Perimeter.objects.filter(kind=Perimeter.KIND_CITY).count()} {Perimeter.KIND_CITY}s"
+        )
 
         self.set_logger(options.get("verbosity"))
 
@@ -192,7 +195,6 @@ class Command(BaseCommand):
                     last_progress = progress
 
                 name = item["nom"]
-                kind = Perimeter.KIND_CITY
                 insee_code = item["code"]
 
                 post_codes = item["codesPostaux"]
@@ -239,16 +241,19 @@ class Command(BaseCommand):
 
                 if not dry_run:
                     Perimeter.objects.update_or_create(
-                        kind=kind,
+                        kind=Perimeter.KIND_CITY,
+                        name=name,
+                        insee_code=insee_code,
+                        post_codes=post_codes,
+                        department_code=department_code,
+                        region_code=region_code,
+                        population=population,
                         defaults={
-                            "name": name,
-                            "insee_code": insee_code,
                             "coords": coords,
-                            "post_codes": post_codes,
-                            "department_code": department_code,
-                            "region_code": region_code,
-                            "population": population,
                         },
                     )
 
         self.stdout.write("Done.")
+        self.stdout.write(
+            f"After: {Perimeter.objects.filter(kind=Perimeter.KIND_CITY).count()} {Perimeter.KIND_CITY}s"
+        )

--- a/lemarche/perimeters/management/commands/import_communes.py
+++ b/lemarche/perimeters/management/commands/import_communes.py
@@ -6,7 +6,6 @@ import os
 
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.management.base import BaseCommand
-from django.template.defaultfilters import slugify
 
 from lemarche.perimeters.models import Perimeter
 from lemarche.siaes.constants import (
@@ -231,11 +230,8 @@ class Command(BaseCommand):
                     self.stderr.write(f"No coordinates for {name}. Skipping…")
                     # continue
 
-                slug = slugify(f"{name}-{department_code}")
-
                 self.logger.debug("-" * 80)
                 self.logger.debug(name)
-                self.logger.debug(slug)
                 self.logger.debug(post_codes)
                 self.logger.debug(insee_code)
                 self.logger.debug(department_code)
@@ -243,7 +239,6 @@ class Command(BaseCommand):
 
                 if not dry_run:
                     Perimeter.objects.update_or_create(
-                        slug=slug,
                         kind=kind,
                         defaults={
                             "name": name,

--- a/lemarche/perimeters/management/commands/import_departements.py
+++ b/lemarche/perimeters/management/commands/import_departements.py
@@ -47,6 +47,9 @@ class Command(BaseCommand):
     def handle(self, dry_run=False, **options):
         self.stdout.write("-" * 80)
         self.stdout.write("Importing Perimeters > departements...")
+        self.stdout.write(
+            f"Before: {Perimeter.objects.filter(kind=Perimeter.KIND_DEPARTMENT).count()} {Perimeter.KIND_DEPARTMENT}s"
+        )
 
         self.set_logger(options.get("verbosity"))
 
@@ -57,7 +60,6 @@ class Command(BaseCommand):
             for i, item in enumerate(json_data):
 
                 name = item["nom"]
-                kind = Perimeter.KIND_DEPARTMENT
                 insee_code = item["code"]
 
                 region_code = item.get("codeRegion")
@@ -70,13 +72,11 @@ class Command(BaseCommand):
                 self.logger.debug(insee_code)
 
                 if not dry_run:
-                    Perimeter.objects.update_or_create(
-                        kind=kind,
-                        defaults={
-                            "name": name,
-                            "insee_code": insee_code,
-                            "region_code": region_code,
-                        },
+                    Perimeter.objects.get_or_create(
+                        kind=Perimeter.KIND_DEPARTMENT,
+                        name=name,
+                        insee_code=insee_code,
+                        region_code=region_code,
                     )
 
         # Also add 'Collectivités d'outre-mer'
@@ -94,18 +94,18 @@ class Command(BaseCommand):
         ]
         for department in MISSING_DEPARTMENTS:
             name = department["nom"]
-            kind = Perimeter.KIND_DEPARTMENT
             insee_code = department["code"]
             region_code = department["codeRegion"]
 
             if not dry_run:
-                Perimeter.objects.update_or_create(
-                    kind=kind,
-                    defaults={
-                        "name": name,
-                        "insee_code": insee_code,
-                        "region_code": region_code,
-                    },
+                Perimeter.objects.get_or_create(
+                    kind=Perimeter.KIND_DEPARTMENT,
+                    name=name,
+                    insee_code=insee_code,
+                    region_code=region_code,
                 )
 
         self.stdout.write("Done.")
+        self.stdout.write(
+            f"After: {Perimeter.objects.filter(kind=Perimeter.KIND_DEPARTMENT).count()} {Perimeter.KIND_DEPARTMENT}s"
+        )

--- a/lemarche/perimeters/management/commands/import_departements.py
+++ b/lemarche/perimeters/management/commands/import_departements.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 from django.core.management.base import BaseCommand
-from django.template.defaultfilters import slugify
 
 from lemarche.perimeters.models import Perimeter
 from lemarche.siaes.constants import DEPARTMENTS, REGIONS
@@ -66,16 +65,12 @@ class Command(BaseCommand):
                 assert insee_code in DEPARTMENTS
                 assert region_code in REGIONS
 
-                slug = slugify(name)
-
                 self.logger.debug("-" * 80)
                 self.logger.debug(name)
-                self.logger.debug(slug)
                 self.logger.debug(insee_code)
 
                 if not dry_run:
                     Perimeter.objects.update_or_create(
-                        slug=slug,
                         kind=kind,
                         defaults={
                             "name": name,
@@ -87,27 +82,24 @@ class Command(BaseCommand):
         # Also add 'Collectivités d'outre-mer'
         # https://fr.wikipedia.org/wiki/Collectivit%C3%A9_d%27outre-mer
         # https://www.insee.fr/fr/information/2028040
-        if not dry_run:
-            MISSING_DEPARTMENTS = [
-                {"nom": "Saint-Pierre-et-Miquelon", "code": "975", "codeRegion": "97"},
-                {"nom": "Saint-Barthélemy", "code": "977", "codeRegion": "97"},
-                {"nom": "Saint-Martin", "code": "978", "codeRegion": "97"},
-                {"nom": "Terres australes et antarctiques françaises", "code": "984", "codeRegion": "97"},
-                {"nom": "Wallis-et-Futuna", "code": "986", "codeRegion": "97"},
-                {"nom": "Polynésie française", "code": "987", "codeRegion": "97"},
-                {"nom": "Nouvelle-Calédonie", "code": "988", "codeRegion": "97"},
-                {"nom": "Île de Clipperton", "code": "989", "codeRegion": "97"},
-            ]
-            for department in MISSING_DEPARTMENTS:
-                name = department["nom"]
-                kind = Perimeter.KIND_DEPARTMENT
-                insee_code = department["code"]
-                region_code = department["codeRegion"]
+        MISSING_DEPARTMENTS = [
+            {"nom": "Saint-Pierre-et-Miquelon", "code": "975", "codeRegion": "97"},
+            {"nom": "Saint-Barthélemy", "code": "977", "codeRegion": "97"},
+            {"nom": "Saint-Martin", "code": "978", "codeRegion": "97"},
+            {"nom": "Terres australes et antarctiques françaises", "code": "984", "codeRegion": "97"},
+            {"nom": "Wallis-et-Futuna", "code": "986", "codeRegion": "97"},
+            {"nom": "Polynésie française", "code": "987", "codeRegion": "97"},
+            {"nom": "Nouvelle-Calédonie", "code": "988", "codeRegion": "97"},
+            {"nom": "Île de Clipperton", "code": "989", "codeRegion": "97"},
+        ]
+        for department in MISSING_DEPARTMENTS:
+            name = department["nom"]
+            kind = Perimeter.KIND_DEPARTMENT
+            insee_code = department["code"]
+            region_code = department["codeRegion"]
 
-                slug = slugify(name)
-
+            if not dry_run:
                 Perimeter.objects.update_or_create(
-                    slug=slug,
                     kind=kind,
                     defaults={
                         "name": name,

--- a/lemarche/perimeters/management/commands/import_regions.py
+++ b/lemarche/perimeters/management/commands/import_regions.py
@@ -47,6 +47,9 @@ class Command(BaseCommand):
     def handle(self, dry_run=False, **options):
         self.stdout.write("-" * 80)
         self.stdout.write("Importing Perimeters > regions...")
+        self.stdout.write(
+            f"Before: {Perimeter.objects.filter(kind=Perimeter.KIND_REGION).count()} {Perimeter.KIND_REGION}s"
+        )
 
         self.set_logger(options.get("verbosity"))
 
@@ -57,7 +60,6 @@ class Command(BaseCommand):
             for i, item in enumerate(json_data):
 
                 name = item["nom"]
-                kind = Perimeter.KIND_REGION
                 insee_code = item["code"]
 
                 assert insee_code in REGIONS
@@ -73,27 +75,25 @@ class Command(BaseCommand):
                 self.logger.debug(insee_code)
 
                 if not dry_run:
-                    Perimeter.objects.update_or_create(
-                        kind=kind,
-                        defaults={
-                            "name": name,
-                            "insee_code": insee_code,
-                        },
+                    Perimeter.objects.get_or_create(
+                        kind=Perimeter.KIND_REGION,
+                        name=name,
+                        insee_code=insee_code,
                     )
 
         # Also add 'Collectivités d'outre-mer'
         # https://fr.wikipedia.org/wiki/Collectivit%C3%A9_d%27outre-mer
         name = "Collectivités d'outre-mer"
-        kind = Perimeter.KIND_REGION
         insee_code = "R97"
 
         if not dry_run:
-            Perimeter.objects.update_or_create(
-                kind=kind,
-                defaults={
-                    "name": name,
-                    "insee_code": insee_code,
-                },
+            Perimeter.objects.get_or_create(
+                kind=Perimeter.KIND_REGION,
+                name=name,
+                insee_code=insee_code,
             )
 
         self.stdout.write("Done.")
+        self.stdout.write(
+            f"After: {Perimeter.objects.filter(kind=Perimeter.KIND_REGION).count()} {Perimeter.KIND_REGION}s"
+        )

--- a/lemarche/perimeters/management/commands/import_regions.py
+++ b/lemarche/perimeters/management/commands/import_regions.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 from django.core.management.base import BaseCommand
-from django.template.defaultfilters import slugify
 
 from lemarche.perimeters.models import Perimeter
 from lemarche.siaes.constants import REGIONS
@@ -66,21 +65,15 @@ class Command(BaseCommand):
                 # Important! We need to prefix the regions' insee_code to avoid conflicts with departments
                 insee_code = f"R{insee_code}"
 
-                slug = slugify(name)
-
-                # # Special case: some regions have the same name as a department
-                # # managed in Perimeter.set_slug method
-                # if name in REGIONS_WITH_IDENTICAL_DEPARTMENT_NAME:
-                #     slug = f"{slug}-region"
+                # Note: some regions have the same name as a department
+                # managed in Perimeter.set_slug method
 
                 self.logger.debug("-" * 80)
                 self.logger.debug(name)
-                self.logger.debug(slug)
                 self.logger.debug(insee_code)
 
                 if not dry_run:
                     Perimeter.objects.update_or_create(
-                        slug=slug,
                         kind=kind,
                         defaults={
                             "name": name,
@@ -90,15 +83,12 @@ class Command(BaseCommand):
 
         # Also add 'Collectivités d'outre-mer'
         # https://fr.wikipedia.org/wiki/Collectivit%C3%A9_d%27outre-mer
+        name = "Collectivités d'outre-mer"
+        kind = Perimeter.KIND_REGION
+        insee_code = "R97"
+
         if not dry_run:
-            name = "Collectivités d'outre-mer"
-            kind = Perimeter.KIND_REGION
-            insee_code = "R97"
-
-            slug = slugify(name)
-
             Perimeter.objects.update_or_create(
-                slug=slug,
                 kind=kind,
                 defaults={
                     "name": name,

--- a/lemarche/perimeters/tests.py
+++ b/lemarche/perimeters/tests.py
@@ -13,20 +13,20 @@ class PerimeterModelTest(TestCase):
         cls.perimeter_department = PerimeterFactory(
             name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84"
         )
+        cls.perimeter_department_2 = PerimeterFactory(
+            name="Guadeloupe", kind=Perimeter.KIND_DEPARTMENT, insee_code="971", region_code="01"
+        )
         cls.perimeter_region = PerimeterFactory(
             name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
         )
+        cls.perimeter_region_2 = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
 
     def test_slug_field(self):
         self.assertEqual(self.perimeter_city.slug, "grenoble-38")
         self.assertEqual(self.perimeter_department.slug, "isere")
-        perimeter_department_2 = PerimeterFactory(
-            name="Guadeloupe", kind=Perimeter.KIND_DEPARTMENT, insee_code="971", region_code="01"
-        )
-        self.assertEqual(perimeter_department_2.slug, "guadeloupe")
-        self.assertEqual(self.perimeter_region.slug, "auvergne-rhone-alpes")
-        perimeter_region_2 = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
-        self.assertEqual(perimeter_region_2.slug, "guadeloupe-region")
+        self.assertEqual(self.perimeter_department_2.slug, "guadeloupe")
+        self.assertEqual(self.perimeter_region.slug, "auvergne-rhone-alpes-region")
+        self.assertEqual(self.perimeter_region_2.slug, "guadeloupe-region")
 
     def test_name_display_property(self):
         self.assertEqual(str(self.perimeter_city), "Grenoble (38)")


### PR DESCRIPTION
### Quoi ?

Homogénéise la génération des slugs des périmètres Région : rajoute `-region` en suffix à chacuns

Ca générait des conflits lors des lancements des recettes jetables (entre les quelques régions & départements qui ont le même nom)
