### PR TITLE
Renommer le terme QPV

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -137,8 +137,11 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         ),
         ("Données C2", {"fields": Siae.READONLY_FIELDS_FROM_C2}),
         ("Données API Entreprise", {"fields": Siae.READONLY_FIELDS_FROM_API_ENTREPRISE}),
-        ("Données API QPV (Quartiers de la politique de la ville)", {"fields": Siae.READONLY_FIELDS_FROM_QPV}),
-        ("Données API ZRR (Zones de revitalisation rurale)", {"fields": Siae.READONLY_FIELDS_FROM_ZRR}),
+        (
+            "Données API QPV (Quartier prioritaire de la politique de la ville)",
+            {"fields": Siae.READONLY_FIELDS_FROM_QPV},
+        ),
+        ("Données API ZRR (Zone de revitalisation rurale)", {"fields": Siae.READONLY_FIELDS_FROM_ZRR}),
         (
             "Détails",
             {

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -28,8 +28,8 @@ class SiaeSearchForm(forms.Form):
     )
     FORM_PRESTA_CHOICES = EMPTY_CHOICE + Siae.PRESTA_CHOICES
     FORM_TERRITORY_CHOICES = (
-        ("QPV", "Quartiers prioritaire de la ville (QPV)"),
-        ("ZRR", "Zones de revitalisation rurale (ZRR)"),
+        ("QPV", "Quartier prioritaire de la politique de la ville (QPV)"),
+        ("ZRR", "Zone de revitalisation rurale (ZRR)"),
     )
 
     sectors = GroupedModelMultipleChoiceField(


### PR DESCRIPTION
### Quoi ?

QPV
- avant : Quartiers prioritaire de la ville
- maintenant : Quartier prioritaire de la politique de la ville

En profiter pour passer ZRR au singulier aussi.

Mise à jour de l'admin aussi
