### PR TITLE
Renomme 'Mon espace' en 'Tableau de bord'

### DIFF
--- a/lemarche/templates/dashboard/home.html
+++ b/lemarche/templates/dashboard/home.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load static get_verbose_name %}
 
-{% block title %}Mon espace{{ block.super }}{% endblock %}
+{% block title %}Tableau de bord{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -11,7 +11,8 @@
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Mon espace</li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Tableau de bord</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -50,7 +50,7 @@
                                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                                     <!-- <div class="dropdown-header">Bonjour user.full_name</div> -->
                                     <a href="{% url 'dashboard:home' %}" class="dropdown-item">
-                                        Mon espace
+                                        Tableau de bord
                                     </a>
                                     <div class="dropdown-divider"></div>
                                     <a href="{% url 'auth:logout' %}" class="dropdown-item">Déconnexion</a>
@@ -92,18 +92,10 @@
                                 Valoriser vos achats
                             </a>
                         </li>
-                        {% comment 'hidden' %}
-                        <li>
-                            <a href="#" rel="noopener" id="h_fav">
-                                <span>Favoris</span>
-                                <span id="fav-count" class="fs-xs badge badge-marche badge-pill ml-1"></span>
-                            </a>
-                        </li>
-                        {% endcomment %}
                         {% if user.is_authenticated %}
                         <li>
                             <a href="{% url 'dashboard:home' %}" id="h_dashboard" rel="noopener">
-                                <span>Mon espace</span>
+                                <span>Tableau de bord</span>
                             </a>
                         </li>
                         <li>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -45,7 +45,7 @@
                         <li>
                             <div class="dropdown">
                                 <button class="btn btn-outline-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    Mon compte
+                                    Mon espace
                                 </button>
                                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                                     <!-- <div class="dropdown-header">Bonjour user.full_name</div> -->

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -89,7 +89,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(User.objects.count(), self.user_count + 1)
         # user should be automatically logged in
         header = driver.find_element_by_css_selector("header#header")
-        self.assertTrue("Mon compte" in header.text)
+        self.assertTrue("Mon espace" in header.text)
         self.assertTrue("Connexion" not in header.text)
         # should redirect to user dashboard
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('dashboard:home')}")
@@ -127,7 +127,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(User.objects.count(), self.user_count + 1)
         # user should be automatically logged in
         header = driver.find_element_by_css_selector("header#header")
-        self.assertTrue("Mon compte" in header.text)
+        self.assertTrue("Mon espace" in header.text)
         self.assertTrue("Connexion" not in header.text)
         # should redirect to home
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('pages:home')}")
@@ -166,7 +166,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(User.objects.count(), self.user_count + 1)
         # user should be automatically logged in
         header = driver.find_element_by_css_selector("header#header")
-        self.assertTrue("Mon compte" in header.text)
+        self.assertTrue("Mon espace" in header.text)
         self.assertTrue("Connexion" not in header.text)
         # should redirect to home
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('pages:home')}")
@@ -205,7 +205,7 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(User.objects.count(), self.user_count + 1)
         # user should be automatically logged in
         header = driver.find_element_by_css_selector("header#header")
-        self.assertTrue("Mon compte" in header.text)
+        self.assertTrue("Mon espace" in header.text)
         self.assertTrue("Connexion" not in header.text)
         # should redirect to next url
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('siae:search_results')}?kind=ESAT")


### PR DESCRIPTION
### Quoi ?

- renomme 'Mon espace' en 'Tableau de bord'
- renomme 'Mon compte' en 'Mon espace'

### Pourquoi ?

Pour être plus proche de l'UX des emplois
