### PR TITLE
Enlève le caching sur la Home

### DIFF
--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -1,5 +1,5 @@
 {% extends "layouts/base.html" %}
-{% load static bootstrap4 cache %}
+{% load static bootstrap4 %}
 {% load theme_inclusion %}
 {% load wagtailcore_tags %}
 
@@ -36,7 +36,6 @@
     </div>
 </section>
 
-{% cache 3600 home_stats %}
 <section class="s-section m-0 bg-nuance-09">
     <div class="s-section__container container">
         <div class="s-section__row row">
@@ -46,7 +45,6 @@
         </div>
     </div>
 </section>
-{% endcache %}
 
 <section class="s-cards-grid-01">
     <div class="s-cards-grid-01__container container">

--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -1,5 +1,5 @@
 {% extends "layouts/base.html" %}
-{% load static bootstrap4 %}
+{% load static bootstrap4 cache %}
 {% load theme_inclusion %}
 {% load wagtailcore_tags %}
 
@@ -36,6 +36,7 @@
     </div>
 </section>
 
+{% cache 3600 home_stats %}
 <section class="s-section m-0 bg-nuance-09">
     <div class="s-section__container container">
         <div class="s-section__row row">
@@ -45,6 +46,7 @@
         </div>
     </div>
 </section>
+{% endcache %}
 
 <section class="s-cards-grid-01">
     <div class="s-cards-grid-01__container container">

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -5,8 +5,6 @@ from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.urls import reverse_lazy
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from django.views.generic import DetailView, FormView, ListView, TemplateView, View
 
 from lemarche.pages.models import Page
@@ -18,7 +16,6 @@ from lemarche.www.pages.forms import ContactForm
 from lemarche.www.pages.tasks import send_contact_form_email, send_contact_form_receipt
 
 
-@method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
 class HomeView(TemplateView):
     template_name = "pages/home.html"
 


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/330

### Pourquoi ?

Car le caching complet de la home provoquait des erreurs : le header ne changeait pas, même si l'utilisateur était connecté (affichait quand même "Connexion" & "Inscription")

Tentative de fix avec le template tag `{% cache %}` (doc [ici](https://docs.djangoproject.com/fr/4.0/topics/cache/#template-fragment-caching)), mais ca relance quand même les requêtes DB de la view, donc inutile..