### PR TITLE
Espace utilisateur : meilleure gestion des authorizations

### DIFF
--- a/lemarche/www/dashboard/mixins.py
+++ b/lemarche/www/dashboard/mixins.py
@@ -29,7 +29,7 @@ class LoginRequiredUserPassesTestMixin(UserPassesTestMixin):
         return super().dispatch(request, *args, **kwargs)
 
 
-class SiaeUserRequiredMixin(UserPassesTestMixin):
+class SiaeUserRequiredMixin(LoginRequiredUserPassesTestMixin):
     """
     Restrict access to specific users: Siae & Admin
     Where?
@@ -60,7 +60,7 @@ class SiaeMemberRequiredMixin(LoginRequiredUserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("dashboard:home"))
 
 
-class SiaeNotMemberRequiredMixin(UserPassesTestMixin):
+class SiaeNotMemberRequiredMixin(LoginRequiredUserPassesTestMixin):
     """
     Restrict access to users who do not belong to the Siae
     Where?
@@ -77,7 +77,7 @@ class SiaeNotMemberRequiredMixin(UserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("dashboard:home"))
 
 
-class SiaeUserAndNotMemberRequiredMixin(UserPassesTestMixin):
+class SiaeUserAndNotMemberRequiredMixin(LoginRequiredUserPassesTestMixin):
     """
     SiaeUserRequiredMixin + SiaeNotMemberRequiredMixin
     """
@@ -91,7 +91,7 @@ class SiaeUserAndNotMemberRequiredMixin(UserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("dashboard:home"))
 
 
-class FavoriteListOwnerRequiredMixin(UserPassesTestMixin):
+class FavoriteListOwnerRequiredMixin(LoginRequiredUserPassesTestMixin):
     """
     Restrict access to the "view FavoriteList" page to the FavoriteList's user
     """

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -144,9 +144,9 @@ class SiaeEditView(TestCase):
         url = reverse("dashboard:siae_search_by_siret")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        # self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.url.startswith("/accounts/login/"))
 
-    def test_only_siae_user_can_edit_siae(self):
+    def test_siae_user_can_edit_siae(self):
         self.client.login(email=self.user_siae.email, password=DEFAULT_PASSWORD)
         url = reverse("dashboard:siae_edit", args=[self.siae_with_user.slug])
         response = self.client.get(url)
@@ -157,7 +157,7 @@ class SiaeEditView(TestCase):
         url = reverse("dashboard:siae_edit", args=[self.siae_with_user.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        # self.assertEqual(response.url, "/profil/")  # redirects first to siae_users
+        # self.assertEqual(response.url, "/profil/")  # redirects first to siae_edit_info_contact
 
     def test_only_siae_user_can_access_siae_edit_tabs(self):
         SIAE_EDIT_URLS = [

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -98,13 +98,13 @@ class ProfileFavoriteListCreateView(LoginRequiredMixin, SuccessMessageMixin, Cre
         return mark_safe(f"Votre liste d'achat <strong>{cleaned_data['name']}</strong> a été crée avec succès.")
 
 
-class ProfileFavoriteListDetailView(LoginRequiredMixin, FavoriteListOwnerRequiredMixin, DetailView):
+class ProfileFavoriteListDetailView(FavoriteListOwnerRequiredMixin, DetailView):
     template_name = "dashboard/profile_favorite_list_detail.html"
     context_object_name = "favorite_list"
     queryset = FavoriteList.objects.prefetch_related("siaes").all()
 
 
-class ProfileFavoriteListEditView(LoginRequiredMixin, FavoriteListOwnerRequiredMixin, SuccessMessageMixin, UpdateView):
+class ProfileFavoriteListEditView(FavoriteListOwnerRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = ProfileFavoriteEditForm
     template_name = "siaes/_favorite_list_edit_modal.html"
     success_message = "Votre liste d'achat a été modifiée avec succès."
@@ -117,9 +117,7 @@ class ProfileFavoriteListEditView(LoginRequiredMixin, FavoriteListOwnerRequiredM
         return reverse_lazy("dashboard:profile_favorite_list_detail", args=[self.kwargs.get("slug")])
 
 
-class ProfileFavoriteListDeleteView(
-    LoginRequiredMixin, FavoriteListOwnerRequiredMixin, SuccessMessageMixin, DeleteView
-):
+class ProfileFavoriteListDeleteView(FavoriteListOwnerRequiredMixin, SuccessMessageMixin, DeleteView):
     template_name = "siaes/_favorite_list_delete_modal.html"
     model = FavoriteList
     # success_message = "Votre liste d'achat a été supprimée avec succès."
@@ -163,7 +161,7 @@ class ProfileFavoriteItemDeleteView(LoginRequiredMixin, SuccessMessageMixin, Del
         )
 
 
-class SiaeSearchBySiretView(LoginRequiredMixin, SiaeUserRequiredMixin, FormMixin, ListView):
+class SiaeSearchBySiretView(SiaeUserRequiredMixin, FormMixin, ListView):
     form_class = SiaeSearchBySiretForm
     template_name = "dashboard/siae_search_by_siret.html"
     context_object_name = "siaes"
@@ -195,9 +193,7 @@ class SiaeSearchBySiretView(LoginRequiredMixin, SiaeUserRequiredMixin, FormMixin
         return super().get(request, *args, **kwargs)
 
 
-class SiaeSearchAdoptConfirmView(
-    LoginRequiredMixin, SiaeUserAndNotMemberRequiredMixin, SuccessMessageMixin, UpdateView
-):
+class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeSearchAdoptConfirmForm
     template_name = "dashboard/siae_search_adopt_confirm.html"
     context_object_name = "siae"
@@ -254,7 +250,7 @@ class SiaeUsersView(SiaeMemberRequiredMixin, DetailView):
         return context
 
 
-class SiaeEditInfoContactView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeEditInfoContactView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeEditInfoContactForm
     template_name = "dashboard/siae_edit_info_contact.html"
     context_object_name = "siae"
@@ -275,7 +271,7 @@ class SiaeEditInfoContactView(LoginRequiredMixin, SiaeMemberRequiredMixin, Succe
         return reverse_lazy("dashboard:siae_edit_info_contact", args=[self.kwargs.get("slug")])
 
 
-class SiaeEditOfferView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeEditOfferView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeEditOfferForm
     template_name = "dashboard/siae_edit_offer.html"
     context_object_name = "siae"
@@ -286,7 +282,7 @@ class SiaeEditOfferView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMess
         return reverse_lazy("dashboard:siae_edit_offer", args=[self.kwargs.get("slug")])
 
 
-class SiaeEditPrestaView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeEditPrestaView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeEditPrestaForm
     template_name = "dashboard/siae_edit_presta.html"
     context_object_name = "siae"
@@ -349,7 +345,7 @@ class SiaeEditPrestaView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMes
         return reverse_lazy("dashboard:siae_edit_presta", args=[self.kwargs.get("slug")])
 
 
-class SiaeEditOtherView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeEditOtherView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeEditOtherForm
     template_name = "dashboard/siae_edit_other.html"
     context_object_name = "siae"
@@ -390,7 +386,7 @@ class SiaeEditOtherView(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMess
         return reverse_lazy("dashboard:siae_edit_other", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserRequestConfirm(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeUserRequestConfirm(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeUserRequestForm
     template_name = "siaes/_siae_user_request_confirm_modal.html"
     context_object_name = "siaeuserrequest"
@@ -419,7 +415,7 @@ class SiaeUserRequestConfirm(LoginRequiredMixin, SiaeMemberRequiredMixin, Succes
         return reverse_lazy("dashboard:siae_users", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserRequestCancel(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeUserRequestCancel(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeUserRequestForm
     template_name = "siaes/_siae_user_request_cancel_modal.html"
     context_object_name = "siaeuserrequest"

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -442,7 +442,7 @@ class SiaeUserRequestCancel(SiaeMemberRequiredMixin, SuccessMessageMixin, Update
         return reverse_lazy("dashboard:siae_users", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserDelete(LoginRequiredMixin, SiaeMemberRequiredMixin, SuccessMessageMixin, DeleteView):
+class SiaeUserDelete(SiaeMemberRequiredMixin, SuccessMessageMixin, DeleteView):
     template_name = "siaes/_siae_user_delete_modal.html"
     model = SiaeUser
     # success_message = "L'utilisateur a été supprimé de votre structure."

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -239,7 +239,7 @@ class SiaeSearchAdoptConfirmView(
             return HttpResponseRedirect(self.get_success_url())
 
 
-class SiaeUsersView(LoginRequiredMixin, SiaeMemberRequiredMixin, DetailView):
+class SiaeUsersView(SiaeMemberRequiredMixin, DetailView):
     template_name = "dashboard/siae_users.html"
     context_object_name = "siae"
     queryset = Siae.objects.all()


### PR DESCRIPTION
### Quoi ?

On utilisait plusieurs mixins sur certains vues du Dashboard, mais elles ne se comportaient pas comme souhaité.
En fait il n'est pas possible de stacker plusieurs mixins sur une même vue (comme pourrait le faire express.js en Node). En particulier, on souhaitait souvent avoir 2 vérifications : 
- est-ce que l'utilisateur est connecté ou pas ? `LoginRequiredMixin` (si non, redirigé vers la page de login + paramètre `next=?`
- est-ce que l'utilisateur a le droit d'accéder à cette page ou pas ? (si non, redirigé en général vers son tableau de bord `/profil/`)

Du coup la solution est de basculer le comportement de `LoginRequiredMixin` directement dans les mixins d'authorizations