### PR TITLE
Afficher aussi Multisectoriel dans les résultats de recherche

### DIFF
--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -204,11 +204,7 @@
                             <div class="il-r">
                                 <h3 class="h2 mb-1 mt-1">Secteurs d'activité</h3>
                                 <ul>
-                                    {% if siae.kind == 'ETTI' and siae.sector_count > 3 %}
-                                        <li>Multisectoriel</li>
-                                    {% elif siae.sector_count %}
-                                        {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
-                                    {% endif %}
+                                    {% siae_sectors_display siae display_max=6 current_search_query=current_search_query output_format='li' %}
                                 </ul>
                                 {% if not siae.sector_count %}
                                     <p>Non renseigné</p>

--- a/lemarche/utils/templatetags/siae_sectors_display.py
+++ b/lemarche/utils/templatetags/siae_sectors_display.py
@@ -10,17 +10,20 @@ register = template.Library()
 def siae_sectors_display(siae, display_max=5, current_search_query="", output_format="string"):
     """Pretty rendering of M2M fields."""
 
-    qs = siae.sectors.all()
+    qs = siae.sectors.values()
 
     # get values
     values = list(qs)
 
     # if the search query contains sectors, filter values on these sectors
     if "sectors=" in current_search_query:
-        values = [elem for elem in values if elem.slug in current_search_query]
+        values = [elem for elem in values if elem["slug"] in current_search_query]
+    # if ETTI with many sectors, then display simply "Multisectoriel"
+    elif siae.kind == "ETTI" and len(values) > 3:
+        values = [{"name": "Multisectoriel"}]
 
     # get list of names
-    values = [force_str(elem.name) for elem in values if elem.name != "Autre"]
+    values = [force_str(elem["name"]) for elem in values if elem["name"] != "Autre"]
 
     # filter number of displayed values
     if len(values) > display_max:
@@ -31,6 +34,6 @@ def siae_sectors_display(siae, display_max=5, current_search_query="", output_fo
     if output_format == "list":
         return values
     elif output_format == "li":
-        return mark_safe("".join([f"<li>{elem}</li>" for elem in values]))
+        return mark_safe("".join([f"<li>{elem_name}</li>" for elem_name in values]))
     else:  # "string"
         return ", ".join(values)

--- a/lemarche/utils/templatetags/tests.py
+++ b/lemarche/utils/templatetags/tests.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+
+from lemarche.sectors.factories import SectorFactory
+from lemarche.siaes.factories import SiaeFactory
+from lemarche.utils.templatetags.siae_sectors_display import siae_sectors_display
+
+
+class SiaeSectorDisplayTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.siae_with_one_sector = SiaeFactory()
+        cls.siae_with_two_sectors = SiaeFactory()
+        cls.siae_with_many_sectors = SiaeFactory()
+        cls.siae_etti = SiaeFactory(kind="ETTI")
+        sector_1 = SectorFactory(name="Entretien")
+        sector_2 = SectorFactory(name="Agro")
+        sector_3 = SectorFactory(name="Hygiène")
+        sector_4 = SectorFactory(name="Bâtiment")
+        sector_5 = SectorFactory(name="Informatique")
+        cls.siae_with_one_sector.sectors.add(sector_1)
+        cls.siae_with_two_sectors.sectors.add(sector_1, sector_2)
+        cls.siae_with_many_sectors.sectors.add(sector_1, sector_2, sector_3, sector_4, sector_5)
+        cls.siae_etti.sectors.add(sector_1, sector_2, sector_3, sector_4, sector_5)
+
+    def test_should_return_list_of_siae_sector_strings(self):
+        self.assertEqual(siae_sectors_display(self.siae_with_one_sector), "Entretien")
+        self.assertEqual(siae_sectors_display(self.siae_with_two_sectors), "Agro, Entretien")  # default ordering: name
+        self.assertEqual(
+            siae_sectors_display(self.siae_with_many_sectors), "Agro, Bâtiment, Entretien, Hygiène, Informatique"
+        )
+
+    def test_should_filter_list_of_siae_sectors(self):
+        self.assertEqual(
+            siae_sectors_display(self.siae_with_many_sectors, display_max=3), "Agro, Bâtiment, Entretien, …"
+        )
+
+    def test_should_return_list_in_the_specified_format(self):
+        self.assertEqual(siae_sectors_display(self.siae_with_two_sectors, output_format="list"), ["Agro", "Entretien"])
+        self.assertEqual(
+            siae_sectors_display(self.siae_with_two_sectors, output_format="li"), "<li>Agro</li><li>Entretien</li>"
+        )
+
+    def test_should_have_different_behavior_for_etti(self):
+        self.assertEqual(siae_sectors_display(self.siae_etti), "Multisectoriel")
+
+    def test_should_filter_list_on_current_search_query(self):
+        self.assertEqual(siae_sectors_display(self.siae_with_one_sector, current_search_query="sectors=agro"), "")
+        self.assertEqual(
+            siae_sectors_display(self.siae_with_two_sectors, current_search_query="sectors=entretien"), "Entretien"
+        )
+        self.assertEqual(
+            siae_sectors_display(self.siae_with_many_sectors, current_search_query="sectors=entretien&sectors=agro"),
+            "Agro, Entretien",
+        )
+        # priority is on current_search (over ETTI)
+        self.assertEqual(
+            siae_sectors_display(self.siae_etti, current_search_query="sectors=entretien&sectors=agro"),
+            "Agro, Entretien",
+        )


### PR DESCRIPTION
### Quoi ?

Pour les ETTI avec beaucoup de secteurs d'activité, on affiche déjà "Multisectoriel" sur leur fiche.
L'idée est d'afficher aussi cette information dans la page de résultats.

J'en ai profité pour rajouter des tests sur le templatetag.
