### PR TITLE
Meilleure lisibilité du formulaire de recherche par siret

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -535,6 +535,15 @@ class Siae(models.Model):
         )
         return not has_contact_field and not has_other_fields
 
+    @property
+    def source_display(self):
+        if self.kind == Siae.KIND_ESAT:
+            return "GESAT/Handeco"
+        elif self.kind == Siae.KIND_SEP:
+            return "l'ATIGIP"
+        else:
+            return "l'ASP"
+
     def sectors_list_to_string(self):
         return ", ".join(self.sectors.all().values_list("name", flat=True))
 

--- a/lemarche/static/itou_marche/components/_forms.scss
+++ b/lemarche/static/itou_marche/components/_forms.scss
@@ -2,7 +2,8 @@
     font-weight: bold;
 }
 .form-group-required > label::after,
-.form-group-required > div > label::after {
+.form-group-required > div > label::after,
+label.required::after {
     content: " *";
     font-weight: 900;
     font-size: 1rem;

--- a/lemarche/templates/dashboard/profile_favorite_list.html
+++ b/lemarche/templates/dashboard/profile_favorite_list.html
@@ -47,7 +47,7 @@
                         <div class="form-group col-auto">
                             <button class="btn btn-primary btn-ico" type="submit" name="action" value="create">
                                 <span>Créer</span>
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M11 11V5h2v6h6v2h-6v6h-2v-6H5v-2z"/></svg>
+                                <i class="ri-add-fill ri-lg"></i>
                             </button>
                         </div>
                     </div>

--- a/lemarche/templates/dashboard/profile_favorite_list.html
+++ b/lemarche/templates/dashboard/profile_favorite_list.html
@@ -36,16 +36,19 @@
             <div class="col-12 col-lg-8">
                 <!-- New list -->
                 <h2>Nouvelle liste</h2>
-                <label class="mb-2 d-inline-block font-weight-bold" for="id_name">Créer une {% if favorite_lists.count %}nouvelle {% endif %}liste</label>
                 <form method="POST" action="{% url 'dashboard:profile_favorite_list_create' %}">
                     {% csrf_token %}
+                    {% bootstrap_form_errors form type="all" %}
+                    <label class="mb-2 d-inline-block font-weight-bold" for="id_name">Créer une {% if favorite_lists.count %}nouvelle {% endif %}liste</label>
                     <div class="form-row">
-                        {% bootstrap_form_errors form type="all" %}
                         <div class="form-group col">
-                            {% bootstrap_field form.name show_label=False  %}
+                            {% bootstrap_field form.name show_label=False %}
                         </div>
                         <div class="form-group col-auto">
-                            <button class="btn btn-primary" type="submit" name="action" value="create">Créer</button>
+                            <button class="btn btn-primary btn-ico" type="submit" name="action" value="create">
+                                <span>Créer</span>
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M11 11V5h2v6h6v2h-6v6h-2v-6H5v-2z"/></svg>
+                            </button>
                         </div>
                     </div>
                 </form>

--- a/lemarche/templates/dashboard/siae_edit_info_contact.html
+++ b/lemarche/templates/dashboard/siae_edit_info_contact.html
@@ -63,7 +63,7 @@
         <div class="col-12 col-lg-8">
             <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
                 <fieldset>
-                    <legend class="h4">Données {% if siae.kind == 'ESAT' %}GESAT/Handeco{% elif siae.kind == 'SEP' %}importées{% else %}ASP{% endif %} de votre structure</legend>
+                    <legend class="h4">Données importées provenant de {{ siae.source_display }}</legend>
                     {% bootstrap_field form.name %}
                     {% bootstrap_field form.brand %}
                     {% bootstrap_field form.siret %}

--- a/lemarche/templates/dashboard/siae_search_adopt_confirm.html
+++ b/lemarche/templates/dashboard/siae_search_adopt_confirm.html
@@ -33,7 +33,7 @@
                     Vérifiez si ces données correspondent bien à votre structure.
                 </p>
                 <p class="mb-0">
-                   <i>Données fixes provenant de {% if siae.kind == 'ESAT' %}GESAT/Handeco{% else %}l'ASP{% endif %}.</i>
+                   <i>Données fixes provenant de {{ siae.source_display }}.</i>
                 </p>
                 
                 <hr>

--- a/lemarche/templates/dashboard/siae_search_by_siret.html
+++ b/lemarche/templates/dashboard/siae_search_by_siret.html
@@ -31,24 +31,19 @@
                 <p class="mb-3 mb-lg-5">Si vous en avez plusieurs, vous aurez la possibilité de spécifier d'autres structures par la suite.</p>
 
                 <form method="GET" action="{% url 'dashboard:siae_search_by_siret' %}" class="mb-3 mb-lg-5">
-                    <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
-                        {% bootstrap_form_errors form type="all" %}
-
-                        <fieldset>
-                            {% bootstrap_field form.siret %}
-                        </fieldset>
-
-                    </div>
-
-                    <div class="row mt-3 mt-lg-5 justify-content-end">
-                        <div class="col-12 col-lg-auto px-5 px-lg-6">
-                            <button type="submit" class="btn btn-primary btn-block btn-ico">
+                    {% bootstrap_form_errors form type="all" %}
+                    <label class="mb-2 d-inline-block font-weight-bold required" for="id_siret">Entrez le numéro SIRET ou SIREN de votre structure</label>
+                    <div class="form-row">
+                        <div class="form-group form-group-required col">
+                            {% bootstrap_field form.siret show_label=False %}
+                        </div>
+                        <div class="form-group col-auto">
+                            <button class="btn btn-primary btn-ico" type="submit">
                                 <span>Rechercher</span>
                                 <i class="ri-search-line ri-lg"></i>
                             </button>
                         </div>
                     </div>
-
                 </form>
 
                 {% if siaes %}

--- a/lemarche/templates/dashboard/siae_search_by_siret.html
+++ b/lemarche/templates/dashboard/siae_search_by_siret.html
@@ -50,24 +50,36 @@
                     <h2>{{ siaes.count }} structure{% if siaes.count > 1 %}s{% endif %} trouvée{% if siaes.count > 1 %}s{% endif %}</h2>
                     {% for siae in siaes %}
                         <hr />
-                        <p title="{% get_verbose_name siae 'name' %}" class="mb-0">
-                            <strong>{% get_verbose_name siae 'name' %} :</strong>
-                            {{ siae.name }}
-                        </p>
-                        <p title="{% get_verbose_name siae 'brand' %}" class="mb-0">
-                            <strong>{% get_verbose_name siae 'brand' %} :</strong>
-                            {{ siae.brand|default:'' }}
-                        </p>
-                        <p title="{% get_verbose_name siae 'siret' %}" class="mb-0">
-                            <strong>{% get_verbose_name siae 'siret' %} :</strong>
-                            {{ siae.siret_display }}
-                        </p>
-                        <p title="Localisation" class="mb-0">
-                            <strong>Localisation :</strong>
-                            {{ siae.city }} {{ siae.post_code }}
-                        </p>
-                        <div class="mt-3">
-                            {% if siae.users.count %}
+                        <div class="row">
+                            <div class="col">
+                                <p title="{% get_verbose_name siae 'name' %}" class="mb-0">
+                                    <strong>{% get_verbose_name siae 'name' %} :</strong>
+                                    {{ siae.name }}
+                                </p>
+                                <p title="{% get_verbose_name siae 'brand' %}" class="mb-0">
+                                    <strong>{% get_verbose_name siae 'brand' %} :</strong>
+                                    {{ siae.brand|default:'' }}
+                                </p>
+                                <p title="{% get_verbose_name siae 'siret' %}" class="mb-0">
+                                    <strong>{% get_verbose_name siae 'siret' %} :</strong>
+                                    {{ siae.siret_display }}
+                                </p>
+                                <p title="Localisation" class="mb-0">
+                                    <strong>Localisation :</strong>
+                                    {{ siae.city }} {{ siae.post_code }}
+                                </p>
+                            </div>
+                            {% if not siae.users.count %}
+                                <div class="col text-right">
+                                    <br />
+                                    <a href="{% url 'dashboard:siae_search_adopt_confirm' siae.slug %}" class="btn btn-outline-primary">
+                                        <span>Sélectionner</span>
+                                    </a>
+                                </div>
+                            {% endif %}
+                        </div>
+                        {% if siae.users.count %}
+                            <div class="mt-3">
                                 <div class="alert alert-warning" role="alert">
                                     <p>
                                         <strong>Rejoindre cette structure</strong><br />
@@ -75,12 +87,8 @@
                                         Si vous souhaitez aussi rejoindre cette structure, <strong><a href="{% url 'pages:contact' %}?siret={{ siae.siret }}">contactez le support</a></strong> (indiquez le Siret pour nous aider à retrouver votre structure).
                                     </p>
                                 </div>
-                            {% else %}
-                                <a href="{% url 'dashboard:siae_search_adopt_confirm' siae.slug %}" class="btn btn-outline-primary">
-                                    <span>Sélectionner</span>
-                                </a>
-                            {% endif %}
-                        </div>
+                            </div>
+                        {% endif %}
                     {% endfor %}
                 {% endif %}
                 {% if not siaes and form.is_valid %}

--- a/lemarche/templates/dashboard/siae_search_by_siret.html
+++ b/lemarche/templates/dashboard/siae_search_by_siret.html
@@ -30,7 +30,7 @@
                 <p class="lead mb-0">Recherchez la structure à laquelle vous êtes attaché.</p>
                 <p class="mb-3 mb-lg-5">Si vous en avez plusieurs, vous aurez la possibilité de spécifier d'autres structures par la suite.</p>
 
-                <form method="GET" action="{% url 'dashboard:siae_search_by_siret' %}" class="mb-3 mb-lg-5">
+                <form method="GET" action="{% url 'dashboard:siae_search_by_siret' %}">
                     {% bootstrap_form_errors form type="all" %}
                     <label class="mb-2 d-inline-block font-weight-bold required" for="id_siret">Entrez le numéro SIRET ou SIREN de votre structure</label>
                     <div class="form-row">
@@ -47,6 +47,7 @@
                 </form>
 
                 {% if siaes %}
+                    <h2>{{ siaes.count }} structure{% if siaes.count > 1 %}s{% endif %} trouvée{% if siaes.count > 1 %}s{% endif %}</h2>
                     {% for siae in siaes %}
                         <hr />
                         <p title="{% get_verbose_name siae 'name' %}" class="mb-0">


### PR DESCRIPTION
### Quoi ?

- faire en sorte que le formulaire de recherche prenne moins de place
- indiquer plus clairement le nombre de résultats trouvés
- helper pour afficher la source des données en fonction du type de la structure (ca commencait à être trop long pour le faire dans le frontend)