### PR TITLE
Enlever "nofollow" sur nos liens externes

### DIFF
--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -123,13 +123,13 @@
                                             {% if not siae.contact_website and not siae.contact_email and not siae.contact_phone %}
                                                 <li  class="mb-1">
                                                     <i class="ri-search-line"></i>
-                                                    <a href="https://www.google.fr/search?q={{ siae.name_display }}" id="company_google" target="_blank" rel="nofollow noopener">Google</a>
+                                                    <a href="https://www.google.fr/search?q={{ siae.name_display }}" id="company_google" target="_blank" rel="noopener">Google</a>
                                                 </li>
                                             {% endif %}
                                             {% if siae.contact_website %}
                                                 <li class="mb-1">
                                                     <i class="ri-window-2-line"></i>
-                                                    <a href="{{ siae.contact_website }}" id="company_website" target="_blank" rel="nofollow noopener">{{ siae.contact_website }}</a>
+                                                    <a href="{{ siae.contact_website }}" id="company_website" target="_blank" rel="noopener">{{ siae.contact_website }}</a>
                                                 </li>
                                             {% endif %}
                                             {% if siae.contact_email %}
@@ -368,7 +368,7 @@
         </div>
         <div class="row">
             <div class="col-12 mt-5">
-                <small><sup>*</sup>source: informations en provenance d'<a href="https://entreprise.api.gouv.fr/" target="_blank" rel="nofollow noopener">entreprise.api.gouv.fr</a></small>
+                <small><sup>*</sup>source: informations en provenance d'<a href="https://entreprise.api.gouv.fr/" target="_blank" rel="noopener">entreprise.api.gouv.fr</a></small>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Quoi ?

On n'a pas besoin de mettre `nofollow` sur nos liens externes.
Au contraire, l'enlever améliore le SEO (search ranking) de ces liens là !
