### PR TITLE
Dépôt de besoin : téléchargement de la liste des structures intéressées

### DIFF
--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -6,7 +6,7 @@
         <div class="col-auto sc-img">
             <span class="p-3 d-inline-block">
                 {% if siae.logo_url %}
-                    <img class="img-fluid" src="{{ siae.logo_url }}" alt="Logo de la structure {{ siae.name }}"  loading="lazy" />
+                    <img class="img-fluid" src="{{ siae.logo_url }}" alt="Logo de la structure {{ siae.name }}" loading="lazy" />
                 {% else %}
                     <img class="img-fluid" src="{% static 'img/default-listing.png' %}" alt="{{ siae.name }}" loading="lazy" />
                 {% endif %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -30,6 +30,22 @@
             <div class="col-12 col-lg-8">
                 <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} structures intéressées</h1>
             </div>
+            <div class="col-12 col-lg-4">
+                <div class="btn-group w-100 mb-3">
+                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&format=xls" id="tender-siae-interested-export-xls" class="btn btn-outline-primary btn-ico btn-block {% if tendersiaes.count == 0 %}disabled{% endif %}" target="_blank">
+                        <span>Télécharger la liste (.xls)</span>
+                        <i class="ri-download-line ri-lg"></i>
+                    </a>
+                    <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="sr-only">Plus d'options de téléchargement</span>
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item {% if tendersiaes.count == 0 %}disabled{% endif %}" target="_blank">
+                            Télécharger la liste (.csv)
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="row">

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -24,14 +24,16 @@
 {% endblock %}
 
 {% block content %}
-<section>
-    <div class="container py-4">
+<section class="pt-4 pb-6">
+    <div class="container">
         <div class="row">
-            <div class="col-12 col-lg">
-                <h1>{{ tendersiaes.count }} structures intéressées</h1>
+            <div class="col-12 col-lg-8">
+                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} structures intéressées</h1>
             </div>
+        </div>
 
-            <div class="col-12 my-5 py-3">
+        <div class="row">
+            <div class="col-12">
                 {% for tendersiae in tendersiaes %}
                     {% include "siaes/_card_tender.html" with siae=tendersiae.siae %}
                 {% endfor %}

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -23,25 +23,52 @@ SIAE_FIELDS_TO_EXPORT = [
     "is_qpv",
     "sectors",
 ]
+SIAE_CONTACT_FIELDS = [
+    "contact_first_name",
+    "contact_last_name",
+    "contact_email",
+    "contact_phone",
+    "contact_social_website",
+]
 SIAE_CUSTOM_FIELDS = ["Inscrite", "Lien vers le marché"]
-SIAE_HEADER = [
-    Siae._meta.get_field(field_name).verbose_name for field_name in SIAE_FIELDS_TO_EXPORT
-] + SIAE_CUSTOM_FIELDS
 
 
-def generate_siae_row(siae: Siae):
+def get_siae_fields(with_contact_info=False):
+    siae_field_list = SIAE_FIELDS_TO_EXPORT
+    if with_contact_info:
+        siae_field_list += SIAE_CONTACT_FIELDS
+    siae_field_list += SIAE_CUSTOM_FIELDS
+    return siae_field_list
+
+
+def generate_header(siae_field_list):
+    header = []
+    for field_name in siae_field_list:
+        try:
+            header.append(Siae._meta.get_field(field_name).verbose_name)
+        except:  # noqa
+            header.append(field_name)
+    return header
+
+
+def generate_siae_row(siae: Siae, siae_field_list):
     siae_row = []
-    for field_name in SIAE_FIELDS_TO_EXPORT + SIAE_CUSTOM_FIELDS:
+    for field_name in siae_field_list:
         col_value = ""
-        # Improve display of some fields: ChoiceFields, BooleanFields, ArrayFields, ManyToManyFields
+        # Improve display of some fields
+        # ChoiceFields
         if field_name in ["nature"]:
             col_value = getattr(siae, f"get_{field_name}_display")()
+        # ArrayFields
         elif field_name in ["presta_type"]:
             col_value = siae.presta_type_display
+        # BooleanFields
         elif field_name in ["is_qpv"]:
             col_value = "Oui" if getattr(siae, field_name, None) else "Non"
+        # ManyToManyFields
         elif field_name == "sectors":
             col_value = siae.sectors_list_to_string()
+        # Custom fields
         elif field_name == "Inscrite":
             col_value = "Oui" if siae.user_count else "Non"
         elif field_name == "Lien vers le marché":
@@ -52,28 +79,34 @@ def generate_siae_row(siae: Siae):
     return siae_row
 
 
-def export_siae_to_csv(csv_writer, siae_queryset):
+def export_siae_to_csv(csv_writer, siae_queryset, with_contact_info=False):
+    # columns
+    field_list = get_siae_fields(with_contact_info)
+
     # header
-    csv_writer.writerow(SIAE_HEADER)
+    csv_writer.writerow(generate_header(field_list))
 
     # rows
     for siae in siae_queryset:
-        siae_row = generate_siae_row(siae)
+        siae_row = generate_siae_row(siae, field_list)
         csv_writer.writerow(siae_row)
 
     return csv_writer
 
 
-def export_siae_to_excel(siae_queryset):
+def export_siae_to_excel(siae_queryset, with_contact_info=False):
     wb = xlwt.Workbook(encoding="utf-8")
     ws = wb.add_sheet("Structures")
 
     row_number = 0
 
+    # columns
+    field_list = get_siae_fields(with_contact_info)
+
     # header
     font_style = xlwt.XFStyle()
     font_style.font.bold = True
-    for (index, header_item) in enumerate(SIAE_HEADER):
+    for (index, header_item) in enumerate(generate_header(field_list)):
         ws.write(row_number, index, header_item, font_style)
         # set column width
         # ws.col(col_num).width = HEADER[col_num][1]
@@ -83,7 +116,7 @@ def export_siae_to_excel(siae_queryset):
     font_style.alignment.wrap = 1
     for siae in siae_queryset:
         row_number += 1
-        siae_row = generate_siae_row(siae)
+        siae_row = generate_siae_row(siae, field_list)
         for (index, row_item) in enumerate(siae_row):
             ws.write(row_number, index, row_item, font_style)
 

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -8,6 +8,7 @@ from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.models import Sector
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.models import Siae
+from lemarche.tenders.models import Tender
 from lemarche.utils.constants import EMPTY_CHOICE
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
@@ -62,6 +63,9 @@ class SiaeSearchForm(forms.Form):
         required=False,
     )
 
+    tender = forms.ModelChoiceField(
+        queryset=Tender.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
+    )
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
@@ -127,6 +131,10 @@ class SiaeSearchForm(forms.Form):
         network = self.cleaned_data.get("networks", None)
         if network:
             qs = qs.filter(networks__in=[network])
+
+        tender = self.cleaned_data.get("tender", None)
+        if tender:
+            qs = qs.filter(tendersiae__tender=tender, tendersiae__contact_click_date__isnull=False)
 
         favorite_list = self.cleaned_data.get("favorite_list", None)
         if favorite_list:

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -103,6 +103,7 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         """Build and return a CSV or XLS."""
         siae_list = self.get_queryset()
         format = self.request.GET.get("format", "xls")
+        with_contact_info = True if self.request.GET.get("tender", None) else False
         filename = f"liste_structures_{date.today()}"
         filename_with_extension = f"{filename}.{format}"
 
@@ -132,13 +133,13 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
                 response["Content-Disposition"] = 'attachment; filename="{}"'.format(filename_with_extension)
 
                 writer = csv.writer(response)
-                export_siae_to_csv(writer, siae_list)
+                export_siae_to_csv(writer, siae_list, with_contact_info)
 
             else:  # "xls"
                 response = HttpResponse(content_type="application/ms-excel")
                 response["Content-Disposition"] = 'attachment; filename="{}"'.format(filename_with_extension)
 
-                wb = export_siae_to_excel(siae_list)
+                wb = export_siae_to_excel(siae_list, with_contact_info)
                 wb.save(response)
 
             return response

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -162,7 +162,7 @@ class TenderListView(LoginRequiredMixin, ListView):
             if siaes:
                 queryset = Tender.objects.filter_with_siae(siaes).is_live()
         else:
-            queryset = Tender.objects.by_user(user).with_siae_stats()
+            queryset = Tender.objects.by_user(user)  # .with_siae_stats()
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -248,15 +248,12 @@ class TenderSiaeInterestedListView(TenderOwnerRequiredMixin, ListView):
 
     def get(self, request, *args, **kwargs):
         """
-        - if there isn't any Siae interested, redirect
-        - user should be tender owner : update siae_interested_list_last_seen_date
+        User should be tender owner : we update siae_interested_list_last_seen_date
         """
-        if not self.get_queryset().count():
-            return HttpResponseRedirect(reverse_lazy("tenders:list"))
         Tender.objects.filter(slug=self.kwargs.get("slug")).update(siae_interested_list_last_seen_date=timezone.now())
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["tender"] = context["tendersiaes"].first().tender
+        context["tender"] = Tender.objects.get(slug=self.kwargs.get("slug"))
         return context

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -162,7 +162,7 @@ class TenderListView(LoginRequiredMixin, ListView):
             if siaes:
                 queryset = Tender.objects.filter_with_siae(siaes).is_live()
         else:
-            queryset = Tender.objects.by_user(user)  # .with_siae_stats()
+            queryset = Tender.objects.by_user(user).with_siae_stats()
         return queryset
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
### Quoi ?

Permettre à l'acheteur de télécharger la liste des structures intéressées par son besoin

### Comment ?

- on réutilise la fonctionnalité d'export (déjà utilisé dans la recherche & les listes de favoris)
- différence notable : on souhaite exporter d'avantage de champs (les infos de contact de chaque structure)