### PR TITLE
Automatiser la maj des Coords lorsque l'adresse d'une structure change

### DIFF
--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -21,6 +21,7 @@ class SiaeFactory(DjangoModelFactory):
     city = factory.Faker("city", locale="fr_FR")
     post_code = factory.Faker("postalcode")
     department = factory.fuzzy.FuzzyChoice([key for (key, value) in Siae.DEPARTMENT_CHOICES])
+    region = factory.fuzzy.FuzzyChoice([key for (key, value) in Siae.REGION_CHOICES])
 
 
 class SiaeOfferFactory(DjangoModelFactory):

--- a/lemarche/siaes/tasks.py
+++ b/lemarche/siaes/tasks.py
@@ -11,7 +11,7 @@ def set_siae_coords(model, siae):
     geocoding_data = get_geocoding_data(siae.address + " " + siae.city, post_code=siae.post_code)
     if geocoding_data:
         if siae.post_code != geocoding_data["post_code"]:
-            if siae.post_code[:2] == geocoding_data["post_code"][:2]:
+            if not siae.post_code or (siae.post_code[:2] == geocoding_data["post_code"][:2]):
                 # update post_code as well
                 model.objects.filter(id=siae.id).update(
                     coords=geocoding_data["coords"], post_code=geocoding_data["post_code"]

--- a/lemarche/siaes/tasks.py
+++ b/lemarche/siaes/tasks.py
@@ -1,0 +1,27 @@
+from huey.contrib.djhuey import task
+
+from lemarche.utils.apis.geocoding import get_geocoding_data
+
+
+@task()
+def set_siae_coords(model, siae):
+    """
+    Why do we use filter+update here? To avoid calling Siae.post_save signal again (recursion)
+    """
+    geocoding_data = get_geocoding_data(siae.address + " " + siae.city, post_code=siae.post_code)
+    if geocoding_data:
+        if siae.post_code != geocoding_data["post_code"]:
+            if siae.post_code[:2] == geocoding_data["post_code"][:2]:
+                # update post_code as well
+                model.objects.filter(id=siae.id).update(
+                    coords=geocoding_data["coords"], post_code=geocoding_data["post_code"]
+                )
+            else:
+                print(
+                    f"Geocoding found a different place,{siae.name},{siae.post_code},{geocoding_data['post_code']}"  # noqa
+                )
+        else:
+            # s.coords = geocoding_data["coords"]
+            model.objects.filter(id=siae.id).update(coords=geocoding_data["coords"])
+    else:
+        print(f"Geocoding not found,{siae.name},{siae.post_code}")

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -194,6 +194,16 @@ class SiaeModelSaveTest(TestCase):
         self.assertEqual(siae.employees_insertion_count, 15)
         self.assertNotEqual(siae.employees_insertion_count_last_updated, employees_insertion_count_last_updated)
 
+    def test_update_address_coords_field(self):
+        siae = SiaeFactory(address="", post_code="", city="", department="", region="")
+        self.assertEqual(siae.address, "")
+        self.assertEqual(siae.coords, None)
+        siae.address = "20 Avenue de Segur"
+        siae.city = "Paris"
+        siae.save()
+        siae = Siae.objects.get(id=siae.id)  # we need to fetch it again to make sure
+        self.assertNotEqual(siae.coords, None)
+
 
 class SiaeModelQuerysetTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
### Quoi ?

Maintenant que les admins peuvent modifier d'avantage certaines structures (dans l'admin), il faut que les coordonnées GPS puissent se mettre à jour en temps réel.

Chaque fois que le champ `address` change, on appelle une tâche qui va (ré)générer le champ `coords` de la structure