### PR TITLE
Dépôt de besoins : stat sur le clic des coordonnées

### DIFF
--- a/lemarche/static/itou_marche/components/_collapse.scss
+++ b/lemarche/static/itou_marche/components/_collapse.scss
@@ -1,0 +1,19 @@
+[aria-expanded="false"] {
+    #collapse__ico-up {
+        display: none;
+    }
+
+    #collapse__ico-down {
+        display: inline;
+    }
+}
+
+[aria-expanded="true"] {
+    #collapse__ico-up {
+        display: inline;
+    }
+
+    #collapse__ico-down {
+        display: none;
+    }
+}

--- a/lemarche/static/itou_marche/itou_marche.scss
+++ b/lemarche/static/itou_marche/itou_marche.scss
@@ -9,6 +9,7 @@
 @import 'components/multiselect';
 @import 'components/autocomplete';
 @import 'components/maparea';
+@import 'components/collapse';
 
 // Sections
 @import 'sections/home';

--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -142,29 +142,6 @@
 		}
 	}
 
-	.map_coordonnees__btn {
-
-		&[aria-expanded="false"] {
-			#map_coordonnees__ico-up {
-				display: none;
-			}
-
-			#map_coordonnees__ico-down {
-				display: inline;
-			}
-		}
-
-		&[aria-expanded="true"] {
-			#map_coordonnees__ico-up {
-				display: inline;
-			}
-
-			#map_coordonnees__ico-down {
-				display: none;
-			}
-		}
-	}
-
 	.profile-detail {
 		.img-left {
 			display: flex;

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -150,12 +150,12 @@
                         <div class="profile_capsule">
                             <div class="map_coordonnees">
                                 {% if user.is_authenticated %}
-                                    <button id="show_data" class="map_coordonnees__btn btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseCoordonnees" aria-expanded="false" aria-controls="collapseCoordonnees">
+                                    <button id="show_data" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseCoordonnees" aria-expanded="false" aria-controls="collapseCoordonnees">
                                         <span>Afficher les coordonnées</span>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="map_coordonnees__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="map_coordonnees__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
                                     </button>
-                                    <div class="collapse mb-lg-2" id="collapseCoordonnees">
+                                    <div id="collapseCoordonnees" class="collapse mb-lg-2">
                                         <ul class="list-unstyled fs-sm">
                                             {% if siae.is_missing_contact %}
                                                 <li class="mb-1">
@@ -202,9 +202,9 @@
                                         </ul>
                                     </div>
                                 {% else %}
-                                    <a href="#" id="show_data-modal-btn" class="map_coordonnees__btn btn btn-block btn-primary btn-ico mb-4" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
+                                    <a href="#" id="show_data-modal-btn" class="btn btn-block btn-primary btn-ico mb-4" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
                                         <span>Afficher les coordonnées</span>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="map_coordonnees__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
                                     </a>
                                 {% endif %}
                             </div>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -1,0 +1,37 @@
+<h2>Pour répondre à cet appel d'offre</h2>
+<div class="row">
+    {% if tender.get_contact_full_name %}
+        <div class="col-md-6">
+            <span class="ri-account-circle-line"></span>
+            {{ tender.get_contact_full_name }}
+        </div>
+    {% endif %}
+    {% if tender.author.company_name %}
+        <div class="col-md-6">
+            <span class="ri-building-2-line"></span>
+            {{ tender.author.company_name }}
+        </div>
+    {% endif %}
+    {% if tender.contact_email %}
+        <div class="col-md-6">
+            <span class="ri-at-line"></span>
+            {{ tender.contact_email }}
+        </div>
+    {% endif %}
+    {% if tender.contact_phone %}
+        <div class="col-md-6">
+            <span class="ri-phone-line"></span>
+            {{ tender.contact_phone }}
+        </div>
+    {% endif %}
+</div>
+{% if tender.external_link %}
+    <div class="row">
+        <div class="col-12">
+            <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
+                Voir l'appel d'offre <span class="ri-external-link-line" aria-hidden="true"></span>
+            </a>
+        </div>
+    </div>
+{% endif %}
+</div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -88,3 +88,20 @@
     </div>
 </section>
 {% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    var tenderContactCollapseButton = document.getElementById('show-tender-contact');
+    tenderContactCollapseButton.addEventListener('click', function() {
+        fetch(`${window.location.href}/contact-click-stat`, {
+            method: 'POST',
+            headers: {
+                'X-CSRFToken': '{{ csrf_token }}'
+            },
+            body: JSON.stringify({}),
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -75,12 +75,10 @@
             {% if tender.author == request.user or user_has_contact_click_date %}
                 {% include "tenders/_detail_contact.html" with tender=tender %}
             {% else %}
-                <button id="show-tender-contact" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseTenderContact" aria-expanded="false" aria-controls="collapseTenderContact">
-                    <span>Afficher les coordonnées pour répondre à cet appel d'offre</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
+                <button type="button" id="show-tender-contact-btn" class="btn btn-primary float-right mb-4" style="display:block">
+                    Afficher les coordonnées
                 </button>
-                <div id="collapseTenderContact" class="collapse py-2">
+                <div id="show-tender-contact-content" class="py-2" style="display:none">
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 </div>
             {% endif %}
@@ -92,9 +90,14 @@
 {% block extra_js %}
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
-    var tenderContactCollapseButton = document.getElementById('show-tender-contact');
+    var tenderContactCollapseButton = document.getElementById('show-tender-contact-btn');
+    var tenderContactCollapseContent = document.getElementById('show-tender-contact-content');
     if (tenderContactCollapseButton) {
         tenderContactCollapseButton.addEventListener('click', function() {
+            // hide button, show content
+            tenderContactCollapseButton.style.display = 'none';
+            tenderContactCollapseContent.style.display = '';
+            // send click stat to backend
             fetch(`${window.location.href}/contact-click-stat`, {
                 method: 'POST',
                 headers: {

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -48,24 +48,36 @@
                     {{ tender.get_perimeters_names }}
                 </div>
             </div>
+
             <hr class="my-5">
+
             <div class="py-2">
                 <h2>Description <span class="float-right fs-sm  text-muted">Début d'intervention : {{ tender.start_working_date|default:"" }}</span></h2>
                 <p>{{ tender.description }}</p>
             </div>
+
             <hr class="my-5">
+
             <div class="py-2">
                 <h2>Contraintes techniques spécifiques</h2>
                 <p>{{ tender.constraints }}</p>
             </div>
+
             <hr class="my-5">
+
             <div class="py-2">
                 <h2>Montant du marché</h2>
                 <p>{{ tender.amount.value|intcomma|default:"-" }}&nbsp;€</p>
             </div>
 
             <hr class="my-5">
-            <div class="py-2">
+
+            <button id="show-tender-contact" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseTenderContact" aria-expanded="false" aria-controls="collapseTenderContact">
+                <span>Afficher les coordonnées pour répondre à cet appel d'offre</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
+            </button>
+            <div id="collapseTenderContact" class="collapse py-2">
                 <h2>Pour répondre à cet appel d'offre</h2>
                 <div class="row">
                     {% if tender.get_contact_full_name %}
@@ -93,16 +105,17 @@
                         </div>
                     {% endif %}
                 </div>
-            </div>
-
-            {% if tender.external_link %}
-                <hr class="my-5">
-                <div class="py-2">
-                    <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                        Voir l'appel d'offre <span class="ri-external-link-line" aria-hidden="true"></span>
-                    </a>
+                {% if tender.external_link %}
+                    <div class="row">
+                        <div class="col-12">
+                            <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
+                                Voir l'appel d'offre <span class="ri-external-link-line" aria-hidden="true"></span>
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
                 </div>
-            {% endif %}
+            </div>
         </div>
     </div>
 </section>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -72,50 +72,18 @@
 
             <hr class="my-5">
 
-            <button id="show-tender-contact" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseTenderContact" aria-expanded="false" aria-controls="collapseTenderContact">
-                <span>Afficher les coordonnées pour répondre à cet appel d'offre</span>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
-            </button>
-            <div id="collapseTenderContact" class="collapse py-2">
-                <h2>Pour répondre à cet appel d'offre</h2>
-                <div class="row">
-                    {% if tender.get_contact_full_name %}
-                        <div class="col-md-6">
-                            <span class="ri-account-circle-line"></span>
-                            {{ tender.get_contact_full_name }}
-                        </div>
-                    {% endif %}
-                    {% if tender.author.company_name %}
-                        <div class="col-md-6">
-                            <span class="ri-building-2-line"></span>
-                            {{ tender.author.company_name }}
-                        </div>
-                    {% endif %}
-                    {% if tender.contact_email %}
-                        <div class="col-md-6">
-                            <span class="ri-at-line"></span>
-                            {{ tender.contact_email }}
-                        </div>
-                    {% endif %}
-                    {% if tender.contact_phone %}
-                        <div class="col-md-6">
-                            <span class="ri-phone-line"></span>
-                            {{ tender.contact_phone }}
-                        </div>
-                    {% endif %}
+            {% if tender.author == request.user %}
+                {% include "tenders/_detail_contact.html" with tender=tender %}
+            {% else %}
+                <button id="show-tender-contact" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseTenderContact" aria-expanded="false" aria-controls="collapseTenderContact">
+                    <span>Afficher les coordonnées pour répondre à cet appel d'offre</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-up"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 8l6 6H6z"/></svg>
+                </button>
+                <div id="collapseTenderContact" class="collapse py-2">
+                    {% include "tenders/_detail_contact.html" with tender=tender %}
                 </div>
-                {% if tender.external_link %}
-                    <div class="row">
-                        <div class="col-12">
-                            <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                                Voir l'appel d'offre <span class="ri-external-link-line" aria-hidden="true"></span>
-                            </a>
-                        </div>
-                    </div>
-                {% endif %}
-                </div>
-            </div>
+            {% endif %}
         </div>
     </div>
 </section>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -72,7 +72,7 @@
 
             <hr class="my-5">
 
-            {% if tender.author == request.user %}
+            {% if tender.author == request.user or user_has_contact_click_date %}
                 {% include "tenders/_detail_contact.html" with tender=tender %}
             {% else %}
                 <button id="show-tender-contact" class="btn btn-block btn-primary btn-ico mb-4" type="button" data-toggle="collapse" data-target="#collapseTenderContact" aria-expanded="false" aria-controls="collapseTenderContact">
@@ -93,15 +93,17 @@
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
     var tenderContactCollapseButton = document.getElementById('show-tender-contact');
-    tenderContactCollapseButton.addEventListener('click', function() {
-        fetch(`${window.location.href}/contact-click-stat`, {
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: JSON.stringify({}),
+    if (tenderContactCollapseButton) {
+        tenderContactCollapseButton.addEventListener('click', function() {
+            fetch(`${window.location.href}/contact-click-stat`, {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': '{{ csrf_token }}'
+                },
+                body: JSON.stringify({}),
+            });
         });
-    });
+    }
 });
 </script>
 {% endblock %}

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>
+<script type="text/javascript">
     $(document).on("click", ".c-card--link", function(e) {
         window.location.href = $(this).data("url");
     });

--- a/lemarche/templates/tenders/list_item.html
+++ b/lemarche/templates/tenders/list_item.html
@@ -49,14 +49,18 @@
 
         {% if tender.author == request.user %}
             <hr>
-            <div class="row">
+            <div class="row text-center">
                 <div class="col-md-4">
                     <i class="ri-mail-check-line"></i>
-                    <strong>{{ tender.siae_email_send_count|default:0 }} structures contactées</strong>
+                    <strong>{{ tender.siae_email_send_count }} structures contactées</strong>
                 </div>
                 <div class="col-md-4">
                     <i class="ri-eye-line"></i>
-                    <strong>{{ tender.siae_detail_display_count|default:0 }} vues</strong>
+                    <strong>{{ tender.siae_detail_display_count }} vues</strong>
+                </div>
+                <div class="col-md-4">
+                    <i class="ri-thumb-up-line"></i>
+                    <strong>{{ tender.siae_contact_click_count }} prestataires intéressés</strong>
                 </div>
             </div>
         {% endif %}

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -14,14 +14,22 @@ class TenderAdmin(admin.ModelAdmin):
         "deadline_date",
         "start_working_date",
         "response_kind",
-        "siae_found_count",
+        "nb_siae_email_send",
+        "nb_siae_detail_display",
+        "nb_siae_contact_click",
         "created_at",
     ]
     list_filter = ["kind", "deadline_date", "start_working_date", "response_kind"]
     # filter on "perimeters"? (loads ALL the perimeters... Use django-admin-autocomplete-filter instead?)
     search_fields = ["id", "title"]
     search_help_text = "Cherche sur les champs : ID, Titre"
-    readonly_fields = ["siae_found_count", "created_at", "updated_at"]
+    readonly_fields = [
+        "nb_siae_email_send",
+        "nb_siae_detail_display",
+        "nb_siae_contact_click",
+        "created_at",
+        "updated_at",
+    ]
 
     autocomplete_fields = ["perimeters", "sectors"]
 
@@ -54,5 +62,34 @@ class TenderAdmin(admin.ModelAdmin):
                 "fields": ("author", "contact_first_name", "contact_last_name", "contact_email", "contact_phone"),
             },
         ),
+        (
+            "Stats",
+            {
+                "fields": ("nb_siae_email_send", "nb_siae_detail_display", "nb_siae_contact_click"),
+            },
+        ),
         ("Info", {"fields": ("created_at", "updated_at")}),
     )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.with_siae_stats()
+        return qs
+
+    def nb_siae_email_send(self, tender):
+        return tender.siae_email_send_count
+
+    nb_siae_email_send.short_description = "Structures contactées"
+    nb_siae_email_send.admin_order_field = "siae_email_send_count"
+
+    def nb_siae_detail_display(self, tender):
+        return tender.siae_detail_display_count
+
+    nb_siae_detail_display.short_description = "Structures vues"
+    nb_siae_detail_display.admin_order_field = "siae_detail_display_count"
+
+    def nb_siae_contact_click(self, tender):
+        return tender.siae_contact_click_count
+
+    nb_siae_contact_click.short_description = "Structures intéressées"
+    nb_siae_contact_click.admin_order_field = "siae_contact_click_count"

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -58,6 +58,11 @@ class TenderQuerySet(models.QuerySet):
                     When(tendersiae__detail_display_date__isnull=False, then=1), default=0, output_field=IntegerField()
                 )
             ),
+            siae_contact_click_count=Sum(
+                Case(
+                    When(tendersiae__contact_click_date__isnull=False, then=1), default=0, output_field=IntegerField()
+                )
+            ),
         )
 
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -114,17 +114,27 @@ class TenderModelQuerysetTest(TestCase):
         siae_1 = SiaeFactory()
         siae_2 = SiaeFactory()
         siae_3 = SiaeFactory()
-        tender = TenderFactory(siaes=[siae_1])
-        TenderSiae.objects.create(tender=tender, siae=siae_2, email_send_date=timezone.now())
+        siae_4 = SiaeFactory()
+        tender_with_siae = TenderFactory(siaes=[siae_1])
+        TenderSiae.objects.create(tender=tender_with_siae, siae=siae_2, email_send_date=timezone.now())
         TenderSiae.objects.create(
-            tender=tender, siae=siae_3, email_send_date=timezone.now(), detail_display_date=timezone.now()
+            tender=tender_with_siae, siae=siae_3, email_send_date=timezone.now(), detail_display_date=timezone.now()
         )
-        TenderFactory()
-        self.assertEqual(tender.siaes.count(), 3)
+        TenderSiae.objects.create(
+            tender=tender_with_siae,
+            siae=siae_4,
+            email_send_date=timezone.now(),
+            detail_display_date=timezone.now(),
+            contact_click_date=timezone.now(),
+        )
+        tender_without_siae = TenderFactory()
+        self.assertEqual(tender_with_siae.siaes.count(), 4)
         self.assertEqual(Tender.objects.count(), 2)
-        tender_in_queryset = Tender.objects.with_siae_stats().first()
-        self.assertEqual(tender_in_queryset.siae_email_send_count, 2)
-        self.assertEqual(tender_in_queryset.siae_detail_display_count, 1)
-        empty_tender_in_queryset = Tender.objects.with_siae_stats().last()
-        self.assertEqual(empty_tender_in_queryset.siae_email_send_count, 0)
-        self.assertEqual(empty_tender_in_queryset.siae_detail_display_count, 0)
+        tender_with_siae = Tender.objects.with_siae_stats().first()
+        self.assertEqual(tender_with_siae.siae_email_send_count, 3)
+        self.assertEqual(tender_with_siae.siae_detail_display_count, 2)
+        self.assertEqual(tender_with_siae.siae_contact_click_count, 1)
+        tender_without_siae = Tender.objects.with_siae_stats().last()
+        self.assertEqual(tender_without_siae.siae_email_send_count, 0)
+        self.assertEqual(tender_without_siae.siae_detail_display_count, 0)
+        self.assertEqual(tender_without_siae.siae_contact_click_count, 0)

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lemarche.www.tenders.views import TenderCreateView, TenderDetail, TenderListView
+from lemarche.www.tenders.views import TenderCreateView, TenderDetail, TenderDetailContactClickStat, TenderListView
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -10,4 +10,5 @@ urlpatterns = [
     path("ajouter", TenderCreateView.as_view(), name="create"),
     path("", TenderListView.as_view(), name="list"),
     path("<str:slug>", TenderDetail.as_view(), name="detail"),
+    path("<str:slug>/contact-click-stat", TenderDetailContactClickStat.as_view(), name="detail-contact-click-stat"),
 ]

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -3,10 +3,11 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator
 from django.http import HttpResponseForbidden, HttpResponseRedirect, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, View
 
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import Tender, TenderSiae
@@ -129,8 +130,9 @@ class TenderDetail(LoginRequiredMixin, DetailView):
         return context
 
 
-class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
-    model = Tender
+class TenderDetailContactClickStat(LoginRequiredMixin, View):
+    def get_object(self):
+        return get_object_or_404(Tender, slug=self.kwargs.get("slug"))
 
     def post(self, request, *args, **kwargs):
         if self.request.user.kind == User.KIND_SIAE:


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/268
Sur les dépôt de besoin, cacher les coordonnées derrière un bouton. Une fois cliqué, le bouton disparaitra au prochain affichage du dépot de besoin.

### Pourquoi ?

Avoir des stats d'affichage