### PR TITLE
Permettre aux utilisateurs de rechercher dans plusieurs périmètres

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -29,15 +29,15 @@ GEO_RANGE_COUNTRY = "COUNTRY"
 
 
 def get_filter_city(perimeter, with_country=False):
-    filters = (
-        Q(post_code__in=perimeter.post_codes)
-        | (
+    filters = Q(post_code__in=perimeter.post_codes) | (
+        Q(geo_range=GEO_RANGE_DEPARTMENT) & Q(department=perimeter.department_code)
+    )
+    if perimeter.coords:
+        filters |= (
             Q(geo_range=GEO_RANGE_CUSTOM)
             # why distance / 1000 ? because convert from meter to km
             & Q(geo_range_custom_distance__gte=Distance("coords", perimeter.coords) / 1000)
         )
-        | (Q(geo_range=GEO_RANGE_DEPARTMENT) & Q(department=perimeter.department_code))
-    )
     if with_country:
         filters |= Q(geo_range=GEO_RANGE_COUNTRY)
     return filters

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -212,23 +212,15 @@ class SiaeQuerySet(models.QuerySet):
         return self.filter(get_filter_city(perimeter))
 
     def in_perimeters_area(self, perimeters: models.QuerySet, with_country=False):
-        cities = perimeters.filter(kind=Perimeter.KIND_CITY)
-        departments = perimeters.filter(kind=Perimeter.KIND_DEPARTMENT)
-        regions = perimeters.filter(kind=Perimeter.KIND_REGION)
         conditions = Q()
-        if cities:
-            # https://stackoverflow.com/questions/20222457/django-building-a-queryset-with-q-objects
-            conditions |= get_filter_city(cities[0], with_country)
-            for c in cities[1:]:
-                conditions |= get_filter_city(c, with_country)
-        if departments:
-            conditions |= Q(department=departments[0].insee_code)
-            for d in departments[1:]:
-                conditions |= Q(department=d.insee_code)
-        if regions:
-            conditions |= Q(region=regions[0].name)
-            for r in regions[1:]:
-                conditions |= Q(region=r.name)
+        for perimeter in perimeters:
+            if perimeter.kind == Perimeter.KIND_CITY:
+                # https://stackoverflow.com/questions/20222457/django-building-a-queryset-with-q-objects
+                conditions |= get_filter_city(perimeter, with_country)
+            if perimeter.kind == Perimeter.KIND_DEPARTMENT:
+                conditions |= Q(department=perimeter.insee_code)
+            if perimeter.kind == Perimeter.KIND_REGION:
+                conditions |= Q(region=perimeter.name)
         return self.filter(conditions)
 
     def within(self, point, distance_km=0):

--- a/lemarche/static/js/perimeters_autocomplete_fields.js
+++ b/lemarche/static/js/perimeters_autocomplete_fields.js
@@ -1,5 +1,8 @@
+// need to setup "current-perimeters" div which contains the currents perimeters selected to manage the refresh page
+
 const perimeterAutocompleteContainer = document.querySelector('#dir_form_perimeter_name');
 const perimetersContainer = document.querySelector('#perimeters-selected');
+const inputName = perimeterAutocompleteContainer.dataset.inputName;
 
 function removeInputOnClick() {
   let idRefInput = $(this).data('refinput');
@@ -14,13 +17,13 @@ function createHiddenInputPerimeter(resultId, resultName) {
   $('<input>', {
       type: 'hidden',
       id: resultIdString,
-      name: 'general-perimeters',
+      name: inputName,
       value: resultId
   }).appendTo(perimetersContainer);
   let button = $('<button>', {
       type: 'button',
-      class: "btn btn-sm btn-outline-primary btn-warning mr-2",
-      title: `Retirer ${resultName} du besoin`,
+      class: "btn btn-sm btn-outline-primary btn-warning mr-2 mb-2",
+      title: `Retirer ${resultName}`,
       text: `${resultName}`,
       'data-refInput': resultIdString,
       click: removeInputOnClick
@@ -141,6 +144,14 @@ document.addEventListener("DOMContentLoaded", function() {
       // tStatusResults:
       // tAssistiveHint:
     });
+  }
+
+
+  let currentPerimeters = JSON.parse(document.getElementById('current-perimeters').textContent);
+  if (currentPerimeters) {
+      currentPerimeters.forEach(perimeter => {
+          createHiddenInputPerimeter(parseInt(perimeter['id']), perimeter['name']);
+      });
   }
 });
 

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -119,7 +119,6 @@
     <script type="text/javascript" src="{% static 'vendor/accessible-slick-1.0.1/slick.min.js' %}"></script>
     <!-- custom javascript -->
     <script type="text/javascript" src="{% static 'js/sector_multiselect_field.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/perimeter_autocomplete_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/kind_multiselect_field.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/territory_multiselect_field.js' %}"></script>
     {% endcompress %}

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -32,16 +32,17 @@
                             <div class="col-12 col-md-6 mt-lg-3 pr-md-0">
                                 {% bootstrap_field form.sectors form_group_class="form-group use-multiselect" %}
                             </div>
-                            {% bootstrap_field form.perimeter %}
+                            {% comment %} {% bootstrap_field form.perimeters %} {% endcomment %}
                             <div class="col-12 col-md-6 mt-lg-3">
-                                <div id="dir_form_perimeter_name" class="form-group">
-                                    <label for="perimeter_name">{{ form.perimeter_name.label }}</label>
+                                <div id="dir_form_perimeter_name" data-input-name="{{ form.perimeters.name }}" class="form-group">
+                                    <label for="perimeter_name">{{ form.perimeters.label }}</label>
                                     <div class="field-holder">
                                         <div>
                                             {# {{ form.perimeter_name }} #}
                                         </div>
                                     </div>
                                 </div>
+                                <div id="perimeters-selected" class="mt-1"></div>
                             </div>
                         </div>
                         <div class="row">
@@ -117,7 +118,7 @@
                     {% for siae in siaes %}
                         {% include "siaes/_card_search_result.html" with siae=siae %}
                     {% endfor %}
-    
+
                     {% include "includes/_pagination.html" %}
                 {% else %}
                     <div class="no-results">
@@ -199,6 +200,10 @@
 {% endblock %}
 
 {% block extra_js %}
+{% comment %} <script type="text/javascript" src="{% static 'js/perimeter_autocomplete_field.js' %}"></script> {% endcomment %}
+{{ current_perimeters|json_script:"current-perimeters" }}
+<script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
+
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
     // Set listings markers on load
@@ -239,7 +244,13 @@ document.addEventListener("DOMContentLoaded", function() {
             layer.bindPopup(`<a href="/prestataires/${feature.properties.slug}/"><p class="h6">${featureDisplayName}</p></a>`);
         }
     }).addTo(map);
-    map.fitBounds(geojson.getBounds());
+    geoBounds = geojson.getBounds();
+    if(geoBounds.isValid()){
+        map.fitBounds(geoBounds);
+    }
+
+
+
 });
 </script>
 <script type="text/javascript" src="{% static 'js/envoi_groupe_modal_video.js' %}"></script>

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -34,7 +34,7 @@
     {% bootstrap_field form.presta_type %}
     <div class="form-group form-group-required {% if form.perimeters.errors %}is-invalid{% endif %}">
         <label for="perimeter_name">{{ form.perimeters.label }}</label>
-        <div id="dir_form_perimeter_name">
+        <div id="dir_form_perimeter_name" data-input-name="general-perimeters">
             <div class="field-holder">{{ form.perimeter_name }}</div>
         </div>
         <small class="form-text text-muted">{{ form.perimeters.help_text }}</small>
@@ -46,8 +46,8 @@
 {% endblock content_form %}
 
 {% block extra_js %}
-<script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 {{ current_perimeters|json_script:"current-perimeters" }}
+<script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     let is_in_country_area = document.getElementById('id_general-is_country_area');
@@ -74,12 +74,6 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    let currentPerimeters = JSON.parse(document.getElementById('current-perimeters').textContent);
-    if (currentPerimeters) {
-        currentPerimeters.forEach(perimeter => {
-            createHiddenInputPerimeter(parseInt(perimeter['id']), perimeter['name']);
-        });
-    }
 });
 </script>
 {% endblock %}

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -122,6 +122,14 @@ class SiaeSearchForm(forms.Form):
 
         return qs
 
+    def clean(self):
+        """
+        We override the clean method to manage the error of perimeters doesn't exit
+        """
+        super().clean()
+        if "perimeters" in self.errors:
+            self.errors["perimeters"][0] = "Périmètre inconnu"
+
     # def get_perimeter(self):
     #     """
     #     Method to extract the perimeter searched by the user.

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -33,12 +33,10 @@ class SiaeSearchForm(forms.Form):
     )
     # The hidden `perimeter` field is populated by the autocomplete JavaScript mechanism,
     # see `perimeter_autocomplete_field.js`.
-    perimeter = forms.CharField(required=False, widget=forms.HiddenInput())
-    # Most of the field will be overridden by the autocomplete mechanism
-    perimeter_name = forms.CharField(
-        label="Lieu d'intervention",
+    perimeters = forms.ModelMultipleChoiceField(
+        label=Perimeter._meta.verbose_name_plural,
+        queryset=Perimeter.objects.all(),
         required=False,
-        widget=forms.TextInput(attrs={"placeholder": "Région, département, ville"}),
     )
     kind = forms.MultipleChoiceField(
         label="Type de structure",
@@ -70,29 +68,7 @@ class SiaeSearchForm(forms.Form):
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
 
-    def clean(self):
-        """
-        We override the clean method to manage 2 edge cases:
-        a) if perimeter is empty but perimeter_name is not
-            - how come? the user used the typeahead but didn't select a perimeter option
-            - result? show an error
-        b) if perimeter_name is empty but perimeter is not
-            - how come? the user had previously searched a valid perimeter option, but erased it
-            - result? erase the perimeter data. also managed in get_perimeter()
-            - TODO: manage this case in the frontend?
-        """
-        cleaned_data = super().clean()
-        perimeter = cleaned_data.get("perimeter", "")
-        perimeter_name = cleaned_data.get("perimeter_name", "")
-        if not perimeter and perimeter_name:
-            raise forms.ValidationError(
-                {"perimeter_name": "Périmètre inconnu. Veuillez en choisir un dans la liste, ou effacer le texte."}
-            )
-        if perimeter and not perimeter_name:
-            self.cleaned_data["perimeter"] = ""
-            return self.cleaned_data
-
-    def filter_queryset(self, perimeter=None):  # noqa C901
+    def filter_queryset(self):  # noqa C901
         """
         Method to filter the Siaes depending on the search filters.
         We also make sure there are no duplicates.
@@ -107,8 +83,9 @@ class SiaeSearchForm(forms.Form):
         if sectors:
             qs = qs.filter_sectors(sectors)
 
-        if perimeter:
-            qs = self.perimeter_filter(qs, perimeter)
+        perimeters = self.cleaned_data.get("perimeters", None)
+        if perimeters:
+            qs = qs.in_perimeters_area(perimeters)
 
         kind = self.cleaned_data.get("kind", None)
         if kind:
@@ -145,23 +122,23 @@ class SiaeSearchForm(forms.Form):
 
         return qs
 
-    def get_perimeter(self):
-        """
-        Method to extract the perimeter searched by the user.
-        Useful to avoid duplicate DB queries on the Perimeter model.
-        """
-        perimeter = None
-        search_perimeter = self.data.get("perimeter", None)
-        search_perimeter_name = self.data.get("perimeter_name", None)
-        # A valid perimeter search must have both the `perimeter` & `perimeter_name` fields in the querystring
-        if search_perimeter and search_perimeter_name:
-            try:
-                perimeter = Perimeter.objects.get(slug=search_perimeter)
-            except Perimeter.DoesNotExist:
-                pass
-        return perimeter
+    # def get_perimeter(self):
+    #     """
+    #     Method to extract the perimeter searched by the user.
+    #     Useful to avoid duplicate DB queries on the Perimeter model.
+    #     """
+    #     perimeters = None
+    #     search_perimeters = self.data.getlist("perimeters", None)
+    #     # A valid perimeter search must have both the `perimeter` & `perimeter_name` fields in the querystring
+    #     if search_perimeters:
+    #         try:
+    #             # perimeters = Perimeter.objects.in_bulk(search_perimeters)
+    #             perimeters = Perimeter.objects.filter(id__in=search_perimeters)
+    #         except Perimeter.DoesNotExist:
+    #             pass
+    #     return perimeters
 
-    def perimeter_filter(self, qs, perimeter):
+    def perimeter_filter(self, qs, perimeters):
         """
         Method to filter the Siaes depending on the perimeter filter.
         The search_perimeter should be a Perimeter slug.
@@ -178,21 +155,12 @@ class SiaeSearchForm(forms.Form):
         **REGION**
         return only the Siae in this region
         """
-        if not perimeter:
+        if not perimeters:
             return qs
-        if perimeter.kind == Perimeter.KIND_CITY:
-            # qs = qs.in_range_of_point(city_coords=perimeter.coords)
-            qs = qs.in_city_area(perimeter=perimeter)
-        elif perimeter.kind == Perimeter.KIND_DEPARTMENT:
-            qs = qs.in_department(department_code=perimeter.insee_code)
-        elif perimeter.kind == Perimeter.KIND_REGION:
-            qs = qs.in_region(region_name=perimeter.name)
-        else:
-            # unknown perimeter kind, don't filter
-            pass
-        return qs
 
-    def order_queryset(self, qs, perimeter):
+        return qs.in_perimeters_area(perimeters)
+
+    def order_queryset(self, qs):
         """
         Method to order the search results (can depend on the search filters).
 
@@ -220,7 +188,10 @@ class SiaeSearchForm(forms.Form):
         )
 
         # annotate on distance to siae if CITY searched
-        if perimeter:
+        # TODO: QUID des distances
+        perimeters = self.cleaned_data.get("perimeters", None)
+        if perimeters and len(perimeters) == 1:
+            perimeter = perimeters[0]
             if perimeter and perimeter.kind == Perimeter.KIND_CITY:
                 qs = qs.annotate(
                     distance=Case(

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -42,9 +42,9 @@ class SiaeSearchResultsView(FormMixin, ListView):
         - filter and order using the SiaeSearchForm
         - if the user is authenticated, annotate with favorite info
         """
-        filter_form = SiaeSearchForm(data=self.request.GET)
-        results = filter_form.filter_queryset()
-        results_ordered = filter_form.order_queryset(results)
+        self.filter_form = SiaeSearchForm(data=self.request.GET)
+        results = self.filter_form.filter_queryset()
+        results_ordered = self.filter_form.order_queryset(results)
         if self.request.user.is_authenticated:
             results_ordered = results_ordered.annotate_with_user_favorite_list_count(self.request.user)
         return results_ordered
@@ -57,7 +57,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         """
         context = super().get_context_data(**kwargs)
         if len(self.request.GET.keys()):
-            siae_search_form = SiaeSearchForm(data=self.request.GET)
+            siae_search_form = self.filter_form if self.filter_form else SiaeSearchForm(data=self.request.GET)
             context["form"] = siae_search_form
             if siae_search_form.is_valid():
                 current_perimeters = siae_search_form.cleaned_data.get("perimeters")
@@ -80,18 +80,19 @@ class SiaeSearchResultsView(FormMixin, ListView):
         return context
 
     def get(self, request, *args, **kwargs):
-        siae_list = self.get_queryset()
+        self.object_list = self.get_queryset()
         # Track search event
         track(
             "backend",
             "directory_search",
-            meta=extract_meta_from_request(self.request, results_count=siae_list.count()),
+            meta=extract_meta_from_request(self.request, results_count=self.object_list.count()),
         )
-        user = self.request.user
+        user = request.user
         if not user.is_anonymous and user.kind == user.KIND_BUYER:
             add_to_contact_list(user, "buyer_search")
 
-        return super().get(request, *args, **kwargs)
+        context = self.get_context_data()
+        return self.render_to_response(context)
 
 
 class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -60,9 +60,9 @@ class SiaeSearchResultsView(FormMixin, ListView):
             siae_search_form = SiaeSearchForm(data=self.request.GET)
             context["form"] = siae_search_form
             if siae_search_form.is_valid():
-                tender_perimeters = siae_search_form.cleaned_data.get("perimeters")
-                if tender_perimeters:
-                    context["current_perimeters"] = list(tender_perimeters.values("id", "name"))
+                current_perimeters = siae_search_form.cleaned_data.get("perimeters")
+                if current_perimeters:
+                    context["current_perimeters"] = list(current_perimeters.values("id", "name"))
         # store the current search query in the session
         current_search_query = self.request.GET.urlencode()
         self.request.session[CURRENT_SEARCH_QUERY_COOKIE_NAME] = current_search_query


### PR DESCRIPTION
### Quoi ?

Permettre aux utilisateurs de rechercher dans plusieurs périmètres.

### Pourquoi ?

Donner plus de flexibilité et de précision aux utilisateurs dans leurs recherches.

### Comment ?

Par l'utilisation d'un "ou", structures dans "Paris" ou "Marseille".

