### PR TITLE
Sentry : ne plus capturer les détails des transactions

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -41,7 +41,7 @@ def sentry_init(dsn):
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=0,
         # Associate users (ID+email+username+IP) to errors.
         # https://docs.sentry.io/platforms/python/django/
         send_default_pii=True,


### PR DESCRIPTION
### Quoi ?

On ne s'en sert pas, elles sont "dropped" de toute façon