### PR TITLE
Supprimer l'envoi de l'e-mail de bienvenue

### DIFF
--- a/lemarche/templates/auth/signup_welcome_email_body.txt
+++ b/lemarche/templates/auth/signup_welcome_email_body.txt
@@ -1,4 +1,0 @@
-Votre compte a été créé. Nous sommes heureux de vous compter parmi nous.
-
-Le marché de l'inclusion
-https://lemarche.inclusion.beta.gouv.fr/

--- a/lemarche/www/auth/tasks.py
+++ b/lemarche/www/auth/tasks.py
@@ -5,20 +5,7 @@ from huey.contrib.djhuey import task
 
 from lemarche.users.models import User
 from lemarche.utils.apis import api_mailjet
-from lemarche.utils.emails import whitelist_recipient_list
 from lemarche.utils.urls import get_domain_url
-
-
-def send_welcome_email(user):
-    email_subject_prefix = f"[{settings.BITOUBI_ENV.upper()}] " if settings.BITOUBI_ENV != "prod" else ""
-    email_subject = email_subject_prefix + f"Bienvenue {user.first_name} !"
-    email_body = render_to_string("auth/signup_welcome_email_body.txt", {})
-
-    _send_mail_async(
-        email_subject=email_subject,
-        email_body=email_body,
-        recipient_list=whitelist_recipient_list([user.email]),
-    )
 
 
 def send_signup_notification_email(user):

--- a/lemarche/www/auth/views.py
+++ b/lemarche/www/auth/views.py
@@ -10,7 +10,7 @@ from lemarche.users.models import User
 from lemarche.utils.tracker import extract_meta_from_request, track
 from lemarche.utils.urls import get_safe_url
 from lemarche.www.auth.forms import LoginForm, PasswordResetForm, SignupForm
-from lemarche.www.auth.tasks import add_to_contact_list, send_signup_notification_email, send_welcome_email
+from lemarche.www.auth.tasks import add_to_contact_list, send_signup_notification_email
 
 
 class LoginView(auth_views.LoginView):
@@ -81,9 +81,9 @@ class SignupView(SuccessMessageMixin, CreateView):
         - track signup
         """
         user = form.save()
+        # add to Mailjet list (to send welcome email + automation)
         add_to_contact_list(user, "signup")
-        # welcome email
-        send_welcome_email(user)
+        # signup notification email for the team
         send_signup_notification_email(user)
         # login the user
         user = authenticate(username=form.cleaned_data["email"], password=form.cleaned_data["password1"])


### PR DESCRIPTION
### Quoi ?

A chaque inscription, on envoit un e-mail de bienvenue. Mais il est moche + il fait doublon.

### Pourquoi ?

On a mis en place des envois d'e-mails automatisés avec Mailjet (dont un e-mail de bienvenue post-inscription)
