### PR TITLE
Fix : l'utilisateur ne pouvait pas enlever sa recherche par périmètre 

### DIFF
--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -28,6 +28,7 @@
                 {% if form.errors %}
                     <div class="alert alert-danger" role="alert">{{ form.errors|show_first_form_error_message }}</div>
                 {% endif %}
+                {% bootstrap_form_errors form type="all" %}
                 <div class="row">
                     <div class="col-12 col-lg-8">
                         <div class="row first-row">

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -315,11 +315,26 @@ class SiaePerimeterSearchFilterTest(TestCase):
         qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 14)
 
+    def test_search_perimeter_name_empty_but_perimeter_valid(self):
+        form = SiaeSearchForm({"perimeter": "auvergne-rhone-alpes-region", "perimeter_name": ""})
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
+        self.assertEqual(qs.count(), 14)  # perimeter filter is also ignored
+
     def test_search_perimeter_name_not_empty(self):
         form = SiaeSearchForm({"perimeter": "", "perimeter_name": "Old Search"})
         perimeter = form.get_perimeter()
         qs = form.filter_queryset(perimeter)
         self.assertEqual(qs.count(), 14)
+        self.assertFalse(form.is_valid())
+        self.assertIn("perimeter_name", form.errors.keys())
+        self.assertIn("Périmètre inconnu", form.errors["perimeter_name"][0])
+
+    def test_search_perimeter_name_not_empty_but_perimeter_name_valid(self):
+        form = SiaeSearchForm({"perimeter": "", "perimeter_name": "Auvergne-Rhône-Alpes (région)"})
+        perimeter = form.get_perimeter()
+        qs = form.filter_queryset(perimeter)
+        self.assertEqual(qs.count(), 14)  # perimeter filter is also ignored
         self.assertFalse(form.is_valid())
         self.assertIn("perimeter_name", form.errors.keys())
         self.assertIn("Périmètre inconnu", form.errors["perimeter_name"][0])


### PR DESCRIPTION
### Quoi ?

Bug qui empêchait l'utilisateur d'enlever sa recherche par périmètre (le formulaire était vide, mais ca continuait tout de même à filtrer)
- amélioré la logique
- ajouté des tests
