### PR TITLE
Afficher l'Enseigne plutôt que la Raison sociale quand elle est disponible

### DIFF
--- a/lemarche/templates/dashboard/home.html
+++ b/lemarche/templates/dashboard/home.html
@@ -47,7 +47,7 @@
                             <div class="s-cards-grid-01__col col d-sm-flex">
                                 <div class="card c-card c-card--mini mb-3 w-100">
                                     <div class="card-body">
-                                        <h3 class="mb-3">{{ siaeuser.siae.name }}</h3>
+                                        <h3 class="mb-3">{{ siaeuser.siae.name_display }}</h3>
                                         <div class="row">
                                             <div class="col-6">
                                                 <h4 class="mt-2 mb-0">Ma fiche commerciale</h4>

--- a/lemarche/templates/dashboard/siae_edit_base.html
+++ b/lemarche/templates/dashboard/siae_edit_base.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name }} : modifier</li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display }} : modifier</li>
                     </ol>
                 </nav>
             </div>


### PR DESCRIPTION
### Quoi ?

- Dans la recherche et la fiche structure, on utilise `name_display` pour afficher l'Enseigne (plutôt que la Raison sociale) si elle est renseignée
- Ce travail permet de faire la même chose dans le Tableau de bord de l'utilisateur