### PR TITLE
Ajout d'une zone pliante pour l'affichage des références clients

### DIFF
--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -86,7 +86,7 @@
 .s-siae-03 {
 	padding-top: 1.5rem;
 	padding-bottom: 1.5rem;
-	
+
 	@media (min-width:992px) {
 		padding-top: 2rem;
 		padding-bottom: 3rem;
@@ -153,14 +153,14 @@
 			flex: 1;
 		}
 	}
-	
+
 	#content {
 		display: grid;
 		grid-column-gap: 16px;
 		grid-row-gap: 16px;
-		grid-template-columns: 1fr; 
+		grid-template-columns: 1fr;
 		grid-template-rows: auto;
-				
+
 		@media (min-width:992px) {
 			grid-template-columns: 66% 33%;
 			grid-template-rows: auto 1fr;
@@ -169,12 +169,12 @@
 				grid-column: 1 / 1;
 				grid-row: 1 / 1;
 			}
-			
+
 			#sidebar {
 				grid-column: 2 / 2;
 				grid-row: 1 / 3;
 			}
-			
+
 			#user_detail {
 				grid-column: 1 / 1;
 				grid-row: 2 / 2;
@@ -184,9 +184,9 @@
 		@media (min-width:1200px) {
 			grid-column-gap: 32px;
 			grid-row-gap: 32px;
-		}		
+		}
 	}
-	
+
 	.img-left .il-l img {
 		margin-top: 0.25rem;
 		margin-right: 0.5rem;
@@ -271,26 +271,39 @@
 		max-width: 100px;
 	}
 
+	.is-collapse-caret-clients {
+		text-decoration: none;
+		display: inline-block;
+
+		&[aria-expanded=true]::before {
+			content: 'Moins ';
+		}
+
+		&[aria-expanded=false]::before {
+			content: 'Plus ';
+		}
+	}
+
 	#user_update_cta {
-	
+
 		.col-12 {
-	
+
 			.card {
 				position: relative;
-	
+
 				@media (min-width:992px) {
 					background-image: url('/static/images/partenaires-illu-01.png');
 					background-repeat: no-repeat;
 					background-position: right center;
 					background-size: auto 100%;
-				}			
+				}
 			}
-	
+
 			.card-footer {
 				background-color: transparent !important;
 			}
 		}
-	} 	
+	}
 }
 
 .si-separator {
@@ -357,5 +370,5 @@
 
 	.siae-card .card-footer {
 		padding-left: 16px;
-	}		
+	}
 }

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -281,7 +281,7 @@
                                 </div>
                                 <div class="il-r">
                                     <h3 class="h2 mb-1 mt-1">Références clients</h3>
-                                    {% if siae.client_reference_count < 6 %}
+                                    {% if siae.client_reference_count <= 6 %}
                                         <ul class="list-unstyled row row-cols-3 align-items-center">
                                         {% for image in siae.client_references.all %}
                                             <li class="col">

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -281,11 +281,33 @@
                                 </div>
                                 <div class="il-r">
                                     <h3 class="h2 mb-1 mt-1">Références clients</h3>
-                                    {% for image in siae.client_references.all %}
-                                        {% if image.logo_url %}
-                                            <img class="client-ref" src="{{ image.logo_url }}" alt="{{ image.name }}" title="{{ image.name }}" />
-                                        {% endif %}
-                                    {% endfor %}
+                                    {% if siae.client_reference_count < 6 %}
+                                        <ul class="list-unstyled row row-cols-3 align-items-center">
+                                        {% for image in siae.client_references.all %}
+                                            <li class="col">
+                                                <img class="img-fluid img-fitcover" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                            </li>
+                                        {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        <ul class="list-unstyled row row-cols-3 align-items-center mb-0">
+                                        {% for image in siae.client_references.all|slice:":6" %}
+                                            <li class="col">
+                                                <img class="img-fluid img-fitcover" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                            </li>
+                                        {% endfor %}
+                                        </ul>
+                                        <div class="collapse" id="collapseMoreRefClients">
+                                            <ul class="list-unstyled row row-cols-3 align-items-center mb-0">
+                                            {% for image in siae.client_references.all|slice:"6:" %}
+                                                <li class="col">
+                                                    <img class="img-fluid img-fitcover" src="{{ image.logo_url }}" alt="{{ image.name }}" />
+                                                </li>
+                                            {% endfor %}
+                                            </ul>
+                                        </div>
+                                        <a class="mt-3 is-collapse-caret-clients has-collapse-caret collapsed" data-toggle="collapse" href="#collapseMoreRefClients" role="button" aria-expanded="false" aria-controls="collapseMoreRefClients" title="Plus de références clients">de références clients</a>
+                                    {% endif %}
                                 </div>
                             </div>
                         {% endif %}


### PR DESCRIPTION
### Quoi ?

Limiter le nbr de références client visible sur une fiche commerciale.
Voir ticket Notion https://www.notion.so/Limiter-le-nbr-de-r-f-rences-client-sur-une-fiche-commerciale-dde62465a31b42be8ddf75566ef6b1a9

### Pourquoi ?

Parfois les ESI affichent des dizaines de ref client ce qui alourdit la lisibilité de leur fiche commerciale.

### Comment ?

Limité à 6 et ajouter la possibilité d’ouvrir comme un collapse afin de toutes les consulter.

### Captures d'écran (optionnel)
![capture 2022-06-28 à 14 09 34](https://user-images.githubusercontent.com/3874024/176175052-87a5175c-bbf4-49c6-bae6-94c6d76521bd.png)
![capture 2022-06-28 à 14 09 29](https://user-images.githubusercontent.com/3874024/176175062-543897f0-7ffd-400a-83c8-eeebb95dec17.png)


