### PR TITLE
API : amélioration sur Siae.is_active

### DIFF
--- a/lemarche/api/siaes/filters.py
+++ b/lemarche/api/siaes/filters.py
@@ -23,8 +23,9 @@ class SiaeFilter(django_filters.FilterSet):
         to_field_name="slug",
         queryset=Network.objects.all(),
     )
+    is_active = django_filters.BooleanFilter(label="Convention active (ASP) ou import")
     updated_at = django_filters.IsoDateTimeFromToRangeFilter(label="Date de dernière mise à jour")
 
     class Meta:
         model = Siae
-        fields = ["kind", "presta_type", "department", "updated_at"]
+        fields = ["kind", "presta_type", "department", "is_active", "updated_at"]

--- a/lemarche/api/siaes/serializers.py
+++ b/lemarche/api/siaes/serializers.py
@@ -92,6 +92,9 @@ class SiaeListSerializer(SiaeDetailSerializer):
             "post_code",
             "department",
             "region",
+            # "is_qpv",
+            # "is_cocontracting",
+            "is_active",
             # boolean stuff available in detail
             # M2M stuff available in detail
             "created_at",

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -52,7 +52,7 @@ class SiaeListFilterApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         # default_siae = {"kind": Siae.KIND_EI, "presta_type": [Siae.PRESTA_DISP], "department": "01"}
-        SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01")
+        SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_DISP], department="01", is_active=False)
         SiaeFactory(kind=Siae.KIND_ETTI, presta_type=[Siae.PRESTA_DISP], department="01")  # siae_with_kind
         SiaeFactory(kind=Siae.KIND_ACI, presta_type=[Siae.PRESTA_BUILD], department="01")  # siae_with_presta_type
         SiaeFactory(kind=Siae.KIND_EI, presta_type=[Siae.PRESTA_PREST], department="38")  # siae_with_department
@@ -83,6 +83,16 @@ class SiaeListFilterApiTest(TestCase):
         # self.assertEqual(response.data["count"], 1)
         # self.assertEqual(len(response.data["results"]), 4 + 2 + 2)  # results aren't paginated
         self.assertEqual(len(response.data), 4 + 2 + 2)
+
+    def test_should_filter_siae_list_by_is_active(self):
+        url = reverse("api:siae-list") + "?is_active=false&token=admin"
+        response = self.client.get(url)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(len(response.data["results"]), 1)
+        url = reverse("api:siae-list") + "?is_active=true&token=admin"
+        response = self.client.get(url)
+        self.assertEqual(response.data["count"], 3 + 2 + 2)
+        self.assertEqual(len(response.data["results"]), 3 + 2 + 2)
 
     def test_should_filter_siae_list_by_kind(self):
         # single

--- a/lemarche/api/siaes/views.py
+++ b/lemarche/api/siaes/views.py
@@ -15,9 +15,6 @@ class SiaeViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     Données d'une structure d'insertion par l'activité économique (SIAE).
     """
 
-    # ModelViewSet needs 'queryset' to be set otherwise the router won't be
-    # able to derive the model Basename. To avoid loading data on object
-    # initialisation we load an empty queryset.
     queryset = Siae.objects.prefetch_many_to_many()
     serializer_class = SiaeListSerializer
     filter_class = SiaeFilter


### PR DESCRIPTION
### Quoi ?

- Avoir l'info "is_active" dans la liste des Siae
- Pouvoir filter par le champ "is_active"

### Pourquoi ?

Retour d'un utilisateur de l'API