### PR TITLE
Dépôt de besoin : remplacer "déposer" par "publier"

### DIFF
--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -130,7 +130,7 @@
                             Certaines structures n'ont pas mis à jour leurs informations sur le marché de l'inclusion !
                         </p>
                         <p>
-                            En déposant votre besoin, vous pouvez toutes les solliciter automatiquement.
+                            En publiant votre besoin, vous pouvez toutes les solliciter automatiquement.
                             Ce sont elles qui reviendront vers vous si elles peuvent se positionner.
                         </p>
                         {% if user.is_authenticated %}

--- a/lemarche/templates/tenders/create_base.html
+++ b/lemarche/templates/tenders/create_base.html
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Déposer un besoin</li>
+                        <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/create_step_confirmation.html
+++ b/lemarche/templates/tenders/create_step_confirmation.html
@@ -1,7 +1,7 @@
 {% extends "tenders/create_base.html" %}
 {% load static bootstrap4 %}
 
-{% block title %}Déposer un besoin{{ block.super }}{% endblock %}
+{% block title %}Publier un besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Déposer un besoin</li>
+                        <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/create_step_contact.html
+++ b/lemarche/templates/tenders/create_step_contact.html
@@ -1,7 +1,7 @@
 {% extends "tenders/create_base.html" %}
 {% load bootstrap4 static %}
 
-{% block title %}Déposer un besoin{{ block.super }}{% endblock %}
+{% block title %}Publier un besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Déposer un besoin</li>
+                        <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/create_step_description.html
+++ b/lemarche/templates/tenders/create_step_description.html
@@ -1,7 +1,7 @@
 {% extends "tenders/create_base.html" %}
 {% load bootstrap4 static %}
 
-{% block title %}Déposer un besoin{{ block.super }}{% endblock %}
+{% block title %}Publier un besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Déposer un besoin</li>
+                        <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -1,7 +1,7 @@
 {% extends "tenders/create_base.html" %}
 {% load bootstrap4 static %}
 
-{% block title %}Déposer un besoin{{ block.super }}{% endblock %}
+{% block title %}Publier un besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Déposer un besoin</li>
+                        <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -151,8 +151,6 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
                 "fields": (
                     "accept_rgpd",
                     "accept_survey",
-                    "accept_offers_for_pro_sector",
-                    "accept_quote_promise",
                     "accept_share_contact_to_external_partners",
                 )
             },

--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -52,8 +52,7 @@ class SignupForm(UserCreationForm):
         label=User._meta.get_field("accept_survey").help_text, help_text="", required=False
     )
 
-    # accept_share_contact_to_external_partners is hidden by default in the frontend.
-    # Shown if the user choses kind SIAE
+    # accept_share_contact_to_external_partners is hidden by default in the frontend. Shown if the user choses kind SIAE  # noqa
     accept_share_contact_to_external_partners = forms.BooleanField(
         label=User._meta.get_field("accept_share_contact_to_external_partners").help_text, help_text="", required=False
     )

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -48,7 +48,7 @@ class TenderCreateMultiStepView(NotSiaeUserRequiredMixin, SessionWizardView):
     instance = None
     success_url = reverse_lazy("tenders:list")
     success_message = """
-        Votre besoin <strong>{tender_title}</strong> a été déposé sur le marché !<br />
+        Votre besoin <strong>{tender_title}</strong> a été publié sur le marché !<br />
         Les <strong>{tender_siae_count} structures</strong> qui correspondent à vos critères seront notifiées
         dès que votre besoin sera validé par notre équipe.
     """


### PR DESCRIPTION
### Quoi ?

Homogénéiser le wording pour la publication de besoins
