### PR TITLE
Meilleur affichage des réseaux

### DIFF
--- a/lemarche/fixtures/django/07_networks.json
+++ b/lemarche/fixtures/django/07_networks.json
@@ -17,7 +17,7 @@
       "fields": {
          "name": "UNAPEI",
          "slug": "unapei",
-         "brand": "UNAPEI",
+         "brand": "",
          "website": "https://www.unapei.org/",
          "created_at": "2021-07-01T12:44:57Z",
          "updated_at": "2021-10-26T22:26:47.574Z"
@@ -29,7 +29,7 @@
       "fields": {
          "name": "UNAI",
          "slug": "unai",
-         "brand": "UNAI",
+         "brand": "",
          "website": "https://unai.fr",
          "created_at": "2021-07-01T12:45:10Z",
          "updated_at": "2021-10-26T22:26:47.578Z"
@@ -41,7 +41,7 @@
       "fields": {
          "name": "Tissons la solidarité",
          "slug": "tissons-la-solidarite",
-         "brand": "Tissons la solidarité",
+         "brand": "",
          "website": "https://www.tissonslasolidarite.fr/",
          "created_at": "2021-07-01T12:45:23Z",
          "updated_at": "2021-10-26T22:26:47.581Z"
@@ -53,7 +53,7 @@
       "fields": {
          "name": "Réseau Envie",
          "slug": "reseau-envie",
-         "brand": "Réseau Envie",
+         "brand": "",
          "website": "https://www.envie.org/",
          "created_at": "2021-07-01T12:45:37Z",
          "updated_at": "2021-10-26T22:26:47.583Z"
@@ -65,7 +65,7 @@
       "fields": {
          "name": "Réseau Cocagne",
          "slug": "reseau-cocagne",
-         "brand": "Réseau Cocagne",
+         "brand": "",
          "website": "http://www.reseaucocagne.asso.fr/",
          "created_at": "2021-07-01T12:45:49Z",
          "updated_at": "2021-10-26T22:26:47.586Z"
@@ -113,7 +113,7 @@
       "fields": {
          "name": "Coorace",
          "slug": "coorace",
-         "brand": "Coorace",
+         "brand": "",
          "website": "http://www.coorace.org/",
          "created_at": "2021-07-01T12:46:46Z",
          "updated_at": "2021-10-26T22:26:47.598Z"
@@ -137,7 +137,7 @@
       "fields": {
          "name": "Chantier Ecole",
          "slug": "chantier-ecole",
-         "brand": "Chantier Ecole",
+         "brand": "",
          "website": "http://www.chantierecole.org/",
          "created_at": "2021-07-01T12:47:25Z",
          "updated_at": "2021-10-26T22:26:47.604Z"

--- a/lemarche/templates/pages/partenaires.html
+++ b/lemarche/templates/pages/partenaires.html
@@ -241,7 +241,7 @@
                         <img src="{% static 'images/logo-partners-fei.min.png' %}" class="img-fluid" alt="Logo de la fédération des entreprises d'insertion" loading="lazy" />
                     </div>
                     <div class="card-body">
-                        <p class="h3 lh-base">FEI</p>
+                        <p class="h3 lh-base">Fédération des Entreprises d'Insertion</p>
                         <p>
                             La fédération créée en 1988 représente les 1404 entreprises d’insertion (EI)
                             et entreprises de travail temporaire d’insertion (ETTI) de France.

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -299,7 +299,12 @@
                                     <h3 class="h2 mb-1 mt-1">Réseaux</h3>
                                     <ul>
                                     {% for network in siae.networks.all %}
-                                        <li><a href="{{ network.website }}" class="network_link" rel="noopener" target="_blank">{{ network.brand }}</a></li>
+                                        <li>
+                                            <a href="{{ network.website }}" class="network_link" rel="noopener" target="_blank">
+                                                <span>{{ network.name }}</span>
+                                                {% if network.brand %}<span>({{ network.brand }})</span>{% endif %}
+                                            </a>
+                                        </li>
                                     {% endfor %}
                                     </ul>
                                 </div>


### PR DESCRIPTION
### Quoi ?

- Afficher le nom du réseau par défaut (et son enseigne entre parenthèses lorsqu'elle est présente)
- Renommer FEI en "Fédération des Entreprises d'Insertion" sur la page Partenaires