### PR TITLE
Synchroniser le champ Enseigne depuis le C1

### DIFF
--- a/lemarche/siaes/management/commands/sync_c1_c4.py
+++ b/lemarche/siaes/management/commands/sync_c1_c4.py
@@ -16,7 +16,7 @@ from lemarche.utils.data import rename_dict_key
 
 UPDATE_FIELDS = [
     # "name",  # what happens to the slug if the name is updated?
-    # "brand",
+    "brand",
     # "kind"
     "siret",
     "siret_is_valid",


### PR DESCRIPTION
### Quoi ?

On ne synchronisait ni la Raison sociale (`name`) ni l'Enseigne (`brand`) des structures.
- pour la Raison sociale, c'est touchy, ca provient de l'ASP, et le `slug` a été généré à partir de lui
- mais l'Enseigne est flexible, vide dans la moitié des cas. C'est elle qu'on affiche si le champ est rempli
