### PR TITLE
Dépôt de besoins : fixes

### DIFF
--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -18,9 +18,9 @@
             </div>
             <div class="s-prefooter__col col-12 col-lg-6 d-flex align-items-center">
                 <ul class="s-prefooter__gridlist">
-                    <li><a href="/faq/">Comment ça marche ?</a></li>
-                    <li><a href="{% url 'pages:decouvrir_inclusion' %}">C'est quoi l'inclusion ?</a></li>
-                    <li><a href="/qui-sommes-nous/">Qui sommes-nous ?</a></li>
+                    <li><a href="/faq/">Comment ça marche&nbsp;?</a></li>
+                    <li><a href="{% url 'pages:decouvrir_inclusion' %}">C'est quoi l'inclusion&nbsp;?</a></li>
+                    <li><a href="/qui-sommes-nous/">Qui sommes-nous&nbsp;?</a></li>
                     <li><a href="{% url 'api:home' %}">API</a></li>
                     <li><a href="{% url 'pages:stats' %}">Statistiques</a></li>
                     <li><a href="https://github.com/betagouv/itou-marche/" target="_blank" rel="noopener" title="Github (lien externe)">Github</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -1,4 +1,9 @@
-<h2>Pour répondre à cet appel d'offres</h2>
+{% if tender.author == request.user %}
+    <h2>Coordonnées</h2>
+{% else %}
+    <h2>Pour plus d'information et/ou afin de répondre, utilisez les coordonnées suivantes :</h2>
+{% endif %}
+
 <div class="row">
     {% if tender.get_contact_full_name %}
         <div class="col-md-6">

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -6,6 +6,9 @@
             <div class="col-md-8" style="border-right:1px solid">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
+                    {% if not tender.validated_at %}
+                        <span class="float-right badge badge-base badge-pill badge-pilotage">En cours de validation</span>
+                    {% endif %}
                 </p>
 
                 <a href="{% url 'tenders:detail' tender.slug %}" class="text-decoration-none">

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -4,12 +4,9 @@
     <div class="card-body">
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid">
-                <div class="row">
-                    <div class="col-12">
-                        Date de clôture : {{ tender.deadline_date|default:"" }}
-                        <span class="float-right badge badge-base badge-pill badge-emploi">{{ tender.get_kind_display }}</span>
-                    </div>
-                </div>
+                <p class="mb-1">
+                    Date de clôture : {{ tender.deadline_date|default:"" }}
+                </p>
 
                 <a href="{% url 'tenders:detail' tender.slug %}" class="text-decoration-none">
                     <h2 class="py-2">{{ tender.title }}</h2>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -4,7 +4,7 @@
     <div class="card-body">
         <div class="row">
             <div class="col-md-12">
-                <p>
+                <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -58,7 +58,10 @@
                     <hr class="my-5">
 
                     <div class="py-2">
-                        <h2>Description <span class="float-right fs-sm  text-muted">Début d'intervention : {{ tender.start_working_date|default:"" }}</span></h2>
+                        <h2>
+                            Description
+                            {% if tender.start_working_date %}<span class="float-right fs-sm text-muted">Début d'intervention : {{ tender.start_working_date }}</span>{% endif %}
+                        </h2>
                         <p>{{ tender.description|linebreaks }}</p>
                     </div>
 

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -59,7 +59,7 @@
 
                     <div class="py-2">
                         <h2>Description <span class="float-right fs-sm  text-muted">Début d'intervention : {{ tender.start_working_date|default:"" }}</span></h2>
-                        <p>{{ tender.description }}</p>
+                        <p>{{ tender.description|linebreaks }}</p>
                     </div>
 
                     <hr class="my-5">


### PR DESCRIPTION
### Quoi ?

Dépôt de besoin : 
- wording "affichage des coordonnées" pour les vendeurs
- afficher les sauts de ligne de la description
- cacher date d'intervention si vide
- badge : cacher le type de besoin à l'auteur. afficher si "en cours de validation"