### PR TITLE
Répare les erreurs générées par l'envoi d'un message Slack

### DIFF
--- a/lemarche/utils/apis/api_mailjet.py
+++ b/lemarche/utils/apis/api_mailjet.py
@@ -57,7 +57,7 @@ def add_to_contact_list_async(email_address, properties, contact_list_id, client
     try:
         response = client.post(contact_list_endpoint(contact_list_id), json=data)
         response.raise_for_status()
-        logger.info("add user to newsletter")
+        logger.info("add user to contact list")
         logger.info(response.json())
         return response.json()
     except httpx.HTTPStatusError as e:

--- a/lemarche/utils/apis/api_slack.py
+++ b/lemarche/utils/apis/api_slack.py
@@ -45,8 +45,8 @@ def send_message_to_channel(text: str, service_id: str, client: httpx.Client = N
             response = client.post(f"{BASE_URL}{service_id}", json=data)
             response.raise_for_status()
             logger.info("send message to slack")
-            logger.info(response.json())
-            return response.json()
+            # logger.info(response.json())  // you'll receive a "HTTP 200" response with a plain text ok indicating that your message posted successfully  # noqa
+            return True
         except httpx.HTTPStatusError as e:
             logger.error("Error while fetching `%s`: %s", e.request.url, e)
             raise e


### PR DESCRIPTION
### Quoi ?

Lors de l'utilisation du Webhook Slack, la réponse est sous la forme de plaintext `ok`, et non d'un JSON : https://api.slack.com/messaging/webhooks#handling_errors