### PR TITLE
Télécharger directement la liste des structures sur la page "Valoriser vos achats"

### DIFF
--- a/lemarche/static/itou_marche/layouts/_pages.scss
+++ b/lemarche/static/itou_marche/layouts/_pages.scss
@@ -115,7 +115,7 @@
 			}
 			
 			@media (min-width:1200px) {
-				left: 10%;
+				left: 8%;
 			}					
 		}
 	}

--- a/lemarche/templates/dashboard/profile_favorite_list_detail.html
+++ b/lemarche/templates/dashboard/profile_favorite_list_detail.html
@@ -46,7 +46,7 @@
             <div class="col-12 col-lg-4">
                 {% if favorite_list.siaes.count > 0 %}
                 <div class="btn-group w-100 mb-3">
-                    <a href="{% url 'siae:search_results_download' %}?favorite_list={{ favorite_list.slug }}&format=xls" id="csv-submit" class="btn btn-primary btn-ico btn-block" target="_blank">
+                    <a href="{% url 'siae:search_results_download' %}?favorite_list={{ favorite_list.slug }}&format=xls" id="favorite-list-export-xls" class="btn btn-primary btn-ico btn-block" target="_blank">
                         <span>Télécharger la liste (.xls)</span>
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M13 10h5l-6 6-6-6h5V3h2v7zm-9 9h16v-7h2v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-8h2v7z"/></svg>
                     </a>
@@ -54,7 +54,7 @@
                         <span class="sr-only">Plus d'options de téléchargement</span>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right">
-                        <a href="{% url 'siae:search_results_download' %}?favorite_list={{ favorite_list.slug }}&format=csv" id="csv-submit" class="dropdown-item" target="_blank">
+                        <a href="{% url 'siae:search_results_download' %}?favorite_list={{ favorite_list.slug }}&format=csv" id="favorite-list-export-csv" class="dropdown-item" target="_blank">
                             Télécharger la liste (.csv)
                         </a>
                     </div>

--- a/lemarche/templates/pages/valoriser-achats.html
+++ b/lemarche/templates/pages/valoriser-achats.html
@@ -35,13 +35,30 @@
             </div>
             <div class="s-page-menu-01__col s-page-menu-01__col--cta col-12 text-center">
                 <span class="ff-extra-01">créer votre compte et</span>
-                <a href="{% url 'siae:search_results' %}" class="btn btn-primary btn-ico d-block d-md-inline-block">
-                    <span>Télécharger la liste complète</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-                        <path fill="none" d="M0 0h24v24H0z" />
-                        <path d="M13 13v5.585l1.828-1.828 1.415 1.415L12 22.414l-4.243-4.242 1.415-1.415L11 18.585V13h2zM12 2a7.001 7.001 0 0 1 6.954 6.194 5.5 5.5 0 0 1-.953 10.784v-2.014a3.5 3.5 0 1 0-1.112-6.91 5 5 0 1 0-9.777 0 3.5 3.5 0 0 0-1.292 6.88l.18.03v2.014a5.5 5.5 0 0 1-.954-10.784A7 7 0 0 1 12 2z" fill="currentColor" />
-                    </svg>
-                </a>
+                {% if user.is_authenticated %}
+                    <div class="btn-group">
+                        <a href="{% url 'siae:search_results_download' %}?format=xls" id="valoriser-siae-export-xls" class="btn btn-primary btn-ico d-block d-md-inline-block">
+                            <span>Télécharger la liste complète (.xls)</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M13 10h5l-6 6-6-6h5V3h2v7zm-9 9h16v-7h2v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-8h2v7z"/></svg>
+                        </a>
+                        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">Plus d'options de téléchargement</span>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                            <a href="{% url 'siae:search_results_download' %}?format=csv" id="valoriser-siae-export-csv" class="dropdown-item">
+                                Télécharger la liste complète (.csv)
+                            </a>
+                        </div>
+                    </div>
+                {% else %}
+                    <a href="{% url 'auth:login' %}?message=login-to-download&next={% url 'pages:valoriser_achats' %}" id="valoriser-siae-export-anon" class="btn btn-primary btn-ico d-block d-md-inline-block">
+                        <span>Télécharger la liste complète</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                            <path fill="none" d="M0 0h24v24H0z" />
+                            <path d="M13 13v5.585l1.828-1.828 1.415 1.415L12 22.414l-4.243-4.242 1.415-1.415L11 18.585V13h2zM12 2a7.001 7.001 0 0 1 6.954 6.194 5.5 5.5 0 0 1-.953 10.784v-2.014a3.5 3.5 0 1 0-1.112-6.91 5 5 0 1 0-9.777 0 3.5 3.5 0 0 0-1.292 6.88l.18.03v2.014a5.5 5.5 0 0 1-.954-10.784A7 7 0 0 1 12 2z" fill="currentColor" />
+                        </svg>
+                    </a>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -109,20 +109,21 @@
                         <div class="col-sm-6">
                             {% if user.is_authenticated %}
                                 <div class="btn-group btn-block">
-                                    <a href="{% url 'siae:search_results_download' %}?{{ current_search_query }}&format=xls" id="csv-submit" class="btn btn-block btn-outline-primary" target="_blank">
-                                        Télécharger la liste (.xls)
+                                    <a href="{% url 'siae:search_results_download' %}?{{ current_search_query }}&format=xls" id="siae-export-xls" class="btn btn-block btn-outline-primary btn-ico">
+                                        <span>Télécharger la liste (.xls)</span>
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M13 10h5l-6 6-6-6h5V3h2v7zm-9 9h16v-7h2v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-8h2v7z"/></svg>
                                     </a>
                                     <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                         <span class="sr-only">Plus d'options de téléchargement</span>
                                     </button>
                                     <div class="dropdown-menu dropdown-menu-right">
-                                        <a href="{% url 'siae:search_results_download' %}?{{ current_search_query }}&format=csv" id="csv-submit" class="dropdown-item" target="_blank">
+                                        <a href="{% url 'siae:search_results_download' %}?{{ current_search_query }}&format=csv" id="siae-export-csv" class="dropdown-item">
                                             Télécharger la liste (.csv)
                                         </a>
                                     </div>
                                 </div>
                             {% else %}
-                                <a href="{% url 'auth:login' %}?message=login-to-download&next={% url 'siae:search_results' %}?{{ current_search_query_escaped }}" id="csv-submit" class="btn btn-block btn-outline-primary">
+                                <a href="{% url 'auth:login' %}?message=login-to-download&next={% url 'siae:search_results' %}?{{ current_search_query_escaped }}" id="siae-export-anon" class="btn btn-block btn-outline-primary">
                                     Télécharger la liste
                                 </a>
                             {% endif %}

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -89,7 +89,6 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
 
     def get_queryset(self):
         """Filter results."""
-        print(self.request.GET)
         filter_form = SiaeSearchForm(data=self.request.GET)
         perimeter = filter_form.get_perimeter()
         results = filter_form.filter_queryset(perimeter)


### PR DESCRIPTION
### Quoi ?

suite de https://github.com/betagouv/itou-marche/pull/176

- télécharger directement la liste des structures sur la page "Valoriser ses achats"
- proposer les 2 options : XLS & CSV
- rediriger vers la page de connexion si l'utilisateur n'est pas connecté (en attendant la modale)
- améliorer les id de ces boutons pour le tracking
- utiliser le même icon partout

### Pourquoi ?

Sur la page "Valoriser vos achats", l'utilisateur était redirigé vers la page de recherches, ce qui engendrait de la friction (clics supplémentaires).