### PR TITLE
PostgreSQL 14 : réparer le CI

### DIFF
--- a/.github/workflows/linting_testing.yml
+++ b/.github/workflows/linting_testing.yml
@@ -26,7 +26,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgis/postgis:14-master
+        image: postgis/postgis:14-3.2
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/linting_testing.yml
+++ b/.github/workflows/linting_testing.yml
@@ -26,7 +26,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgis/postgis:14-3.2
+        image: postgis/postgis:14-3.1
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/docker/dev/postgres/Dockerfile
+++ b/docker/dev/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # https://registry.hub.docker.com/r/postgis/postgis
-FROM postgis/postgis:14-master
+FROM postgis/postgis:14-3.1
 
 RUN localedef -i fr_FR -c -f UTF-8 -A /usr/share/locale/locale.alias fr_FR.UTF-8
 ENV LANG fr_FR.utf8

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -231,29 +231,29 @@ class SiaeModelSaveTest(TestCase):
         self.assertNotEqual(siae.coords, None)
 
 
-# class SiaeModelQuerysetTest(TestCase):
-#     def setUp(self):
-#         pass
+class SiaeModelQuerysetTest(TestCase):
+    def setUp(self):
+        pass
 
-#     def test_is_live_queryset(self):
-#         SiaeFactory(is_active=True, is_delisted=True)
-#         SiaeFactory(is_active=False, is_delisted=True)
-#         SiaeFactory(is_active=True, is_delisted=False)  # live
-#         SiaeFactory(is_active=False, is_delisted=False)
-#         self.assertEqual(Siae.objects.count(), 4)
-#         self.assertEqual(Siae.objects.is_live().count(), 1)
-#         self.assertEqual(Siae.objects.is_not_live().count(), 3)
+    def test_is_live_queryset(self):
+        SiaeFactory(is_active=True, is_delisted=True)
+        SiaeFactory(is_active=False, is_delisted=True)
+        SiaeFactory(is_active=True, is_delisted=False)  # live
+        SiaeFactory(is_active=False, is_delisted=False)
+        self.assertEqual(Siae.objects.count(), 4)
+        self.assertEqual(Siae.objects.is_live().count(), 1)
+        self.assertEqual(Siae.objects.is_not_live().count(), 3)
 
-#     def test_has_user_queryset(self):
-#         SiaeFactory()
-#         siae = SiaeFactory()
-#         user = UserFactory()
-#         siae.users.add(user)
-#         self.assertEqual(Siae.objects.count(), 2)
-#         self.assertEqual(Siae.objects.has_user().count(), 1)
+    def test_has_user_queryset(self):
+        SiaeFactory()
+        siae = SiaeFactory()
+        user = UserFactory()
+        siae.users.add(user)
+        self.assertEqual(Siae.objects.count(), 2)
+        self.assertEqual(Siae.objects.has_user().count(), 1)
 
-#     # def test_annotate_with_user_favorite_list_ids(self):
-#     # see favorites > tests.py
+    # def test_annotate_with_user_favorite_list_ids(self):
+    # see favorites > tests.py
 
 
 class SiaeGroupModelTest(TestCase):

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -306,9 +306,9 @@ class SiaePerimeterSearchFilterTest(TestCase):
             coords=Point(-4.0916, 47.9914),
         )
 
-    # def test_object_count(self):
-    #     self.assertEqual(Perimeter.objects.count(), 4)
-    #     self.assertEqual(Siae.objects.count(), 14)
+    def test_object_count(self):
+        self.assertEqual(Perimeter.objects.count(), 4)
+        self.assertEqual(Siae.objects.count(), 14)
 
     def test_search_perimeter_empty(self):
         form = SiaeSearchForm({"perimeter": "", "perimeter_name": ""})


### PR DESCRIPTION
### Quoi ?

Suite à la PR https://github.com/betagouv/itou-marche/pull/295 (upgrade de Postgres à la version 14), certains tests ne marchent plus. Tentative de réparer en indiquant une version différente dans la config.
