### PR TITLE
Recherche : afficher seulement les secteurs d'activités recherchés des structures

### DIFF
--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -1,4 +1,4 @@
-{% load static m2m_list_display %}
+{% load static siae_sectors_display %}
 {% load theme_inclusion %}
 
 <div class="card c-card c-card--marche siae-card">
@@ -29,7 +29,7 @@
                         {% if siae.sectors %}
                         <li class="sc-profile-sectors col-12 col-lg-6 pl-lg-2 mb-3 mb-lg-0 d-flex" title="Secteur(s) d'activité">
                             <img src="{% static_theme_images 'ico-service-line.svg' %}" height="16" alt="" />
-                            <span class="ml-1">{% m2m_list_display siae 'sectors' display_max=3 current_search_query=current_search_query %}</span>
+                            <span class="ml-1">{% siae_sectors_display siae display_max=3 current_search_query=current_search_query %}</span>
                         </li>
                         {% endif %}
                     </ul>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -29,7 +29,7 @@
                         {% if siae.sectors %}
                         <li class="sc-profile-sectors col-12 col-lg-6 pl-lg-2 mb-3 mb-lg-0 d-flex" title="Secteur(s) d'activité">
                             <img src="{% static_theme_images 'ico-service-line.svg' %}" height="16" alt="" />
-                            <span class="ml-1">{% m2m_list_display siae 'sectors' display_max=3 %}</span>
+                            <span class="ml-1">{% m2m_list_display siae 'sectors' display_max=3 current_search_query=current_search_query %}</span>
                         </li>
                         {% endif %}
                     </ul>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -29,7 +29,7 @@
                         {% if siae.sectors %}
                         <li class="sc-profile-sectors col-12 col-lg-6 pl-lg-2 mb-3 mb-lg-0 d-flex" title="Secteur(s) d'activité">
                             <img src="{% static_theme_images 'ico-service-line.svg' %}" height="16" alt="" />
-                            <span class="ml-1">{% m2m_list_display siae 'sectors' 3 %}</span>
+                            <span class="ml-1">{% m2m_list_display siae 'sectors' display_max=3 %}</span>
                         </li>
                         {% endif %}
                     </ul>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -1,5 +1,5 @@
 {% extends "layouts/base.html" %}
-{% load static array_choices_display m2m_list_display %}
+{% load static array_choices_display siae_sectors_display %}
 {% load theme_inclusion %}
 
 {% block title %}{{ siae.name_display }}{{ block.super }}{% endblock %}
@@ -207,7 +207,7 @@
                                     {% if siae.kind == 'ETTI' and siae.sector_count > 3 %}
                                         <li>Multisectoriel</li>
                                     {% elif siae.sector_count %}
-                                        {% m2m_list_display siae 'sectors' display_max=6 current_search_query=current_search_query output_format='li' %}
+                                        {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
                                     {% endif %}
                                 </ul>
                                 {% if not siae.sector_count %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -207,7 +207,7 @@
                                     {% if siae.kind == 'ETTI' and siae.sector_count > 3 %}
                                         <li>Multisectoriel</li>
                                     {% elif siae.sector_count %}
-                                        {% m2m_list_display siae 'sectors' display_max=6 output_format='li' %}
+                                        {% m2m_list_display siae 'sectors' display_max=6 current_search_query=current_search_query output_format='li' %}
                                     {% endif %}
                                 </ul>
                                 {% if not siae.sector_count %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -207,14 +207,7 @@
                                     {% if siae.kind == 'ETTI' and siae.sector_count > 3 %}
                                         <li>Multisectoriel</li>
                                     {% elif siae.sector_count %}
-                                        {% for sector in siae.sectors.all %}
-                                            {% if forloop.counter0 < 7 %}
-                                                <li>{{ sector.name }} {% if sector.name == 'Autre' %}<small>({{ sector.group.name }})</small>{% endif %}</li>
-                                            {% endif %}
-                                        {% endfor %}
-                                        {% if siae.sector_count > 6 %}
-                                            <li>…</li>
-                                        {% endif %}
+                                        {% m2m_list_display siae 'sectors' display_max=6 output_format='li' %}
                                     {% endif %}
                                 </ul>
                                 {% if not siae.sector_count %}

--- a/lemarche/utils/templatetags/m2m_list_display.py
+++ b/lemarche/utils/templatetags/m2m_list_display.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def m2m_list_display(obj, field, display_max=5, output_format="string"):
+def m2m_list_display(obj, field, display_max=5, current_search_query="", output_format="string"):
     """Pretty rendering of M2M fields."""
 
     if type(obj) == Siae:
@@ -18,6 +18,11 @@ def m2m_list_display(obj, field, display_max=5, output_format="string"):
 
     # get values
     values = list(qs)
+
+    # if the search query contains sectors, only return these sectors
+    if field == "sectors":
+        if "sectors=" in current_search_query:
+            values = [elem for elem in values if elem.slug in current_search_query]
 
     # get list of names
     values = [force_str(elem.name) for elem in values if elem.name != "Autre"]

--- a/lemarche/utils/templatetags/m2m_list_display.py
+++ b/lemarche/utils/templatetags/m2m_list_display.py
@@ -1,5 +1,6 @@
 from django import template
 from django.utils.encoding import force_str
+from django.utils.html import mark_safe
 
 from lemarche.siaes.models import Siae
 
@@ -8,16 +9,28 @@ register = template.Library()
 
 
 @register.simple_tag
-def m2m_list_display(obj, field, display_max=5):
+def m2m_list_display(obj, field, display_max=5, output_format="string"):
     """Pretty rendering of M2M fields."""
 
     if type(obj) == Siae:
         if field == "sectors":
             qs = obj.sectors.all()
 
-    values = [force_str(elem.name) for elem in list(qs) if elem.name != "Autre"]
-    values_to_string = ", ".join(values[:display_max])
-    if len(values) > display_max:
-        values_to_string += ", ..."
+    # get values
+    values = list(qs)
 
-    return values_to_string
+    # get list of names
+    values = [force_str(elem.name) for elem in values if elem.name != "Autre"]
+
+    # filter number of displayed values
+    if len(values) > display_max:
+        values = values[:display_max]
+        values.append("…")
+
+    # output format
+    if output_format == "list":
+        return values
+    elif output_format == "li":
+        return mark_safe("".join([f"<li>{elem}</li>" for elem in values]))
+    else:  # "string"
+        return ", ".join(values)

--- a/lemarche/utils/templatetags/siae_sectors_display.py
+++ b/lemarche/utils/templatetags/siae_sectors_display.py
@@ -2,27 +2,22 @@ from django import template
 from django.utils.encoding import force_str
 from django.utils.html import mark_safe
 
-from lemarche.siaes.models import Siae
-
 
 register = template.Library()
 
 
 @register.simple_tag
-def m2m_list_display(obj, field, display_max=5, current_search_query="", output_format="string"):
+def siae_sectors_display(siae, display_max=5, current_search_query="", output_format="string"):
     """Pretty rendering of M2M fields."""
 
-    if type(obj) == Siae:
-        if field == "sectors":
-            qs = obj.sectors.all()
+    qs = siae.sectors.all()
 
     # get values
     values = list(qs)
 
-    # if the search query contains sectors, only return these sectors
-    if field == "sectors":
-        if "sectors=" in current_search_query:
-            values = [elem for elem in values if elem.slug in current_search_query]
+    # if the search query contains sectors, filter values on these sectors
+    if "sectors=" in current_search_query:
+        values = [elem for elem in values if elem.slug in current_search_query]
 
     # get list of names
     values = [force_str(elem.name) for elem in values if elem.name != "Autre"]


### PR DESCRIPTION
### Quoi ?

Si une recherche inclut le filtre sur les secteurs d'activité, alors pour chaque fiche structure retournée on n'affiche que les secteurs d'activités effectivement recherchés (et pas tous les secteurs de la structure)

### Pourquoi ?

Meilleure lisibilité des résultats et des fiches structures.
