### PR TITLE
Limiter l'affichage des dépôts de besoins aux ESI

### DIFF
--- a/lemarche/templates/tenders/create.html
+++ b/lemarche/templates/tenders/create.html
@@ -69,10 +69,14 @@
                             <div class="form-group">
                                 {{ form.start_working_date.label_tag }}
                                 <div class="input-group">
-                                    <input id="id_{{ form.start_working_date.name }}" class="form-control" name="{{ form.start_working_date.name }}" type="{{ form.start_working_date.field.widget.input_type }}" value="{{ form.start_working_date.value}}" />
+                                    <input id="id_{{ form.start_working_date.name }}" class="form-control{% if form.start_working_date.errors %} is-invalid{% endif %}" name="{{ form.start_working_date.name }}" type="{{ form.start_working_date.field.widget.input_type }}" value="{{ form.start_working_date.value}}" />
                                     <div class="input-group-append">
                                         <span class="input-group-text"><i class="ri-calendar-2-line ri-lg"></i></span>
                                     </div>
+                                    {% for error in form.start_working_date.errors %}
+                                        <div class="invalid-feedback">{{ error }}</div>
+                                    {% endfor %}
+
                                 </div>
                             </div>
                         </fieldset>
@@ -89,10 +93,13 @@
                             <div class="form-group form-group-required">
                                 {{ form.deadline_date.label_tag }}
                                 <div class="input-group">
-                                    <input id="id_{{ form.deadline_date.name }}" class="form-control" name="{{ form.deadline_date.name }}" type="{{ form.deadline_date.field.widget.input_type }}" value="{{ form.deadline_date.value}}" />
+                                    <input id="id_{{ form.deadline_date.name }}" class="form-control{% if form.deadline_date.errors %} is-invalid{% endif %}" name="{{ form.deadline_date.name }}" type="{{ form.deadline_date.field.widget.input_type }}" value="{{ form.deadline_date.value}}" />
                                     <div class="input-group-append">
                                         <span class="input-group-text"><i class="ri-calendar-2-line ri-lg"></i></span>
                                     </div>
+                                    {% for error in form.deadline_date.errors %}
+                                        <div class="invalid-feedback">{{ error }}</div>
+                                    {% endfor %}
                                 </div>
                             </div>
                         </fieldset>

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import date, datetime
 from functools import reduce
 from uuid import uuid4
 
@@ -18,6 +18,9 @@ from lemarche.utils.fields import ChoiceArrayField
 class TenderQuerySet(models.QuerySet):
     def by_user(self, user):
         return self.filter(author=user)
+
+    def is_live(self):
+        return self.filter(Q(validated_at__isnull=False) & Q(deadline_date__gte=datetime.today()))
 
     def in_perimeters(self, post_code, department, region):
         filters = (
@@ -164,7 +167,7 @@ class Tender(models.Model):
         ordering = ["-updated_at", "deadline_date"]
 
     def clean(self):
-        today = datetime.date.today()
+        today = date.today()
         if self.deadline_date and (self.deadline_date < today):
             raise ValidationError("La date de cloture des réponses ne doit pas être antérieure à aujourd'hui.")
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -1,10 +1,9 @@
-from datetime import date, datetime
+from datetime import datetime
 from functools import reduce
 from uuid import uuid4
 
 import _operator
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
 from django.db.models import Case, Count, IntegerField, Q, Sum, When
 from django.urls import reverse
@@ -165,16 +164,6 @@ class Tender(models.Model):
         verbose_name = "Besoin d'acheteur"
         verbose_name_plural = "Besoins des acheteurs"
         ordering = ["-updated_at", "deadline_date"]
-
-    def clean(self):
-        today = date.today()
-        if self.deadline_date and (self.deadline_date < today):
-            raise ValidationError("La date de cloture des réponses ne doit pas être antérieure à aujourd'hui.")
-
-        if self.deadline_date and self.start_working_date and (self.start_working_date < self.deadline_date):
-            raise ValidationError(
-                "La date idéale de début des prestations ne doit pas être antérieure de cloture des réponses."
-            )
 
     def __str__(self):
         return self.title

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -1,10 +1,11 @@
-import datetime
+# import datetime
 from importlib import import_module
 from random import randint
 
 from django.apps import apps
 from django.db import IntegrityError
-from django.forms import ValidationError
+
+# from django.forms import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -26,16 +27,17 @@ class TenderModelTest(TestCase):
         tender = TenderFactory(title=str_test)
         self.assertEqual(str(tender), str_test)
 
-    def test_deadline_start_before_today(self):
-        today = datetime.date.today()
-        tender = TenderFactory()
-        tender.deadline_date = today - datetime.timedelta(days=1)
-        self.assertRaises(ValidationError, tender.clean)
+    # todo : update with testing form
+    # def test_deadline_start_before_today(self):
+    #     today = datetime.date.today()
+    #     tender = TenderFactory()
+    #     tender.deadline_date = today - datetime.timedelta(days=1)
+    #     self.assertNotRaises(ValidationError, tender.clean)
 
-    def test_deadline_start_after_start_working_date(self):
-        tender = TenderFactory()
-        tender.start_working_date = tender.deadline_date - datetime.timedelta(days=1)
-        self.assertRaises(ValidationError, tender.clean)
+    # def test_deadline_start_after_start_working_date(self):
+    #     tender = TenderFactory()
+    #     tender.start_working_date = tender.deadline_date - datetime.timedelta(days=1)
+    #     self.assertRaises(ValidationError, tender.clean)
 
     def test_not_empty_deadline(self):
         tender = TenderFactory()

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django import forms
 
 from lemarche.sectors.models import Sector
@@ -48,10 +50,25 @@ class AddTenderForm(forms.ModelForm):
             "kind": forms.RadioSelect(),
         }
 
-    # def clean(self):
-    #     super().clean()
-    #     msg_field_missing = "{} est un champ obligatoire"
-    #     if "perimeters" in self.errors:
-    #         self.add_error("perimeters", msg_field_missing.format("Lieux d'exécution"))
-    #     if "sectors" in self.errors:
-    #         self.add_error("sectors", msg_field_missing.format(Sector._meta.verbose_name_plural))
+    def clean(self):
+        super().clean()
+        msg_field_missing = "{} est un champ obligatoire"
+        if "perimeters" in self.errors:
+            self.add_error("perimeters", msg_field_missing.format("Lieux d'exécution"))
+        if "sectors" in self.errors:
+            self.add_error("sectors", msg_field_missing.format(Sector._meta.verbose_name_plural))
+        today = date.today()
+        if self.cleaned_data.get("deadline_date") and (self.cleaned_data.get("deadline_date") < today):
+            self.add_error(
+                "deadline_date", "La date de clôture des réponses ne doit pas être antérieure à aujourd'hui."
+            )
+
+        if (
+            self.cleaned_data.get("deadline_date")
+            and self.cleaned_data.get("start_working_date")
+            and (self.cleaned_data.get("start_working_date") < self.cleaned_data.get("deadline_date"))
+        ):
+            self.add_error(
+                "start_working_date",
+                "La date idéale de début des prestations ne doit pas être antérieure de clôture des réponses.",
+            )

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django.contrib.gis.geos import Point
 from django.test import TestCase
@@ -126,7 +126,11 @@ class TenderListViewTest(TestCase):
         cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
         cls.user_partner = UserFactory(kind=User.KIND_PARTNER)
-        cls.tender = TenderFactory(author=cls.user_buyer_1)
+        cls.tender = TenderFactory(author=cls.user_buyer_1, validated_at=date.today())
+        cls.tender_2 = TenderFactory(author=cls.user_buyer_1, deadline_date=date.today() - timedelta(days=5))
+        cls.tender_3 = TenderFactory(
+            author=cls.user_buyer_1, validated_at=date.today(), deadline_date=date.today() - timedelta(days=5)
+        )
 
     def test_anonymous_user_cannot_list_tenders(self):
         url = reverse("tenders:list")
@@ -154,7 +158,7 @@ class TenderListViewTest(TestCase):
         url = reverse("tenders:list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["tenders"]), 1)
+        self.assertEqual(len(response.context["tenders"]), 3)
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
         self.client.login(email=self.user_partner.email, password=DEFAULT_PASSWORD)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -82,7 +82,7 @@ class TenderListView(LoginRequiredMixin, ListView):
             # TODO: manage many siaes
             siae = user.siaes.first()
             if siae:
-                queryset = Tender.objects.filter_with_siae(siae)
+                queryset = Tender.objects.filter_with_siae(siae).is_live()
         else:
             queryset = Tender.objects.by_user(user).with_siae_stats()
         return queryset


### PR DESCRIPTION
### Quoi ?

Eviter l'affichage de dépôt de besoin brouillon.

### Pourquoi ?

Eviter les fausse joies pour les SIAES.
