### PR TITLE
Redirection après adoption d'une structure

### DIFF
--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -111,7 +111,7 @@ class DashboardSiaeSearchAdoptViewTest(TestCase):
         url = reverse("dashboard:siae_search_adopt_confirm", args=[self.siae_without_user.slug])
         response = self.client.post(url)  # data={}
         self.assertEqual(response.status_code, 302)  # redirect to success_url
-        self.assertEqual(response.url, "/profil/")
+        self.assertEqual(response.url, f"/profil/prestataires/{self.siae_without_user.slug}/modifier/")
         self.assertEqual(self.siae_without_user.users.count(), 1)
         self.assertEqual(self.user_siae.siaes.count(), 1 + 1)
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -198,8 +198,7 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
     template_name = "dashboard/siae_search_adopt_confirm.html"
     context_object_name = "siae"
     queryset = Siae.objects.all()
-    success_message = "Votre structure a été rajoutée dans votre espace."
-    success_url = reverse_lazy("dashboard:home")
+    success_message = "Rattachement confirmé ! Vous pouvez dès à présent mettre à jour sa fiche."
 
     def get_context_data(self, **kwargs):
         """
@@ -232,7 +231,10 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
                 f"<i>Cet utilisateur ne fait plus partie de la structure ? <a href=\"{reverse_lazy('dashboard:siae_search_by_siret')}?siret={self.object.siret}\">Contactez le support</a></i>"  # noqa
             )
             messages.add_message(self.request, messages.SUCCESS, success_message)
-            return HttpResponseRedirect(self.get_success_url())
+            return HttpResponseRedirect(reverse_lazy("dashboard:home"))
+
+    def get_success_url(self):
+        return reverse_lazy("dashboard:siae_edit", args=[self.kwargs.get("slug")])
 
 
 class SiaeUsersView(SiaeMemberRequiredMixin, DetailView):


### PR DESCRIPTION
### Quoi ?

Lorsque un utilisateur se rattache à une structure, modifier la page vers lequel il est redirigé : 
- avant : tableau de bord
- après : formulaire de modification de cette structure
