### PR TITLE
Tri aléatoire par défaut

### DIFF
--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -197,13 +197,13 @@ class SiaeSearchForm(forms.Form):
         """
         Method to order the search results (can depend on the search filters).
 
-        By default, the Siaes are ordered by name.
-
+        By default, Siae will be ordered randomly (was by "name" before. could also be by "-last_updated"?)
         **BUT**
         - if a Siae has a a SiaeOffer, or a description, or a User, then it is "boosted"
         - if the search is on a CITY perimeter, we order by coordinates first
         """
-        ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user", "name"]
+        DEFAULT_ORDERING = ["?"]
+        ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user"] + DEFAULT_ORDERING
         # annotate on description presence: https://stackoverflow.com/a/65014409/4293684
         # qs = qs.annotate(has_description=Exists(F("description")))  # doesn't work
         qs = qs.annotate(

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -385,14 +385,6 @@ class SiaeSearchOrderTest(TestCase):
         SiaeFactory(name="Une autre structure")
         SiaeFactory(name="ABC Insertion")
 
-    def test_should_order_by_name(self):
-        url = reverse("siae:search_results", kwargs={})
-        response = self.client.get(url)
-        siaes = list(response.context["siaes"])
-        self.assertEqual(len(siaes), 3)
-        self.assertEqual(siaes[0].name, "ABC Insertion")
-        self.assertEqual(siaes[-1].name, "Une autre structure")
-
     def test_should_bring_the_siae_with_users_to_the_top(self):
         siae_with_user = SiaeFactory(name="ZZ ESI")
         user = UserFactory()
@@ -403,7 +395,6 @@ class SiaeSearchOrderTest(TestCase):
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_user, True)
         self.assertEqual(siaes[0].name, "ZZ ESI")
-        self.assertEqual(siaes[1].name, "ABC Insertion")
 
     def test_should_bring_the_siae_with_descriptions_to_the_top(self):
         SiaeFactory(name="ZZ ESI 2", description="coucou")
@@ -413,7 +404,6 @@ class SiaeSearchOrderTest(TestCase):
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_description, True)
         self.assertEqual(siaes[0].name, "ZZ ESI 2")
-        self.assertEqual(siaes[1].name, "ABC Insertion")
 
     def test_should_bring_the_siae_with_offers_to_the_top(self):
         siae_with_offer = SiaeFactory(name="ZZ ESI 3")
@@ -425,7 +415,6 @@ class SiaeSearchOrderTest(TestCase):
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_offer, True)
         self.assertEqual(siaes[0].name, "ZZ ESI 3")
-        self.assertEqual(siaes[1].name, "ABC Insertion")
 
     def test_should_bring_the_siae_closer_to_the_city_to_the_top(self):
         PerimeterFactory(


### PR DESCRIPTION
### Quoi ?

Avant : les structures étaient triées par "nom" par défaut
Après : les structures sont triées aléatoirement

Rappel : les structures qui ont des offres/description/utilisateurs sont boostées