### PR TITLE
Fix de l'affichage des infos de contacts des dépôts de besoins

### DIFF
--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -12,20 +12,20 @@
             {{ tender.author.company_name }}
         </div>
     {% endif %}
-    {% if tender.contact_email %}
+    {% if tender.can_display_contact_email %}
         <div class="col-md-6">
             <span class="ri-at-line"></span>
             {{ tender.contact_email }}
         </div>
     {% endif %}
-    {% if tender.contact_phone %}
+    {% if tender.can_display_contact_phone %}
         <div class="col-md-6">
             <span class="ri-phone-line"></span>
             {{ tender.contact_phone }}
         </div>
     {% endif %}
 </div>
-{% if tender.external_link %}
+{% if tender.can_display_contact_external_link %}
     <div class="row">
         <div class="col-12">
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -208,6 +208,18 @@ class Tender(models.Model):
     def get_perimeters_names(self):
         return ", ".join(self.perimeters.values_list("name", flat=True))
 
+    @cached_property
+    def can_display_contact_email(self):
+        return self.RESPONSE_KIND_EMAIL in self.response_kind and self.contact_email
+
+    @cached_property
+    def can_display_contact_phone(self):
+        return self.RESPONSE_KIND_TEL in self.response_kind and self.contact_phone
+
+    @cached_property
+    def can_display_contact_external_link(self):
+        return self.RESPONSE_KIND_EXTERNAL in self.response_kind and self.external_link
+
     def get_absolute_url(self):
         return reverse("tenders:detail", kwargs={"slug": self.slug})
 


### PR DESCRIPTION
### Quoi ?

Fix de l'affichage des infos de contacts des dépôts de besoins en fonction de ce que les acheteurs ont sélectionnés.
