### PR TITLE
Dépot de besoins 7/X : améliorations dans l'admin + fix temporaire des envois

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -9,13 +9,18 @@ class TenderAdmin(admin.ModelAdmin):
     list_display = [
         "id",
         "title",
+        "author",
         "kind",
         "deadline_date",
-        "response_kind",
         "start_working_date",
+        "response_kind",
+        "siae_found_count",
         "created_at",
     ]
-    list_filter = ["kind", "deadline_date", "response_kind", "start_working_date"]
+    list_filter = ["kind", "deadline_date", "start_working_date", "response_kind"]
     # filter on "perimeters"? (loads ALL the perimeters... Use django-admin-autocomplete-filter instead?)
     search_fields = ["id", "title"]
     search_help_text = "Cherche sur les champs : ID, Titre"
+    readonly_fields = ["siae_found_count"]
+
+    autocomplete_fields = ["perimeters", "sectors"]

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -21,6 +21,38 @@ class TenderAdmin(admin.ModelAdmin):
     # filter on "perimeters"? (loads ALL the perimeters... Use django-admin-autocomplete-filter instead?)
     search_fields = ["id", "title"]
     search_help_text = "Cherche sur les champs : ID, Titre"
-    readonly_fields = ["siae_found_count"]
+    readonly_fields = ["siae_found_count", "created_at", "updated_at"]
 
     autocomplete_fields = ["perimeters", "sectors"]
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": ("title", "slug", "kind"),
+            },
+        ),
+        (
+            "Détails",
+            {
+                "fields": (
+                    "description",
+                    "constraints",
+                    "perimeters",
+                    "sectors",
+                    "external_link",
+                    "amount",
+                    "response_kind",
+                    "deadline_date",
+                    "start_working_date",
+                ),
+            },
+        ),
+        (
+            "Contact",
+            {
+                "fields": ("author", "contact_first_name", "contact_last_name", "contact_email", "contact_phone"),
+            },
+        ),
+        ("Info", {"fields": ("created_at", "updated_at")}),
+    )

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from huey.contrib.djhuey import task
 
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import Tender
@@ -11,15 +10,17 @@ from lemarche.utils.urls import get_domain_url
 EMAIL_SUBJECT_PREFIX = f"[{settings.BITOUBI_ENV.upper()}] " if settings.BITOUBI_ENV != "prod" else ""
 
 
-@task()
+# @task()
 def send_tender_emails_to_siae_list(tender: Tender, siae_found_list):
     for siae in siae_found_list:
         send_tender_email_to_siae(tender, siae)
 
 
-@task()
+# @task()
 def send_tender_email_to_siae(tender: Tender, siae: Siae):
-    email_subject = EMAIL_SUBJECT_PREFIX + f"{siae.name_display} a besoin de vous sur le marché de l'inclusion"
+    email_subject = (
+        EMAIL_SUBJECT_PREFIX + f"{tender.author.company_name} a besoin de vous sur le marché de l'inclusion"
+    )
     recipient_list = whitelist_recipient_list([siae.contact_email])
     if recipient_list:
         recipient_email = recipient_list[0] if recipient_list else ""
@@ -27,6 +28,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae):
 
         variables = {
             "FULL_NAME": siae.contact_first_name,
+            "BUYER_COMPANY": tender.author.company_name,
             "RESPONSE_KIND": tender.get_kind_display(),
             "SECTORS": tender.get_sectors_names,
             "PERIMETERS": tender.get_perimeters_names,

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -12,7 +12,9 @@ from lemarche.tenders.models import Tender
 from lemarche.users.models import User
 from lemarche.www.dashboard.mixins import NotSiaeUserRequiredMixin
 from lemarche.www.tenders.forms import AddTenderForm
-from lemarche.www.tenders.tasks import send_tender_emails_to_siae_list
+
+
+# from lemarche.www.tenders.tasks import send_tender_emails_to_siae_list
 
 
 TITLE_DETAIL_PAGE_SIAE = "Trouver de nouvelles opportunités"
@@ -43,7 +45,7 @@ class TenderCreateView(NotSiaeUserRequiredMixin, SuccessMessageMixin, CreateView
         tender.save()
 
         # task
-        send_tender_emails_to_siae_list(tender, siae_found_list)
+        # send_tender_emails_to_siae_list(tender, siae_found_list)
 
         messages.add_message(
             self.request,


### PR DESCRIPTION
### Quoi ?

Admin
- passer quelques champs en readonly
- passer quelques champs en autocomplete pour accélérer le chargement de la page
- ajouter un fieldset pour espacer un peu la page

Fix temporaire des envois
- huey n'arrive pas à faire de jointures/récupération d'infos, donc j'ai désactivé le `task()` + l'envoi d'emails : on les lancera manuellement en ligne de commande en attendant
- fix sur l'email_subject
- fix sur une variable manquante