### PR TITLE
Bouton afficher les coordonnées doit être vert

### DIFF
--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -202,7 +202,7 @@
                                         </ul>
                                     </div>
                                 {% else %}
-                                    <a href="#" id="show_data-modal-btn" class="btn btn-block btn-primary btn-ico mb-4" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
+                                    <a href="#" id="show_data-modal-btn" class="btn btn-block btn-success btn-ico mb-4" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
                                         <span>Afficher les coordonnées</span>
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="collapse__ico-down"><path fill="none" d="M0 0h24v24H0z"/><path fill="currentColor" d="M12 16l-6-6h12z"/></svg>
                                     </a>


### PR DESCRIPTION
### Quoi ?

On a modifié la couleur du bouton "Afficher les coordonnées" (sur les fiches structures), il doit être vert pour tout les utilisateurs : 
- connectés (déjà fait ici : https://github.com/betagouv/itou-marche/pull/276)
- anonymes (modifs de cette PR)
