### PR TITLE
Recherche : ordonner par date de dernière mise à jour

### DIFF
--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -127,12 +127,15 @@ class SiaeSearchForm(forms.Form):
         """
         Method to order the search results (can depend on the search filters).
 
-        By default, Siae will be ordered randomly (was by "name" before. could also be by "-last_updated"?)
+        By default, Siae will be ordered by "-updated_at"
+        **WHY**
+        - push siae to update their profile, and have the freshest data at the top
+        - we tried random order ("?"), but it had some bugs with pagination
         **BUT**
         - if a Siae has a a SiaeOffer, or a description, or a User, then it is "boosted"
         - if the search is on a CITY perimeter, we order by coordinates first
         """
-        DEFAULT_ORDERING = ["?"]
+        DEFAULT_ORDERING = ["-updated_at"]
         ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user"] + DEFAULT_ORDERING
         # annotate on description presence: https://stackoverflow.com/a/65014409/4293684
         # qs = qs.annotate(has_description=Exists(F("description")))  # doesn't work

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -432,6 +432,13 @@ class SiaeSearchOrderTest(TestCase):
         SiaeFactory(name="Une autre structure")
         SiaeFactory(name="ABC Insertion")
 
+    def test_should_order_by_last_updated(self):
+        url = reverse("siae:search_results", kwargs={})
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 3)
+        self.assertEqual(siaes[0].name, "ABC Insertion")
+
     def test_should_bring_the_siae_with_users_to_the_top(self):
         siae_with_user = SiaeFactory(name="ZZ ESI")
         user = UserFactory()


### PR DESCRIPTION
### Quoi ?

Change de l'ordre de base des structures renvoyées par la recherche

### Pourquoi ?

L'ordre par défaut actuel est "l'aléatoire", mais ca provoque des bugs (structures qui réapparaissent d'une page à une autre)