### PR TITLE
Recherche par nom, enseigne et siret

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -157,12 +157,13 @@ class SiaeQuerySet(models.QuerySet):
     def search_query_set(self):
         return self.is_live().exclude(kind="OPCS").prefetch_many_to_many()
 
+    def filter_siret_startswith(self, siret):
+        return self.filter(siret__startswith=siret)
+
     def filter_full_text(self, full_text_string):
         return self.annotate(
-            search=SearchVector("name", config="french")
-            + SearchVector("brand", config="french")
-            + SearchVector("siret")
-        ).filter(search=full_text_string)
+            search=SearchVector("name", config="french") + SearchVector("brand", config="french")
+        ).filter(Q(search=full_text_string) | Q(siret__startswith=full_text_string))
 
     def filter_sectors(self, sectors):
         return self.filter(sectors__in=sectors)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -176,6 +176,9 @@ class SiaeQuerySet(models.QuerySet):
     def filter_sectors(self, sectors):
         return self.filter(sectors__in=sectors)
 
+    def filter_networks(self, networks):
+        return self.filter(networks__in=networks)
+
     def has_user(self):
         """Only return siaes who have at least 1 User."""
         return self.filter(users__isnull=False).distinct()

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -5,6 +5,7 @@ from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.measure import D
 from django.contrib.postgres.aggregates import ArrayAgg
+from django.contrib.postgres.search import SearchVector
 from django.db import IntegrityError, models, transaction
 from django.db.models import Count, Q
 from django.db.models.signals import m2m_changed, post_delete, post_save
@@ -155,6 +156,9 @@ class SiaeQuerySet(models.QuerySet):
 
     def search_query_set(self):
         return self.is_live().exclude(kind="OPCS").prefetch_many_to_many()
+
+    def filter_full_text(self, full_text_string):
+        return self.annotate(search=SearchVector("name", "brand", "siret")).filter(search=full_text_string)
 
     def filter_sectors(self, sectors):
         return self.filter(sectors__in=sectors)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -158,7 +158,11 @@ class SiaeQuerySet(models.QuerySet):
         return self.is_live().exclude(kind="OPCS").prefetch_many_to_many()
 
     def filter_full_text(self, full_text_string):
-        return self.annotate(search=SearchVector("name", "brand", "siret")).filter(search=full_text_string)
+        return self.annotate(
+            search=SearchVector("name", config="french")
+            + SearchVector("brand", config="french")
+            + SearchVector("siret")
+        ).filter(search=full_text_string)
 
     def filter_sectors(self, sectors):
         return self.filter(sectors__in=sectors)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -161,8 +161,6 @@ class SiaeQuerySet(models.QuerySet):
     def filter_siret_startswith(self, siret):
         return self.filter(siret__startswith=siret)
 
-    # def filter_full_text(self, full_text_string):
-
     def filter_full_text(self, full_text_string):
         # Simple method 1: SearchVectors
         #     return self.annotate(

--- a/lemarche/static/js/kind_multiselect_field.js
+++ b/lemarche/static/js/kind_multiselect_field.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * Multiselect dropdown for the kind search form field
      */
 
-    const kindFormElement = document.querySelector('#search-form #id_kind');
+    const kindFormElement = document.querySelector('#filter-search-form #id_kind');
     const kindFormPlaceholder = 'Insertion, handicap';
 
     const buttonTextAndTitle = function(options, select) {

--- a/lemarche/static/js/kind_multiselect_field.js
+++ b/lemarche/static/js/kind_multiselect_field.js
@@ -3,12 +3,14 @@ document.addEventListener('DOMContentLoaded', function() {
      * Multiselect dropdown for the kind search form field
      */
 
-    const kindFormElement = document.querySelector('#filter-search-form #id_kind');
-    const kindFormPlaceholder = 'Insertion, handicap';
+    const FORM_INPUT_ID = "id_kind";
+    const FORM_MULTISELECT_ID = `${FORM_INPUT_ID}_multiselect`;
+    const FORM_ELEMENT = document.querySelector(`#filter-search-form #${FORM_INPUT_ID}`);
+    const FORM_PLACEHOLDER = 'Insertion, handicap';
 
     const buttonTextAndTitle = function(options, select) {
         if (options.length === 0) {
-            return kindFormPlaceholder;
+            return FORM_PLACEHOLDER;
         }
         else if (options.length > 2) {
             return `${options.length} types sélectionnés`;
@@ -27,9 +29,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // only on pages with id_kind
-    if (document.body.contains(kindFormElement)) {
-        $('#id_kind').multiselect({
+    if (document.body.contains(FORM_ELEMENT)) {
+        $(`#${FORM_INPUT_ID}`).multiselect({
             // height & width
             maxHeight: 400,
             buttonWidth: '100%',
@@ -41,19 +42,19 @@ document.addEventListener('DOMContentLoaded', function() {
             // ability to select all group's child options in 1 click
             enableClickableOptGroups: true,
             // other
-            buttonContainer: '<div id="id_kind_multiselect" class="btn-group" />',
+            buttonContainer: `<div id="${FORM_MULTISELECT_ID}" class="btn-group" />`,
             widthSynchronizationMode: 'ifPopupIsSmaller',
             // enableHTML: true,
-            // nonSelectedText: `<span class="fake-placeholder">${kindFormPlaceholder}</span>`,
+            // nonSelectedText: `<span class="fake-placeholder">${FORM_PLACEHOLDER}</span>`,
         });
 
-        // hack to set the placeholder color to grey when there is no kind selected
-        const multiselectSelectedText = document.querySelector('#id_kind_multiselect .multiselect-selected-text');
-        if (multiselectSelectedText.innerText === kindFormPlaceholder) {
+        // hack to set the placeholder color to grey when there is no item selected
+        const multiselectSelectedText = document.querySelector(`#${FORM_MULTISELECT_ID} .multiselect-selected-text`);
+        if (multiselectSelectedText.innerText === FORM_PLACEHOLDER) {
             multiselectSelectedText.classList.add('fake-placeholder');
         }
         multiselectSelectedText.addEventListener('DOMSubtreeModified', function () {
-            if (this.innerText === kindFormPlaceholder) {
+            if (this.innerText === FORM_PLACEHOLDER) {
                 this.classList.add('fake-placeholder');
             } else {
                 this.classList.remove('fake-placeholder');

--- a/lemarche/static/js/network_multiselect_field.js
+++ b/lemarche/static/js/network_multiselect_field.js
@@ -1,23 +1,19 @@
 document.addEventListener('DOMContentLoaded', function() {
     /**
-     * Multiselect dropdown for the sector search form field
+     * Multiselect dropdown for the network search form field
      */
-    const FORM_INPUT_ID = "id_sectors";
+
+    const FORM_INPUT_ID = "id_networks";
     const FORM_MULTISELECT_ID = `${FORM_INPUT_ID}_multiselect`;
-    let FORM_SELECTOR = `.use-multiselect #${FORM_INPUT_ID}`;
-    let FORM_ELEMENT = document.querySelector(FORM_SELECTOR);
-    if (!FORM_ELEMENT) {
-        FORM_SELECTOR = ".use-multiselect select";
-        FORM_ELEMENT = document.querySelector(FORM_SELECTOR);
-    }
-    const FORM_PLACEHOLDER = 'Espaces verts, informatique, restauration…';
+    const FORM_ELEMENT = document.querySelector(`.use-multiselect #${FORM_INPUT_ID}`);
+    const FORM_PLACEHOLDER = 'Choisir…';
 
     const buttonTextAndTitle = function(options, select) {
         if (options.length === 0) {
             return FORM_PLACEHOLDER;
         }
         else if (options.length > 2) {
-            return `${options.length} secteurs sélectionnés`;
+            return `${options.length} réseaux sélectionnés`;
         }
         else {
             var labels = [];
@@ -34,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     if (document.body.contains(FORM_ELEMENT)) {
-        $(FORM_SELECTOR).multiselect({
+        $(`#${FORM_INPUT_ID}`).multiselect({
             // height & width
             maxHeight: 400,
             buttonWidth: '100%',
@@ -59,23 +55,23 @@ document.addEventListener('DOMContentLoaded', function() {
             buttonContainer: `<div id="${FORM_MULTISELECT_ID}" class="btn-group" />`,
             widthSynchronizationMode: 'ifPopupIsSmaller',
             // enableHTML: true,
-            // nonSelectedText: `<span class="fake-placeholder">${FORM_PLACEHOLDER}</span>`,
+            // nonSelectedText: `<span class="text-muted">${FORM_PLACEHOLDER}</span>`,
             templates: {
                 resetButton: '<div class="multiselect-reset p-2"><button type="button" class="btn btn-sm btn-block btn-outline-primary"></button></div>',
                 // buttonGroupReset: '<button type="button" class="multiselect-reset btn btn-outline-primary btn-block"></button>'
             }
         });
 
-        // hack to set the placeholder color to grey when there is no item selected
+        // hack to set the placeholder color to grey when there is no sector selected
         const multiselectSelectedText = document.querySelector(`#${FORM_MULTISELECT_ID} .multiselect-selected-text`);
         if (multiselectSelectedText.innerText === FORM_PLACEHOLDER) {
-            multiselectSelectedText.classList.add('fake-placeholder');
+            multiselectSelectedText.classList.add('text-muted');
         }
         multiselectSelectedText.addEventListener('DOMSubtreeModified', function () {
             if (this.innerText === FORM_PLACEHOLDER) {
-                this.classList.add('fake-placeholder');
+                this.classList.add('text-muted');
             } else {
-                this.classList.remove('fake-placeholder');
+                this.classList.remove('text-muted');
             }
         })
     }

--- a/lemarche/static/js/perimeter_autocomplete_field.js
+++ b/lemarche/static/js/perimeter_autocomplete_field.js
@@ -95,7 +95,7 @@ document.addEventListener("DOMContentLoaded", function() {
       element: perimeterAutocompleteContainer,
       id: 'perimeter_name',
       name: 'perimeter_name',  // url GET param name
-      placeholder: 'Région, département, ville',  // 'Autour de (Arras, Bobigny, Strasbourg…)',
+      placeholder: 'Région, ville…',  // 'Autour de (Arras, Bobigny, Strasbourg…)', 'Région, département, ville'
       minLength: 2,
       defaultValue: perimeterNameParamInitial,
       source: async (query, populateResults) => {  // TODO; use debounce ?

--- a/lemarche/static/js/perimeter_autocomplete_field.js
+++ b/lemarche/static/js/perimeter_autocomplete_field.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", function() {
    * Accessible autocomplete for the perimeter search form field
    */
 
-  const perimeterAutocompleteContainer = document.querySelector('#search-form #dir_form_perimeter_name');
+  const perimeterAutocompleteContainer = document.querySelector('#filter-search-form #dir_form_perimeter_name');
   // let perimeterNameInput = document.getElementById('perimeter_name');  // autocomplete // not yet inititated (see bottom)
   let perimeterInput = document.getElementById('id_perimeter');  // hidden
 

--- a/lemarche/static/js/presta_type_multiselect_field.js
+++ b/lemarche/static/js/presta_type_multiselect_field.js
@@ -1,23 +1,19 @@
 document.addEventListener('DOMContentLoaded', function() {
     /**
-     * Multiselect dropdown for the sector search form field
+     * Multiselect dropdown for the presta_type search form field
      */
-    const FORM_INPUT_ID = "id_sectors";
+
+    const FORM_INPUT_ID = "id_presta_type";
     const FORM_MULTISELECT_ID = `${FORM_INPUT_ID}_multiselect`;
-    let FORM_SELECTOR = `.use-multiselect #${FORM_INPUT_ID}`;
-    let FORM_ELEMENT = document.querySelector(FORM_SELECTOR);
-    if (!FORM_ELEMENT) {
-        FORM_SELECTOR = ".use-multiselect select";
-        FORM_ELEMENT = document.querySelector(FORM_SELECTOR);
-    }
-    const FORM_PLACEHOLDER = 'Espaces verts, informatique, restauration…';
+    const FORM_ELEMENT = document.querySelector(`#filter-search-form #${FORM_INPUT_ID}`);
+    const FORM_PLACEHOLDER = 'Mise à disposition, Prestation';
 
     const buttonTextAndTitle = function(options, select) {
         if (options.length === 0) {
             return FORM_PLACEHOLDER;
         }
         else if (options.length > 2) {
-            return `${options.length} secteurs sélectionnés`;
+            return `${options.length} types sélectionnés`;
         }
         else {
             var labels = [];
@@ -34,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     if (document.body.contains(FORM_ELEMENT)) {
-        $(FORM_SELECTOR).multiselect({
+        $(`#${FORM_INPUT_ID}`).multiselect({
             // height & width
             maxHeight: 400,
             buttonWidth: '100%',
@@ -43,39 +39,25 @@ document.addEventListener('DOMContentLoaded', function() {
             buttonTextAlignment: 'left',
             buttonText: buttonTextAndTitle,
             buttonTitle: buttonTextAndTitle,
-            // filter options
-            enableFiltering: true,
-            enableCaseInsensitiveFiltering: true,
-            filterPlaceholder: FORM_PLACEHOLDER,
-            // reset button
-            includeResetOption: true,
-            includeResetDivider: true,
-            resetText: 'Réinitialiser la sélection',
-            // enableResetButton: true,
-            // resetButtonText: 'Réinitialiser',
             // ability to select all group's child options in 1 click
             enableClickableOptGroups: true,
             // other
             buttonContainer: `<div id="${FORM_MULTISELECT_ID}" class="btn-group" />`,
             widthSynchronizationMode: 'ifPopupIsSmaller',
             // enableHTML: true,
-            // nonSelectedText: `<span class="fake-placeholder">${FORM_PLACEHOLDER}</span>`,
-            templates: {
-                resetButton: '<div class="multiselect-reset p-2"><button type="button" class="btn btn-sm btn-block btn-outline-primary"></button></div>',
-                // buttonGroupReset: '<button type="button" class="multiselect-reset btn btn-outline-primary btn-block"></button>'
-            }
+            // nonSelectedText: `<span class="text-muted">${FORM_PLACEHOLDER}</span>`,
         });
 
         // hack to set the placeholder color to grey when there is no item selected
         const multiselectSelectedText = document.querySelector(`#${FORM_MULTISELECT_ID} .multiselect-selected-text`);
         if (multiselectSelectedText.innerText === FORM_PLACEHOLDER) {
-            multiselectSelectedText.classList.add('fake-placeholder');
+            multiselectSelectedText.classList.add('text-muted');
         }
         multiselectSelectedText.addEventListener('DOMSubtreeModified', function () {
             if (this.innerText === FORM_PLACEHOLDER) {
-                this.classList.add('fake-placeholder');
+                this.classList.add('text-muted');
             } else {
-                this.classList.remove('fake-placeholder');
+                this.classList.remove('text-muted');
             }
         })
     }

--- a/lemarche/static/js/territory_multiselect_field.js
+++ b/lemarche/static/js/territory_multiselect_field.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * Multiselect dropdown for the territory search form field
      */
 
-    const territoryFormElement = document.querySelector('#search-form #id_territory');
+    const territoryFormElement = document.querySelector('#filter-search-form #id_territory');
     const territoryFormPlaceholder = 'QPV, ZRR';
 
     const buttonTextAndTitle = function(options, select) {

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -64,7 +64,7 @@
             <li><a href="#nav-primary">Aller au menu principal</a></li>
             <li><a href="#main">Aller au contenu principal</a></li>
             {% if request.path == "/prestataires/" %}
-                <li><a href="#search-form">Aller à la recherche de structures de l’insertion et du handicap</a></li>
+                <li><a href="#filter-search-form">Aller à la recherche de structures de l’insertion et du handicap</a></li>
             {% endif %}
         </ul>
     </nav>

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -120,7 +120,9 @@
     <!-- custom javascript -->
     <script type="text/javascript" src="{% static 'js/sector_multiselect_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/kind_multiselect_field.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/presta_type_multiselect_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/territory_multiselect_field.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/network_multiselect_field.js' %}"></script>
     {% endcompress %}
     <script type="text/javascript" src="{% static 'js/utils.js'%}"></script>
     {% if BITOUBI_ENV not in "dev" %}

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -23,61 +23,95 @@
 {% block content %}
 <section class="s-siae-01">
     <div class="container">
-        <div id="dir_form" class="dir_form">
-            <form method="GET" action="{% url 'siae:search_results' %}" id="search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
-                {% bootstrap_form_errors form type="all" %}
-                <div class="row">
-                    <div class="col-12 col-lg-10">
-                        <div class="row first-row">
-                            <div class="col-12 col-md-6 mt-lg-3 pr-md-0">
-                                {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
-                            </div>
-                            <div class="col-12 col-md-6 mt-lg-3">
-                                <div class="form-group">
-                                    <label for="id_perimeters">{{ form.perimeters.label }}</label>
-                                    <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
-                                    <div id="perimeters-selected" class="mt-1"></div>
-                                </div>
-                            </div>
-                            <div class="col-12 col-md-3 mt-lg-3 pr-md-0">
-                                {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
-                            </div>
-                            <div class="col-12 col-md-1 mt-lg-7 pr-md-0 text-center">
-                                ou
-                            </div>
-                            <div class="col-12 col-md-5 mt-lg-3 pr-md-0">
-                                {% bootstrap_field form.q %}
-                            </div>
-                        </div>
-                        <p data-toggle="collapse" data-target="#collapseFormExtra" aria-expanded="false" aria-controls="collapseFormExtra">
-                            <a href="#">Plus de critères</a>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
-                        </p>
-                        <div id="collapseFormExtra" class="row collapse">
-                            <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                                {% bootstrap_field form.kind %}
-                            </div>
-                            <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                                {% bootstrap_field form.presta_type %}
-                            </div>
-                            <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                                {% bootstrap_field form.territory %}
-                            </div>
-                            <div class="col-12 col-md-3 mt-lg-2">
-                                {% bootstrap_field form.networks %}
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-sm-6 col-lg-2 mt-3 mt-3 mt-md-0 mt-lg-3 pr-sm-0 pr-lg-2">
-                        <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
-                        <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
-                            <span>Rechercher</span>
-                            <i class="ri-search-line ri-lg"></i>
-                        </button>
+        <div class="card c-card">
+            <div class="card-body">
+                <div class="row mb-3 mb-lg-5">
+                    <div class="col-12">
+                        <ul class="nav nav-tabs">
+                            <li class="nav-item">
+                                <a href="#" id="filter-nav-item" class="nav-link">
+                                    J'ai un projet d'achat
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="#" id="text-nav-item" class="nav-link">
+                                    Je cherche une structure
+                                    <span class="fs-xs badge badge-base badge-pill badge-pilotage">Nouveauté</span>
+                                </a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
-            </form>
+
+                <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                    {% bootstrap_form_errors form type="all" %}
+                    <div class="row">
+                        <div class="col-12 col-lg-8">
+                            <div class="row">
+                                <div class="col-12 col-md-6 mt-lg-3">
+                                    <div class="form-group">
+                                        <label for="id_perimeters">{{ form.perimeters.label }}</label>
+                                        <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
+                                        <div id="perimeters-selected" class="mt-1"></div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-4 d-none d-md-block">
+                            <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
+                            <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                <span>Rechercher</span>
+                                <i class="ri-search-line ri-lg"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                            {% bootstrap_field form.kind %}
+                        </div>
+                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                            {% bootstrap_field form.presta_type %}
+                        </div>
+                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                            {% bootstrap_field form.territory %}
+                        </div>
+                        <div class="col-12 col-md-3 mt-lg-2">
+                            {% bootstrap_field form.networks %}
+                        </div>
+                    </div>
+                    <div class="row d-md-none">
+                        <div class="col-12 col-lg-4">
+                            <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                <span>Rechercher</span>
+                                <i class="ri-search-line ri-lg"></i>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+
+                <form method="GET" action="{% url 'siae:search_results' %}" id="text-search-form" style="display:none" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                    {% bootstrap_form_errors form type="all" %}
+                    <div class="row">
+                        <div class="col-12 col-lg-8">
+                            <div class="row">
+                                <div class="col-12">
+                                    {% bootstrap_field form.q %}
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-4">
+                            <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
+                            <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                <span>Rechercher</span>
+                                <i class="ri-search-line ri-lg"></i>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
 </section>
@@ -209,6 +243,46 @@
 {% block extra_js %}
 {{ current_perimeters|json_script:"current-perimeters" }}
 <script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    let filterSearchForm = document.getElementById('filter-search-form');
+    let filterNavItem = document.getElementById('filter-nav-item');
+    let perimeterInput = document.getElementById('perimeter_name');
+    let sectorsInput = document.getElementById('id_sectors');  // id_sectors_multiselect
+
+    let textSearchForm = document.getElementById('text-search-form');
+    let textNavItem = document.getElementById('text-nav-item');
+    let qInput = document.getElementById('id_q');
+
+    function showFilterSearchForm() {
+        filterNavItem.classList.add("active", "font-weight-bold");
+        textNavItem.classList.remove("active", "font-weight-bold");
+        filterSearchForm.style.display = "";
+        textSearchForm.style.display = "none";
+    }
+    function showTextSearchForm() {
+        filterNavItem.classList.remove("active", "font-weight-bold");
+        textNavItem.classList.add("active", "font-weight-bold");
+        filterSearchForm.style.display = "none";
+        textSearchForm.style.display = "";
+    }
+
+    // init
+    if (qInput.value) {
+        showTextSearchForm();
+    } else {
+        showFilterSearchForm();
+    }
+
+    // toggle nav
+    filterNavItem.addEventListener("click", function(e) {
+        showFilterSearchForm();
+    });
+    textNavItem.addEventListener("click", function(e) {
+        showTextSearchForm();
+    });
+});
+</script>
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
     // Set listings markers on load

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -48,7 +48,7 @@
                     <div class="row">
                         <div class="col-12 col-lg-8">
                             <div class="row">
-                                <div class="col-12 col-md-6 mt-lg-3">
+                                <div class="col-12 col-md-6">
                                     <div class="form-group">
                                         <label for="id_perimeters">{{ form.perimeters.label }}</label>
                                         <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
@@ -146,8 +146,9 @@
                                     </div>
                                 </div>
                             {% else %}
-                                <a href="#" id="siae-export-anon" class="btn btn-outline-primary ml-3" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}">
-                                    Télécharger la liste
+                                <a href="#" id="siae-export-anon" class="btn btn-outline-primary btn-ico ml-3" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:search_results' %}?{{ current_search_query_escaped }}">
+                                    <span>Télécharger la liste</span>
+                                    <i class="ri-download-line ri-lg"></i>
                                 </a>
                             {% endif %}
                         {% endif %}

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -54,6 +54,13 @@
                                 {% bootstrap_field form.networks %}
                             </div>
                         </div>
+                        {% if user.is_authenticated and user.kind == 'ADMIN' %}
+                            <div class="row">
+                                <div class="col-12 col-md-6 mt-lg-2 pr-md-0">
+                                    {% bootstrap_field form.q %}
+                                </div>
+                            </div>
+                        {% endif %}
                     </div>
                     <div class="col-12 col-sm-6 col-lg-2 mt-3 mt-3 mt-md-0 mt-lg-3 pr-sm-0 pr-lg-2">
                         <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -27,7 +27,7 @@
             <form method="GET" action="{% url 'siae:search_results' %}" id="search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
                 {% bootstrap_form_errors form type="all" %}
                 <div class="row">
-                    <div class="col-12 col-lg-8">
+                    <div class="col-12 col-lg-10">
                         <div class="row first-row">
                             <div class="col-12 col-md-6 mt-lg-3 pr-md-0">
                                 {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
@@ -39,8 +39,22 @@
                                     <div id="perimeters-selected" class="mt-1"></div>
                                 </div>
                             </div>
+                            <div class="col-12 col-md-3 mt-lg-3 pr-md-0">
+                                {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
+                            </div>
+                            <div class="col-12 col-md-1 mt-lg-7 pr-md-0 text-center">
+                                ou
+                            </div>
+                            <div class="col-12 col-md-5 mt-lg-3 pr-md-0">
+                                {% bootstrap_field form.q %}
+                            </div>
                         </div>
-                        <div class="row">
+                        <p data-toggle="collapse" data-target="#collapseFormExtra" aria-expanded="false" aria-controls="collapseFormExtra">
+                            <a href="#">Plus de critères</a>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
+                        </p>
+                        <div id="collapseFormExtra" class="row collapse">
                             <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
                                 {% bootstrap_field form.kind %}
                             </div>
@@ -54,13 +68,6 @@
                                 {% bootstrap_field form.networks %}
                             </div>
                         </div>
-                        {% if user.is_authenticated and user.kind == 'ADMIN' %}
-                            <div class="row">
-                                <div class="col-12 col-md-6 mt-lg-2 pr-md-0">
-                                    {% bootstrap_field form.q %}
-                                </div>
-                            </div>
-                        {% endif %}
                     </div>
                     <div class="col-12 col-sm-6 col-lg-2 mt-3 mt-3 mt-md-0 mt-lg-3 pr-sm-0 pr-lg-2">
                         <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
@@ -68,13 +75,6 @@
                             <span>Rechercher</span>
                             <i class="ri-search-line ri-lg"></i>
                         </button>
-                    </div>
-                    <div class="col-12 col-sm-6 col-lg-2 mt-3  mt-3 mt-md-0 mt-lg-3 pl-lg-2">
-                        <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
-                        <a href="{% url 'siae:search_results' %}" class="btn btn-outline-primary btn-block reset btn-ico">
-                            <span>Réinitialiser</span>
-                            <i class="ri-refresh-line ri-lg"></i>
-                        </a>
                     </div>
                 </div>
             </form>
@@ -252,7 +252,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     // set map bounds
     geoBounds = geojson.getBounds();
-    if(geoBounds.isValid()) {
+    if (geoBounds.isValid()) {
         map.fitBounds(geoBounds);
     }
 });

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -79,7 +79,7 @@
                             {% bootstrap_field form.territory %}
                         </div>
                         <div class="col-12 col-md-3 mt-lg-2">
-                            {% bootstrap_field form.networks %}
+                            {% bootstrap_field form.networks form_group_class="form-group use-multiselect" %}
                         </div>
                     </div>
                     <div class="row d-md-none">

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -27,7 +27,7 @@
             <div class="s-tabs-01__col col-12">
                 <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
                     <li class="nav-item" role="presentation">
-                        <a class="nav-link active" id="search-filter-tab" data-toggle="tab" href="#search-filter" role="tab" aria-controls="search-filter" aria-selected="true">
+                        <a class="nav-link" id="search-filter-tab" data-toggle="tab" href="#search-filter" role="tab" aria-controls="search-filter" aria-selected="false">
                             <span>&nbsp;&nbsp;&nbsp;</span>
                             <span>J'ai un projet d'achat</span>
                             <span>&nbsp;&nbsp;&nbsp;</span>
@@ -36,7 +36,7 @@
                     <li class="nav-item" role="presentation">
                         <a class="nav-link" id="search-text-tab" data-toggle="tab" href="#search-text" role="tab" aria-controls="search-text" aria-selected="false">
                             <span>Je cherche une structure</span>
-                            <span class="fs-xs badge badge-base badge-pill badge-pilotage ml-3">Nouveauté</span>
+                            <span class="fs-xs badge badge-base badge-pill badge-pilotage ml-2" style="background-color:#6C38D9">Nouveauté</span>
                         </a>
                     </li>
                     <li class="nav-item-dropdown dropdown">
@@ -45,7 +45,7 @@
                     </li>
                 </ul>
                 <div class="tab-content">
-                    <div class="tab-pane fade show active" id="search-filter" role="tabpanel" aria-labelledby="search-filter-tab">
+                    <div class="tab-pane fade" id="search-filter" role="tabpanel" aria-labelledby="search-filter-tab">
                         <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
                             {% bootstrap_form_errors form type="all" %}
                             <div class="row">
@@ -251,30 +251,40 @@
 {{ current_perimeters|json_script:"current-perimeters" }}
 <script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 <script type="text/javascript">
-// document.addEventListener("DOMContentLoaded", function() {
-//     let filterSearchForm = document.getElementById('filter-search-form');
-//     let perimeterInput = document.getElementById('perimeter_name');
-//     let sectorsInput = document.getElementById('id_sectors');  // id_sectors_multiselect
+document.addEventListener("DOMContentLoaded", function() {
+    let searchFilterTab = document.getElementById('search-filter-tab');
+    let searchFilterContent = document.getElementById('search-filter');
+    // let perimetersInput = document.getElementById('id_perimeters');
+    // let sectorsInput = document.getElementById('id_sectors');  // id_sectors_multiselect
 
-//     let textSearchForm = document.getElementById('text-search-form');
-//     let qInput = document.getElementById('id_q');
+    let searchTextTab = document.getElementById('search-text-tab');
+    let searchTextContent = document.getElementById('search-text');
+    let qInput = document.getElementById('id_q');
 
-//     function showFilterSearchForm() {
-//         filterSearchForm.style.display = "";
-//         textSearchForm.style.display = "none";
-//     }
-//     function showTextSearchForm() {
-//         filterSearchForm.style.display = "none";
-//         textSearchForm.style.display = "";
-//     }
+    function showSearchFilterForm() {
+        searchFilterTab.classList.add("active");
+        searchFilterTab.setAttribute("aria-selected", "true");
+        searchFilterContent.classList.add("show", "active");
+    }
+    function hideSearchFilterForm() {
+        searchFilterTab.classList.remove("active");
+        searchFilterTab.setAttribute("aria-selected", "false");
+        searchFilterContent.classList.remove("show", "active");
+    }
+    function showSearchTextForm() {
+        searchTextTab.classList.add("active");
+        searchTextTab.setAttribute("aria-selected", "true");
+        searchTextContent.classList.add("show", "active");
+    }
 
-//     // init
-//     if (qInput.value) {
-//         showTextSearchForm();
-//     } else {
-//         showFilterSearchForm();
-//     }
-// });
+    // init
+    if (qInput.value) {
+        showSearchTextForm();
+        // hideSearchFilterForm();
+    } else {
+        showSearchFilterForm();
+    }
+});
 </script>
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -21,96 +21,102 @@
 {% endblock %}
 
 {% block content %}
-<section class="s-siae-01">
-    <div class="container">
-        <div class="card c-card">
-            <div class="card-body">
-                <div class="row mb-3 mb-lg-5">
-                    <div class="col-12">
-                        <ul class="nav nav-tabs">
-                            <li class="nav-item">
-                                <a href="#" id="filter-nav-item" class="nav-link">
-                                    J'ai un projet d'achat
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a href="#" id="text-nav-item" class="nav-link">
-                                    Je cherche une structure
-                                    <span class="fs-xs badge badge-base badge-pill badge-pilotage">Nouveauté</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-
-                <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
-                    {% bootstrap_form_errors form type="all" %}
-                    <div class="row">
-                        <div class="col-12 col-lg-8">
+<section class="s-tabs-01">
+    <div class="s-tabs-01__container container">
+        <div class="s-tabs-01__row row">
+            <div class="s-tabs-01__col col-12">
+                <ul class="s-tabs-01__nav nav nav-tabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <a class="nav-link active" id="search-filter-tab" data-toggle="tab" href="#search-filter" role="tab" aria-controls="search-filter" aria-selected="true">
+                            <span>&nbsp;&nbsp;&nbsp;</span>
+                            <span>J'ai un projet d'achat</span>
+                            <span>&nbsp;&nbsp;&nbsp;</span>
+                        </a>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <a class="nav-link" id="search-text-tab" data-toggle="tab" href="#search-text" role="tab" aria-controls="search-text" aria-selected="false">
+                            <span>Je cherche une structure</span>
+                            <span class="fs-xs badge badge-base badge-pill badge-pilotage ml-3">Nouveauté</span>
+                        </a>
+                    </li>
+                    <li class="nav-item-dropdown dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-toggle="dropdown" aria-expanded="false">...</a>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
+                    </li>
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade show active" id="search-filter" role="tabpanel" aria-labelledby="search-filter-tab">
+                        <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                            {% bootstrap_form_errors form type="all" %}
                             <div class="row">
-                                <div class="col-12 col-md-6">
-                                    <div class="form-group">
-                                        <label for="id_perimeters">{{ form.perimeters.label }}</label>
-                                        <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
-                                        <div id="perimeters-selected" class="mt-1"></div>
+                                <div class="col-12 col-lg-8">
+                                    <div class="row">
+                                        <div class="col-12 col-md-6">
+                                            <div class="form-group">
+                                                <label for="id_perimeters">{{ form.perimeters.label }}</label>
+                                                <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
+                                                <div id="perimeters-selected" class="mt-1"></div>
+                                            </div>
+                                        </div>
+                                        <div class="col-12 col-md-6">
+                                            {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="col-12 col-md-6">
-                                    {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
+                                <div class="col-12 col-lg-4 d-none d-md-block">
+                                    <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
+                                    <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                        <span>Rechercher</span>
+                                        <i class="ri-search-line ri-lg"></i>
+                                    </button>
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-4 d-none d-md-block">
-                            <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
-                            <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
-                                <span>Rechercher</span>
-                                <i class="ri-search-line ri-lg"></i>
-                            </button>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                            {% bootstrap_field form.kind %}
-                        </div>
-                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                            {% bootstrap_field form.presta_type %}
-                        </div>
-                        <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
-                            {% bootstrap_field form.territory %}
-                        </div>
-                        <div class="col-12 col-md-3 mt-lg-2">
-                            {% bootstrap_field form.networks form_group_class="form-group use-multiselect" %}
-                        </div>
-                    </div>
-                    <div class="row d-md-none">
-                        <div class="col-12 col-lg-4">
-                            <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
-                                <span>Rechercher</span>
-                                <i class="ri-search-line ri-lg"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-
-                <form method="GET" action="{% url 'siae:search_results' %}" id="text-search-form" style="display:none" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
-                    {% bootstrap_form_errors form type="all" %}
-                    <div class="row">
-                        <div class="col-12 col-lg-8">
                             <div class="row">
-                                <div class="col-12">
-                                    {% bootstrap_field form.q %}
+                                <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                                    {% bootstrap_field form.kind %}
+                                </div>
+                                <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                                    {% bootstrap_field form.presta_type %}
+                                </div>
+                                <div class="col-12 col-md-3 mt-lg-2 pr-md-0">
+                                    {% bootstrap_field form.territory %}
+                                </div>
+                                <div class="col-12 col-md-3 mt-lg-2">
+                                    {% bootstrap_field form.networks form_group_class="form-group use-multiselect" %}
                                 </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-lg-4">
-                            <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
-                            <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
-                                <span>Rechercher</span>
-                                <i class="ri-search-line ri-lg"></i>
-                            </button>
-                        </div>
+                            <div class="row d-md-none">
+                                <div class="col-12 col-lg-4">
+                                    <button id="filter-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                        <span>Rechercher</span>
+                                        <i class="ri-search-line ri-lg"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
                     </div>
-                </form>
+                    <div class="tab-pane fade" id="search-text" role="tabpanel" aria-labelledby="search-text-tab">
+                        <form method="GET" action="{% url 'siae:search_results' %}" id="text-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                            {% bootstrap_form_errors form type="all" %}
+                            <div class="row">
+                                <div class="col-12 col-lg-8">
+                                    <div class="row">
+                                        <div class="col-12">
+                                            {% bootstrap_field form.q %}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-lg-4">
+                                    <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
+                                    <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                        <span>Rechercher</span>
+                                        <i class="ri-search-line ri-lg"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -245,44 +251,30 @@
 {{ current_perimeters|json_script:"current-perimeters" }}
 <script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 <script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function() {
-    let filterSearchForm = document.getElementById('filter-search-form');
-    let filterNavItem = document.getElementById('filter-nav-item');
-    let perimeterInput = document.getElementById('perimeter_name');
-    let sectorsInput = document.getElementById('id_sectors');  // id_sectors_multiselect
+// document.addEventListener("DOMContentLoaded", function() {
+//     let filterSearchForm = document.getElementById('filter-search-form');
+//     let perimeterInput = document.getElementById('perimeter_name');
+//     let sectorsInput = document.getElementById('id_sectors');  // id_sectors_multiselect
 
-    let textSearchForm = document.getElementById('text-search-form');
-    let textNavItem = document.getElementById('text-nav-item');
-    let qInput = document.getElementById('id_q');
+//     let textSearchForm = document.getElementById('text-search-form');
+//     let qInput = document.getElementById('id_q');
 
-    function showFilterSearchForm() {
-        filterNavItem.classList.add("active", "font-weight-bold");
-        textNavItem.classList.remove("active", "font-weight-bold");
-        filterSearchForm.style.display = "";
-        textSearchForm.style.display = "none";
-    }
-    function showTextSearchForm() {
-        filterNavItem.classList.remove("active", "font-weight-bold");
-        textNavItem.classList.add("active", "font-weight-bold");
-        filterSearchForm.style.display = "none";
-        textSearchForm.style.display = "";
-    }
+//     function showFilterSearchForm() {
+//         filterSearchForm.style.display = "";
+//         textSearchForm.style.display = "none";
+//     }
+//     function showTextSearchForm() {
+//         filterSearchForm.style.display = "none";
+//         textSearchForm.style.display = "";
+//     }
 
-    // init
-    if (qInput.value) {
-        showTextSearchForm();
-    } else {
-        showFilterSearchForm();
-    }
-
-    // toggle nav
-    filterNavItem.addEventListener("click", function(e) {
-        showFilterSearchForm();
-    });
-    textNavItem.addEventListener("click", function(e) {
-        showTextSearchForm();
-    });
-});
+//     // init
+//     if (qInput.value) {
+//         showTextSearchForm();
+//     } else {
+//         showFilterSearchForm();
+//     }
+// });
 </script>
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -46,7 +46,7 @@
 {% block extra_js %}
 {{ current_perimeters|json_script:"current-perimeters" }}
 <script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
-<script>
+<script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function () {
     let is_in_country_area = document.getElementById('id_general-is_country_area');
     let perimeters = document.getElementById('dir_form_perimeters');
@@ -71,7 +71,6 @@ document.addEventListener('DOMContentLoaded', function () {
             $(perimetersInput).prop("disabled", false);
         }
     });
-
 });
 </script>
 {% endblock %}

--- a/lemarche/www/dashboard/forms.py
+++ b/lemarche/www/dashboard/forms.py
@@ -76,7 +76,7 @@ class SiaeSearchBySiretForm(forms.Form):
 
         siret = self.cleaned_data.get("siret", None)
         if siret:
-            qs = qs.filter(siret__startswith=siret)
+            qs = qs.filter_siret_startswith(siret)
         else:
             # show results only if there is a valid siret provided
             qs = qs.none()

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -87,6 +87,9 @@ class SiaeSearchForm(forms.Form):
 
         full_text_string = self.cleaned_data.get("q", None)
         if full_text_string:
+            # case where a siret search was done, strip all spaces
+            if full_text_string.replace(" ", "").isdigit():
+                full_text_string = full_text_string.replace(" ", "")
             qs = qs.filter_full_text(full_text_string)
 
         sectors = self.cleaned_data.get("sectors", None)

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -25,9 +25,9 @@ class SiaeSearchForm(forms.Form):
     )
 
     q = forms.CharField(
-        label="Recherche texte",
+        label="Numéro de SIRET ou le nom de votre structure",
         required=False,
-        widget=forms.TextInput(attrs={"placeholder": "Nom, SIRET"}),
+        widget=forms.TextInput(attrs={"placeholder": "Ex : 888 888 888 88888"}),
     )
     sectors = GroupedModelMultipleChoiceField(
         label=Sector._meta.verbose_name_plural,

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -24,6 +24,11 @@ class SiaeSearchForm(forms.Form):
         ("ZRR", "Zone de revitalisation rurale (ZRR)"),
     )
 
+    q = forms.CharField(
+        label="Recherche texte",
+        required=False,
+        widget=forms.TextInput(attrs={"placeholder": "Nom, SIRET"}),
+    )
     sectors = GroupedModelMultipleChoiceField(
         label=Sector._meta.verbose_name_plural,
         queryset=Sector.objects.form_filter_queryset(),
@@ -79,6 +84,10 @@ class SiaeSearchForm(forms.Form):
 
         if not hasattr(self, "cleaned_data"):
             self.full_clean()
+
+        full_text_string = self.cleaned_data.get("q", None)
+        if full_text_string:
+            qs = qs.filter_full_text(full_text_string)
 
         sectors = self.cleaned_data.get("sectors", None)
         if sectors:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -143,6 +143,7 @@ class SiaeSearchForm(forms.Form):
         **BUT**
         - if a Siae has a a SiaeOffer, or a description, or a User, then it is "boosted"
         - if the search is on a CITY perimeter, we order by coordinates first
+        - if the search is by keyword, order by "similarity" only
         """
         DEFAULT_ORDERING = ["-updated_at"]
         ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user"] + DEFAULT_ORDERING
@@ -176,6 +177,10 @@ class SiaeSearchForm(forms.Form):
                     )
                 )
                 ORDER_BY_FIELDS = ["distance"] + ORDER_BY_FIELDS
+
+        full_text_string = self.cleaned_data.get("q", None)
+        if full_text_string:
+            ORDER_BY_FIELDS = ["-similarity"]
 
         # final ordering
         qs = qs.order_by(*ORDER_BY_FIELDS)

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -9,7 +9,6 @@ from lemarche.sectors.models import Sector
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import Tender
-from lemarche.utils.constants import EMPTY_CHOICE
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
 
@@ -18,7 +17,6 @@ class SiaeSearchForm(forms.Form):
         ("Insertion par l'activité économique", Siae.KIND_CHOICES_WITH_EXTRA_INSERTION),
         ("Handicap", Siae.KIND_CHOICES_WITH_EXTRA_HANDICAP),
     )
-    FORM_PRESTA_CHOICES = EMPTY_CHOICE + siae_constants.PRESTA_CHOICES
     FORM_TERRITORY_CHOICES = (
         ("QPV", "Quartier prioritaire de la politique de la ville (QPV)"),
         ("ZRR", "Zone de revitalisation rurale (ZRR)"),
@@ -49,9 +47,9 @@ class SiaeSearchForm(forms.Form):
         choices=FORM_KIND_CHOICES_GROUPED,
         required=False,
     )
-    presta_type = forms.ChoiceField(
+    presta_type = forms.MultipleChoiceField(
         label=Siae._meta.get_field("presta_type").verbose_name,
-        choices=FORM_PRESTA_CHOICES,
+        choices=siae_constants.PRESTA_CHOICES,
         required=False,
     )
     territory = forms.MultipleChoiceField(
@@ -59,11 +57,10 @@ class SiaeSearchForm(forms.Form):
         choices=FORM_TERRITORY_CHOICES,
         required=False,
     )
-    networks = forms.ModelChoiceField(
+    networks = forms.ModelMultipleChoiceField(
         label="Réseau",
         queryset=Network.objects.all().order_by("name"),
         to_field_name="slug",
-        empty_label="",
         required=False,
     )
 

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -97,13 +97,13 @@ class SiaeSearchForm(forms.Form):
         if perimeters:
             qs = qs.in_perimeters_area(perimeters)
 
-        kind = self.cleaned_data.get("kind", None)
-        if kind:
-            qs = qs.filter(kind__in=kind)
+        kinds = self.cleaned_data.get("kind", None)
+        if kinds:
+            qs = qs.filter(kind__in=kinds)
 
-        presta_type = self.cleaned_data.get("presta_type", None)
-        if presta_type:
-            qs = qs.filter(presta_type__overlap=[presta_type])
+        presta_types = self.cleaned_data.get("presta_type", None)
+        if presta_types:
+            qs = qs.filter(presta_type__overlap=presta_types)
 
         territory = self.cleaned_data.get("territory", None)
         if territory:
@@ -115,9 +115,9 @@ class SiaeSearchForm(forms.Form):
             elif len(territory) == 2:
                 qs = qs.filter(Q(is_qpv=True) | Q(is_zrr=True))
 
-        network = self.cleaned_data.get("networks", None)
-        if network:
-            qs = qs.filter(networks__in=[network])
+        networks = self.cleaned_data.get("networks", None)
+        if networks:
+            qs = qs.filter_networks(networks)
 
         tender = self.cleaned_data.get("tender", None)
         if tender:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -25,9 +25,9 @@ class SiaeSearchForm(forms.Form):
     )
 
     q = forms.CharField(
-        label="Numéro de SIRET ou le nom de votre structure",
+        label="Recherche via le numéro de SIRET ou le nom de votre structure",
         required=False,
-        widget=forms.TextInput(attrs={"placeholder": "Ex : 888 888 888 88888"}),
+        widget=forms.TextInput(attrs={"placeholder": "Votre recherche…"}),
     )
     sectors = GroupedModelMultipleChoiceField(
         label=Sector._meta.verbose_name_plural,

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -478,7 +478,7 @@ class SiaeFullTextSearchTest(TestCase):
         url = reverse("siae:search_results") + "?q=333 333 333 44444"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
-        self.assertEqual(len(siaes), 0)  # TODO: should be 1
+        self.assertEqual(len(siaes), 1)
 
 
 class SiaeSearchOrderTest(TestCase):

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -431,14 +431,16 @@ class SiaeFullTextSearchTest(TestCase):
         cls.siae_1 = SiaeFactory(name="Ma boite", siret="11111111111111")
         cls.siae_2 = SiaeFactory(name="Une autre activité", siret="22222222222222")
         cls.siae_3 = SiaeFactory(name="ABC Insertion", siret="33333333344444")
+        cls.siae_4 = SiaeFactory(name="Empty", brand="ETHICOFIL", siret="55555555555555")
 
     def test_search_empty_query(self):
         url = reverse("siae:search_results") + "?q="
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
-        self.assertEqual(len(siaes), 3)
+        self.assertEqual(len(siaes), 4)
 
     def test_search_by_siae_name(self):
+        # name & brand work similarly
         url = reverse("siae:search_results") + "?q=boite"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
@@ -475,14 +477,28 @@ class SiaeFullTextSearchTest(TestCase):
         url = reverse("siae:search_results") + "?q=activite"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
-        self.assertEqual(len(siaes), 0)  # TODO: should be 1
-        # self.assertEqual(siaes[0].name, self.siae_2.name)
+        self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_2.name)
         # with accent
         url = reverse("siae:search_results") + "?q=activité"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1)
         self.assertEqual(siaes[0].name, self.siae_2.name)
+
+    def test_search_by_siae_brand(self):
+        url = reverse("siae:search_results") + "?q=ethicofil"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_4.name)
+
+    def test_search_by_siae_brand_should_accept_typos(self):
+        url = reverse("siae:search_results") + "?q=ethicofl"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_4.name)
 
     def test_search_by_siae_siret(self):
         url = reverse("siae:search_results") + "?q=22222222222222"

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -473,7 +473,7 @@ class SiaeFullTextSearchTest(TestCase):
         url = reverse("siae:search_results") + "?q=333333333"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
-        self.assertEqual(len(siaes), 0)  # TODO: should be 1
+        self.assertEqual(len(siaes), 1)
         # siret with space
         url = reverse("siae:search_results") + "?q=333 333 333 44444"
         response = self.client.get(url)

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -515,6 +515,14 @@ class SiaeFullTextSearchTest(TestCase):
         self.assertEqual(len(siaes), 1)
         self.assertEqual(siaes[0].name, self.siae_4.name)
 
+    def test_search_by_siae_name_order_by_similarity(self):
+        SiaeFactory(name="Ma botte", siret="11111111111111")
+        url = reverse("siae:search_results") + "?q=boite"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 2)
+        self.assertEqual(siaes[0].name, self.siae_1.name)
+
     def test_search_by_siae_siret(self):
         url = reverse("siae:search_results") + "?q=22222222222222"
         response = self.client.get(url)

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -172,6 +172,12 @@ class SiaeSectorSearchFilterTest(TestCase):
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1 + 1)  # OR
 
+    def test_search_unknown_sector_ignores_filter(self):
+        url = reverse("siae:search_results") + "?sectors=coucou"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 4)
+
 
 class SiaeNetworkSearchFilterTest(TestCase):
     @classmethod
@@ -182,19 +188,28 @@ class SiaeNetworkSearchFilterTest(TestCase):
         siae_with_network.networks.add(cls.network)
 
     def test_search_network_empty(self):
-        form = SiaeSearchForm({"networks": ""})
-        qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 2)
+        url = reverse("siae:search_results")
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 2)
 
-    def test_search_network(self):
-        form = SiaeSearchForm({"networks": f"{self.network.slug}"})
-        qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 1)
+    def test_search_network_empty_string(self):
+        url = reverse("siae:search_results") + "?networks="
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 2)
+
+    def test_search_network_should_filter(self):
+        url = reverse("siae:search_results") + f"?networks={self.network.slug}"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
 
     def test_search_unknown_network_ignores_filter(self):
-        form = SiaeSearchForm({"networks": "coucou"})
-        qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 2)
+        url = reverse("siae:search_results") + "?networks=coucou"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 2)
 
 
 class SiaePerimeterSearchFilterTest(TestCase):

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -428,9 +428,9 @@ class SiaePerimeterSearchFilterTest(TestCase):
 class SiaeFullTextSearchTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        SiaeFactory(name="Ma boite", siret="11111111111111")
-        SiaeFactory(name="Une autre activité", siret="22222222222222")
-        SiaeFactory(name="ABC Insertion", siret="33333333344444")
+        cls.siae_1 = SiaeFactory(name="Ma boite", siret="11111111111111")
+        cls.siae_2 = SiaeFactory(name="Une autre activité", siret="22222222222222")
+        cls.siae_3 = SiaeFactory(name="ABC Insertion", siret="33333333344444")
 
     def test_search_empty_query(self):
         url = reverse("siae:search_results") + "?q="
@@ -443,26 +443,46 @@ class SiaeFullTextSearchTest(TestCase):
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_1.name)
+        # full name with space
+        url = reverse("siae:search_results") + "?q=ma boite"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_1.name)
+
+    def test_search_by_siae_name_partial(self):
+        url = reverse("siae:search_results") + "?q=insert"
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_3.name)
 
     def test_search_by_siae_name_should_be_case_insensitive(self):
         url = reverse("siae:search_results") + "?q=abc"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_3.name)
+        # with case
         url = reverse("siae:search_results") + "?q=ABC"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_3.name)
 
     def test_search_by_siae_name_should_ignore_accents(self):
         url = reverse("siae:search_results") + "?q=activite"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 0)  # TODO: should be 1
+        # self.assertEqual(siaes[0].name, self.siae_2.name)
+        # with accent
         url = reverse("siae:search_results") + "?q=activité"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 1)
+        self.assertEqual(siaes[0].name, self.siae_2.name)
 
     def test_search_by_siae_siret(self):
         url = reverse("siae:search_results") + "?q=22222222222222"


### PR DESCRIPTION
### Quoi ?

Recherche "full text" basique sur les champs `name`, `brand` & `siret`
- les champs `name` & `brand` utilisent un ~`SearchVector`~ `TrigramSimilarity`
- le champ `siret` est traité séparemment (strip + icontains)

Améliorations possibles (pour une v1.5 ou v2)
- si `SearchVector`, utiliser `config="french_unaccent"` pour ne pas être sensible aux accents
- créer un nouveau champ `search_vector_unaccented` dans le modèle `Siae`, pour faire la recherche sur ce champ directement, et ne pas avoir à générer le search vector à chaque requête. Ce champ devra être mis à jour à chaque fois les champs correspondants de l'instance sont changés (post_save)
- voir comment combiner `TrigramSimiliarity` (pour les champs avec des noms propres ?) et `SearchVector` (pour les champs qui contiennent du français)
