### PR TITLE
Dépôt de besoin : modifier l’intitulé sourcing côté ESI

### DIFF
--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -6,7 +6,13 @@
             <div class="col-md-12">
                 <p>
                     Date de clôture : {{ tender.deadline_date|default:"" }}
-                    <span class="float-right badge badge-base badge-pill badge-emploi">{{ tender.get_kind_display }}</span>
+                    <span class="float-right badge badge-base badge-pill badge-emploi">
+                        {% if tender.kind == "PROJ" %}
+                            {{ title_kind_sourcing_siae }}
+                        {% else %}
+                            {{ tender.get_kind_display }}
+                        {% endif %}
+                    </span>
                 </p>
             </div>
         </div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load bootstrap4 static humanize %}
 
-{% block title %}{{ tender.get_kind_display }} {{ tender.title }}{{ block.super }}{% endblock %}
+{% block title %}{{ kind_title }} {{ tender.title }}{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -36,7 +36,7 @@
                         <div class="col-md-12">
                             <h1>
                                 {{ tender.title }}
-                                <span class="fs-sm badge badge-base badge-pill badge-emploi float-right"  aria-hidden="true">{{ tender.get_kind_display }}</span>
+                                <span class="fs-sm badge badge-base badge-pill badge-emploi float-right"  aria-hidden="true">{{ kind_title }}</span>
                             </h1>
                         </div>
                     </div>

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -21,6 +21,7 @@ from lemarche.www.tenders.tasks import (  # , send_tender_emails_to_siaes
 
 TITLE_DETAIL_PAGE_SIAE = "Trouver de nouvelles opportunités"
 TITLE_DETAIL_PAGE_OTHERS = "Mes besoins"
+TITLE_KIND_SOURCING_SIAE = "Consultation en vue d’un achat"
 
 
 class TenderCreateView(NotSiaeUserRequiredMixin, SuccessMessageMixin, CreateView):
@@ -91,6 +92,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
         user_kind = self.request.user.kind if self.request.user.is_authenticated else "anonymous"
         context["page_title"] = TITLE_DETAIL_PAGE_SIAE if user_kind == User.KIND_SIAE else TITLE_DETAIL_PAGE_OTHERS
+        context["title_kind_sourcing_siae"] = TITLE_KIND_SOURCING_SIAE
         return context
 
 
@@ -115,6 +117,11 @@ class TenderDetailView(LoginRequiredMixin, DetailView):
         tender = self.get_object()
         user_kind = self.request.user.kind if self.request.user.is_authenticated else "anonymous"
         context["parent_title"] = TITLE_DETAIL_PAGE_SIAE if user_kind == User.KIND_SIAE else TITLE_DETAIL_PAGE_OTHERS
+        context["kind_title"] = (
+            TITLE_KIND_SOURCING_SIAE
+            if user_kind == User.KIND_SIAE and tender.kind == Tender.TENDER_KIND_PROJECT
+            else tender.get_kind_display()
+        )
         if self.request.user.kind == User.KIND_SIAE:
             context["user_has_detail_display_date"] = TenderSiae.objects.filter(
                 tender=tender, siae__in=self.request.user.siaes.all(), detail_display_date__isnull=False


### PR DESCRIPTION
### Quoi ?

Dépôt de besoin : modifier l’intitulé sourcing côté ESI, "sourcing" => "Consultation en vue d’un achat"

Il reste inchangé pour les acheteurs.
