### PR TITLE
Accélère l'import des périmètres sur les recettes jetables

### DIFF
--- a/clevercloud/review-app-after-success.sh
+++ b/clevercloud/review-app-after-success.sh
@@ -13,9 +13,10 @@ if [ "$SKIP_FIXTURES" = true ] ; then
 fi
 
 echo "Loading perimeters"
-django-admin import_regions
-django-admin import_departements
-django-admin import_communes
+# django-admin import_regions
+# django-admin import_departements
+# django-admin import_communes
+PGPASSWORD=$POSTGRESQL_ADDON_PASSWORD pg_restore -d $POSTGRESQL_ADDON_DB -h $POSTGRESQL_ADDON_HOST -p $POSTGRESQL_ADDON_PORT -U $POSTGRESQL_ADDON_USER --if-exists --clean --no-owner --no-privileges $APP_HOME/lemarche/perimeters/management/commands/data/perimeters_20220104.sql
 
 # `ls $APP_HOME` does not work as the current user
 # does not have execution rights on the $APP_HOME directory.


### PR DESCRIPTION
### Quoi ?

Avant : les périmètres étaient importés avec des management commands. Cela prenait plusieurs minutes car il y a 35000 communes
Maintenant : les périmètres ont été exportés sous format sql, et sont importés d'un seul coup
