### PR TITLE
Stats : ajout du Matomo Tag Manager

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -451,6 +451,7 @@ TRACKER_HOST = env.str("TRACKER_HOST", "http://localhost")
 HOTJAR_ID = int(env.str("HOTJAR_ID", 0))
 MATOMO_SITE_ID = int(env.str("MATOMO_SITE_ID", 0))
 MATOMO_HOST = env.str("MATOMO_HOST", "")
+MATOMO_TAG_MANAGER_CONTAINER_ID = env.str("MATOMO_TAG_MANAGER_CONTAINER_ID", "")
 CRISP_ID = env.str("CRISP_ID", "")
 
 

--- a/lemarche/templates/includes/_tracker_tarteaucitron.html
+++ b/lemarche/templates/includes/_tracker_tarteaucitron.html
@@ -95,6 +95,15 @@ _paq.push(['enableLinkTracking']);
 })();
 </script> -->
 
+<!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='{{ MATOMO_HOST }}js/container_{{ MATOMO_TAG_MANAGER_CONTAINER_ID }}.js'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+
 <!-- Ajouter manuellement Crisp à tarteaucitron : https://github.com/AmauriC/tarteaucitron.js/pull/281 -->
 <script type="text/javascript">
 tarteaucitron.services.crips = {

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -14,6 +14,7 @@ def expose_settings(request):
         "HOTJAR_ID": settings.HOTJAR_ID,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_HOST": settings.MATOMO_HOST,
+        "MATOMO_TAG_MANAGER_CONTAINER_ID": settings.MATOMO_TAG_MANAGER_CONTAINER_ID,
         "CRISP_ID": settings.CRISP_ID,
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,
         "FACILITATOR_LIST": settings.FACILITATOR_LIST,


### PR DESCRIPTION
### Quoi ?

- création d'un Tag Manager container sur Matomo
- ajout du script dans le Frontend
  - pas possible de le rajouter à tarteaucitron ? pas dispo. cf https://github.com/AmauriC/tarteaucitron.js > issue 471
