### PR TITLE
Cacher la "pub" sur les listes de favoris

### DIFF
--- a/lemarche/templates/siaes/_favorite_video_modal.html
+++ b/lemarche/templates/siaes/_favorite_video_modal.html
@@ -1,4 +1,4 @@
-<div class="modal fade show" id="envoiGroupeModal" tabindex="-1" aria-labelledby="envoiGroupeModalLabel" aria-modal="true" role="dialog">
+<div class="modal fade show" id="favorite_video_modal" tabindex="-1" aria-labelledby="envoiGroupeModalLabel" aria-modal="true" role="dialog">
 	<div class="modal-dialog modal-dialog-centered modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">

--- a/lemarche/templates/siaes/_search_results_favorite_ad_card.html
+++ b/lemarche/templates/siaes/_search_results_favorite_ad_card.html
@@ -1,0 +1,7 @@
+<section class="bg-primary p-4 mb-4">
+    <span class="badge badge-pill badge-pilotage text-primary">Nouveauté</span>
+    <p class="h2 mt-2 mb-3 text-white lh-lg">Gagnez du temps pour contacter les prestataires du marché.</p>
+    <a href="" id="new-favorite-list-modal-btn" data-toggle="modal" data-target="#favorite_video_modal">
+        <img src="{% static 'img/mea-envoi-groupe.png' %}" class="img-fluid" alt="" loading="lazy">
+    </a>
+</section>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -145,13 +145,6 @@
                 {% endif %}
                 </div>
                 <div class="col-12 col-md-4 siae-info mt-6 mt-sm-0">
-                    <section class="bg-primary p-4 mb-4">
-                        <span class="badge badge-pill badge-pilotage text-primary">Nouveauté</span>
-                        <p class="h2 mt-2 mb-3 text-white lh-lg">Gagnez du temps pour contacter les prestataires du marché.</p>
-                        <a href="" id="new-favorite-list-modal-btn" data-toggle="modal" data-target="#envoiGroupeModal">
-                            <img src="{% static 'img/mea-envoi-groupe.png' %}" class="img-fluid" alt="" loading="lazy">
-                        </a>
-                    </section>
                     <div class="siae-info-sticky">
                         <div class="map-holder mb-4">
                             <div id="map-siae-list" class="map-canvas"></div>
@@ -200,7 +193,6 @@
 
 {% block modals %}
     {% include "auth/_login_or_signup_modal.html" %}
-    {% include "siaes/_envoi_groupe_modal.html" %}
     {% include "siaes/_favorite_item_add_modal.html" %}
     {% include "siaes/_favorite_item_remove_modal.html" %}
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

Sur la page de résultats, cacher l'encart annoncant la fonctionnalité des listes de favoris

### Pourquoi ?

On va améliorer la recherche, et on souhaite maintenant mettre en avant la "recherche par Nom/Siret" sur cette page.

### Illustrations

Avant / Après
![Screenshot from 2022-05-11 18-41-53](https://user-images.githubusercontent.com/7147385/167902942-7814b89f-f68b-4d2b-b6ce-65a155113578.png)
![Screenshot from 2022-05-11 18-42-04](https://user-images.githubusercontent.com/7147385/167902948-1808a014-5ca0-4842-9690-9c813cbb15c5.png)

