### PR TITLE
Stats : envoyer le 'results_count'

### DIFF
--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -63,7 +63,7 @@ def extract_meta_from_request(request, siae=None, results_count=None):
 def track(page: str = "", action: str = "load", meta: dict = {}):  # noqa B006
 
     # Don't log in dev
-    if settings.BITOUBI_ENV == "dev":
+    if settings.BITOUBI_ENV != "dev":
         set_payload = {
             "timestamp": datetime.now().isoformat(),
             "page": page,

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -75,11 +75,12 @@ class SiaeSearchResultsView(FormMixin, ListView):
         return context
 
     def get(self, request, *args, **kwargs):
+        siae_list = self.get_queryset()
         # Track search event
         track(
             "backend",
             "directory_search",
-            meta=extract_meta_from_request(self.request),
+            meta=extract_meta_from_request(self.request, results_count=siae_list.count()),
         )
         return super().get(request, *args, **kwargs)
 
@@ -110,7 +111,7 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         track(
             "backend",
             "directory_csv",
-            meta=extract_meta_from_request(self.request),
+            meta=extract_meta_from_request(self.request, results_count=siae_list.count()),
         )
         user = self.request.user
         if user.kind == user.KIND_BUYER:


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/300
Stocker, lorsque c'est pertinent (page avec pagination), le nombre de structures trouvées dans un champ "results_count".

### Pourquoi ?

Ca nous permettrait de répondre aux questions : 
- combien de résultats cette recherche a-t-elle renvoyée ?