### PR TITLE
CRON : fix sur l'export de toutes les structures

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,5 +1,5 @@
 [
-    "0 0 * * 1 $ROOT/clevercloud/siaes_export_all_siae_to_file.sh",
+    "0 0 * * * $ROOT/clevercloud/siaes_export_all_siae_to_file.sh",
     "0 7 * * 1 $ROOT/clevercloud/siaes_sync_c1_c4.sh",
     "20 7 * * 1 $ROOT/clevercloud/siaes_update_api_entreprise_fields.sh",
     "40 7 * * 1 $ROOT/clevercloud/siaes_update_api_qpv_fields.sh"


### PR DESCRIPTION
### Quoi ?

L'export tournait tous les lundi à minuit. Mais il doit tourner *tous les jours* à minuit.

Suite de https://github.com/betagouv/itou-marche/pull/176