### PR TITLE
Stats : cleanup

### DIFF
--- a/lemarche/templates/includes/_tracker_itou.html
+++ b/lemarche/templates/includes/_tracker_itou.html
@@ -7,7 +7,6 @@ const getCookieValueByName = function(cookieName) {
 
 var ORDER = 1;
 var SESSION_ID = '';
-var VERSION = 1;
 
 const uTypeMapping = {
     'SIAE': '4',
@@ -42,15 +41,16 @@ document.cookie = `${USER_TYPE_COOKIE_NAME}=${window.uType}; expires=Fri, 31 Dec
 document.cookie = `${USER_ID_COOKIE_NAME}=${window.uID}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/; Secure`;
 
 async function track(page, action, meta={}) {
-    const body = computeRequestBody(page, action, meta);
+    const data = computeRequestBody(page, action, meta);
 
     if (typeof window !== 'undefined') {
-        await fetch('{{ TRACKER_HOST }}/track', {
+        await fetch(`${window.location.origin}/track/`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'text/plain',
+                'X-CSRFToken': '{{ csrf_token }}',
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify(data)
         });
     }
 }
@@ -79,16 +79,11 @@ function computeRequestBody(page, action, metaIn) {
     meta['source'] = 'bitoubi_frontend';
 
     return {
-        _v: VERSION,
-        timestamp: timeNow.toISOString(),
         order: ORDER += 1,
-        env: '{{ BITOUBI_ENV }}',
         session_id: getSessionId(),
         page: page,
         action: action,
-        meta: JSON.stringify(meta),
-        client_context: {},
-        server_context: {}
+        meta: meta,
     }
 }
 
@@ -139,7 +134,7 @@ function getUrlMeta() {
 
 // track each page load
 document.addEventListener('DOMContentLoaded', () => {
-    track(window.location.pathname, Steps.LOAD);
+    track(page=window.location.pathname, action=Steps.LOAD);
 }, false);
 
 // track each link & button click
@@ -162,9 +157,9 @@ document.addEventListener('click', async (event) => {
     }
 
     await track(
-        window.location.pathname,
-        Steps.CLICK,
-        meta
+        page=window.location.pathname,
+        action=Steps.CLICK,
+        meta=meta
     );
 }, false);
 </script>

--- a/lemarche/templates/includes/_tracker_itou.html
+++ b/lemarche/templates/includes/_tracker_itou.html
@@ -71,7 +71,7 @@ function computeRequestBody(page, action, metaIn) {
     // Optionnaly add meta data (in key/value pairs) from url query string
     const meta = Object.assign(metaIn, getUrlMeta());
     // user info
-    // meta['user_id'] = {% if user.is_authenticated %}'{{ user.id }}'{% else %}null{% endif %};  // privacy concerns...
+    // meta['user_id'] = {% if user.is_authenticated %}'{{ user.id }}'{% else %}null{% endif %};
     meta['is_admin'] = getCookieValueByName(IS_ADMIN_COOKIE_NAME) == 'true';
     meta['user_type'] = getCookieValueByName(USER_TYPE_COOKIE_NAME);
     meta['user_id'] = getCookieValueByName(USER_ID_COOKIE_NAME);
@@ -88,7 +88,7 @@ function computeRequestBody(page, action, metaIn) {
         action: action,
         meta: JSON.stringify(meta),
         client_context: {},
-        server_context: {},
+        server_context: {}
     }
 }
 
@@ -137,10 +137,12 @@ function getUrlMeta() {
     }
 }
 
+// track each page load
 document.addEventListener('DOMContentLoaded', () => {
     track(window.location.pathname, Steps.LOAD);
 }, false);
 
+// track each link & button click
 document.addEventListener('click', async (event) => {
     event = event || window.event;
     var target = event.target || event.srcElement;

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -130,7 +130,7 @@
     <script type="text/javascript" src="{% static 'js/territory_multiselect_field.js' %}"></script>
     {% endcompress %}
     <script type="text/javascript" src="{% static 'js/utils.js'%}"></script>
-    {% if BITOUBI_ENV not in "dev" %}
+    {% if BITOUBI_ENV in "dev" %}
         {% include "includes/_tracker_tarteaucitron.html" %}
         {% include "includes/_tracker_itou.html" %}
     {% endif %}

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -130,7 +130,7 @@
     <script type="text/javascript" src="{% static 'js/territory_multiselect_field.js' %}"></script>
     {% endcompress %}
     <script type="text/javascript" src="{% static 'js/utils.js'%}"></script>
-    {% if BITOUBI_ENV in "dev" %}
+    {% if BITOUBI_ENV not in "dev" %}
         {% include "includes/_tracker_tarteaucitron.html" %}
         {% include "includes/_tracker_itou.html" %}
     {% endif %}

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -10,7 +10,6 @@ def expose_settings(request):
     return {
         "BITOUBI_ENV": settings.BITOUBI_ENV,
         "BITOUBI_ENV_COLOR": settings.BITOUBI_ENV_COLOR,
-        "TRACKER_HOST": settings.TRACKER_HOST,
         "HOTJAR_ID": settings.HOTJAR_ID,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_HOST": settings.MATOMO_HOST,

--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -29,6 +29,8 @@ VERSION = 1
 
 TRACKER_IGNORE_LIST = [
     "static/",
+    "admin/",
+    "select2/",
     "api/perimeters/autocomplete",
 ]
 

--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -69,11 +69,10 @@ def track(
     action: str,
     meta: dict = {},
     session_id: str = None,
-    client_context: dict = {},
 ):  # noqa B006
 
     # Don't log in dev
-    if settings.BITOUBI_ENV != "dev":
+    if settings.BITOUBI_ENV == "dev":
 
         # extract_sessionid_from_request
         if session_id:
@@ -91,7 +90,6 @@ def track(
             "session_id": session_id,
             "action": action,
             "meta": json.dumps(meta | DEFAULT_PAYLOAD["meta"]),
-            "client_context": client_context,
         }
 
         payload = DEFAULT_PAYLOAD | set_payload
@@ -122,14 +120,11 @@ class TrackerMiddleware:
                 # build meta & co
                 meta = extract_meta_from_request(request)
                 session_id = request.COOKIES.get("sessionid", None)
-                request_referer = request.META.get("HTTP_REFERER", "")
-                client_context = {"referer": request_referer, "user_agent": request_ua}
                 track(
                     page=page,
                     action="load",
                     meta=meta,
                     session_id=session_id,
-                    client_context=client_context,
                 )
 
         response = self.get_response(request)

--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -32,6 +32,7 @@ TRACKER_IGNORE_LIST = [
     "admin/",
     "select2/",
     "api/perimeters/autocomplete",
+    "track/",  # avoid duplicate tracking
 ]
 
 USER_KIND_MAPPING = {
@@ -50,8 +51,6 @@ DEFAULT_PAYLOAD = {
     "page": "",
     "action": "load",
     "meta": {"source": "bitoubi_api"},  # needs to be stringifyed...
-    "client_context": {},
-    "server_context": {},
 }
 
 
@@ -74,7 +73,7 @@ def track(
 ):  # noqa B006
 
     # Don't log in dev
-    if settings.BITOUBI_ENV == "dev":
+    if settings.BITOUBI_ENV != "dev":
 
         # extract_sessionid_from_request
         if session_id:

--- a/lemarche/www/pages/urls.py
+++ b/lemarche/www/pages/urls.py
@@ -1,7 +1,15 @@
 from django.urls import include, path
 from django.views.generic import RedirectView, TemplateView
 
-from lemarche.www.pages.views import ContactView, HomeView, PageView, SiaeGroupListView, StatsView, trigger_error
+from lemarche.www.pages.views import (
+    ContactView,
+    HomeView,
+    PageView,
+    SiaeGroupListView,
+    StatsView,
+    TrackView,
+    trigger_error,
+)
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -141,6 +149,8 @@ urlpatterns = [
             ]
         ),
     ),
+    # Tracking endpoint for the frontend
+    path("track/", TrackView.as_view(), name="track_frontend"),
     # Flatpages (created in the admin)
     # path("", include("django.contrib.flatpages.urls")),
     path("<path:url>", PageView.as_view(), name="flatpage"),

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -1,12 +1,15 @@
+import json
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
-from django.http import Http404, HttpResponsePermanentRedirect
+from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.urls import reverse_lazy
-from django.views.generic import DetailView, FormView, ListView, TemplateView
+from django.views.generic import DetailView, FormView, ListView, TemplateView, View
 
 from lemarche.pages.models import Page
 from lemarche.siaes.models import Siae, SiaeGroup
+from lemarche.utils.tracker import track
 from lemarche.www.pages.forms import ContactForm
 from lemarche.www.pages.tasks import send_contact_form_email, send_contact_form_receipt
 
@@ -102,6 +105,18 @@ class PageView(DetailView):
             raise Http404("Page inconnue")
 
         return page
+
+
+class TrackView(View):
+    def post(self, request, *args, **kwargs):
+        data = json.loads(request.body)
+        track(
+            page=data.get("page", ""),
+            action=data.get("action", ""),
+            meta=data,
+            session_id=data.get("sessionid", None),
+        )
+        return JsonResponse({"message": "success"})
 
 
 def trigger_error(request):


### PR DESCRIPTION
### Quoi ?

- ne plus envoyer `server_context` & `client_context`
- envoyer les payload du Frontend au Backend (au lieu de les envoyer directement à `TRACKER_HOST`)
- enrichir la whitelist