### PR TITLE
Dépôt de besoin : afficher une modale freemium pour les utilisateurs non inscrits

### DIFF
--- a/lemarche/templates/auth/_login_or_signup_siae_tender_modal.html
+++ b/lemarche/templates/auth/_login_or_signup_siae_tender_modal.html
@@ -8,37 +8,22 @@
   fill: #333;
 }
 </style>
-<div class="modal fade modal-siae" id="login_or_signup_modal" tabindex="-1" role="dialog" aria-modal="true" data-backdrop="static" data-keyboard="false" aria-labelledby="exampleModalLabel">
+<div class="modal fade modal-siae" id="login_or_signup_siae_tender_modal" tabindex="-1" role="dialog" aria-modal="true" data-backdrop="static" data-keyboard="false" aria-labelledby="exampleModalLabel">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 class="modal-title" id="exampleModalLabel">Profitez gratuitement du Marché</h3>
+                <h3 class="modal-title" id="exampleModalLabel">Cette opportunité commerciale vous intéresse ?</h3>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
                     <i class="ri-close-line"></i>
                 </button>
             </div>
             <div class="modal-body home-content-body">
                 <p class="mb-4">
-                    Ce ne sera pas long ! Inscrivez-vous et accédez à toutes les fonctionnalités du marché.
+                    Inscrivez-vous pour accéder à l'ensemble des demandes publiées par les entreprises et acheteurs publics du Marché de l'inclusion.
                 </p>
-                <ul class="list-unstyled mb-5">
-                    <li class="d-flex mb-2">
-                        <i class="text-success ri-checkbox-circle-fill display-2"></i>
-                        <span class="font-weight-bold ml-2">Publiez vos besoins auprès des structures, et retrouvez celles qui sont intéressées.</span>
-                    </li>
-                    <li class="d-flex mb-2">
-                        <i class="text-success ri-checkbox-circle-fill display-2"></i>
-                        <span class="font-weight-bold ml-2">Téléchargez la liste complète des structures figurant sur le marché.</span>
-                    </li>
-                    <li class="d-flex mb-2">
-                        <i class="text-success ri-checkbox-circle-fill display-2"></i>
-                        <span class="font-weight-bold ml-2">Créez des listes d'achat et sauvegardez vos structures favorites.</span>
-                    </li>
-                    <li class="d-flex mb-2">
-                        <i class="text-success ri-checkbox-circle-fill display-2"></i>
-                        <span class="font-weight-bold ml-2">Accédez aux coordonnées des structures.</span>
-                    </li>
-                </ul>
+                <p class="mb-4">
+                    Le Marché de l'inclusion est un service public gratuit !
+                </p>
                 <div class="text-center">
                     <a href="{% url 'auth:signup' %}?next=next-params-to-replace" id="auth-link" class="btn btn-sm btn-primary">Créer un compte</a>
                 </div>
@@ -54,7 +39,7 @@
 
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
-    const MODAL_ID = '#login_or_signup_modal';
+    const MODAL_ID = '#login_or_signup_siae_tender_modal';
     $(MODAL_ID).on('show.bs.modal', function (event) {
         // Button that triggered the modal
         var button = $(event.relatedTarget);

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -35,6 +35,10 @@
 </section>
 {% endblock %}
 
+{% block modals %}
+    {% include "auth/_login_or_signup_siae_tender_modal.html" %}
+{% endblock %}
+
 {% block extra_js %}
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -11,8 +11,10 @@
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">{{ parent_title }}</a></li>
+                        {% if user.is_authenticated %}
+                            <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Mon espace</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">{{ parent_title }}</a></li>
+                        {% endif %}
                         <li class="breadcrumb-item active" aria-current="page">{{ tender.title|truncatechars:25 }}</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -1,4 +1,5 @@
 {% load bootstrap4 static array_choices_display humanize %}
+
 <div class="card c-card c-card--marche siae-card rounded-lg shadow-lg">
     <p class="text-right text-white bg-tertiary fs-sm rounded-top rounded-lg py-3 px-5 mb-0">
         Date limite de réponse : {{ tender.deadline_date|default:"" }}
@@ -60,27 +61,27 @@
 
         {% if not hide_cta %}
             <hr class="my-5">
-
-            {% if tender.author == request.user or user_has_contact_click_date %}
-                {% include "tenders/_detail_contact.html" with tender=tender %}
-            {% else %}
-                <button type="button" id="show-tender-contact-btn" class="btn btn-primary float-right mb-4" style="display:block">
-                    Je souhaite répondre à ce besoin
-                </button>
-                <div id="show-tender-contact-content" class="py-2" style="display:none">
+            {% if user.is_authenticated %}
+                {% if tender.author == request.user or user_has_contact_click_date %}
                     {% include "tenders/_detail_contact.html" with tender=tender %}
-                </div>
-            {% endif %}
-
-            {% if tender.author == request.user and siae_contact_click_count %}
-                <hr class="my-5" />
-                <div class="row">
-                    <div class="col-12">
-                        <a href="{% url 'tenders:detail-siae-interested' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
-                            {{ siae_contact_click_count }} structures intéressées
-                        </a>
+                {% else %}
+                    <button type="button" id="show-tender-contact-btn" class="btn btn-primary float-right mb-4" style="display:block">
+                        Je souhaite répondre à ce besoin
+                    </button>
+                    <div id="show-tender-contact-content" class="py-2" style="display:none">
+                        {% include "tenders/_detail_contact.html" with tender=tender %}
                     </div>
-                </div>
+                {% endif %}
+                {% if tender.author == request.user and siae_contact_click_count %}
+                    <hr class="my-5" />
+                    <div class="row">
+                        <div class="col-12">
+                            <a href="{% url 'tenders:detail-siae-interested' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
+                                {{ siae_contact_click_count }} structures intéressées
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -82,6 +82,10 @@
                         </div>
                     </div>
                 {% endif %}
+            {% else %}
+                <a href="#" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
+                    <span>Afficher les coordonnées</span>
+                </a>
             {% endif %}
         {% endif %}
     </div>

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -84,7 +84,7 @@
                 {% endif %}
             {% else %}
                 <a href="#" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
-                    <span>Afficher les coordonnées</span>
+                    <span>Je souhaite répondre à ce besoin</span>
                 </a>
             {% endif %}
         {% endif %}

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -215,13 +215,12 @@ class TenderDetailViewTest(TestCase):
             tender=cls.tender_1, siae=cls.siae_1, contact_click_date=timezone.now()
         )
 
-    def test_anonymous_user_cannot_view_tender(self):
+    def test_anyone_can_view_tenders(self):
+        # anonymous
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
-
-    def test_any_user_can_view_tenders(self):
+        self.assertEqual(response.status_code, 200)
+        # users
         for user in User.objects.all():
             self.client.login(email=user.email, password=DEFAULT_PASSWORD)
             url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -173,7 +173,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         return context
 
 
-class TenderDetailView(DetailView):  # LoginRequiredMixin
+class TenderDetailView(DetailView):
     model = Tender
     template_name = "tenders/detail.html"
     context_object_name = "tender"

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -173,7 +173,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         return context
 
 
-class TenderDetailView(LoginRequiredMixin, DetailView):
+class TenderDetailView(DetailView):  # LoginRequiredMixin
     model = Tender
     template_name = "tenders/detail.html"
     context_object_name = "tender"
@@ -182,7 +182,7 @@ class TenderDetailView(LoginRequiredMixin, DetailView):
         """
         Check if the User has any Siae contacted for this Tender. If yes, update 'detail_display_date'
         """
-        if self.request.user.kind == User.KIND_SIAE:
+        if self.request.user.is_authenticated and self.request.user.kind == User.KIND_SIAE:
             tender = self.get_object()
             TenderSiae.objects.filter(
                 tender=tender, siae__in=self.request.user.siaes.all(), detail_display_date__isnull=True
@@ -199,7 +199,7 @@ class TenderDetailView(LoginRequiredMixin, DetailView):
             if user_kind == User.KIND_SIAE and tender.kind == Tender.TENDER_KIND_PROJECT
             else tender.get_kind_display()
         )
-        if self.request.user.kind == User.KIND_SIAE:
+        if self.request.user.is_authenticated and self.request.user.kind == User.KIND_SIAE:
             context["user_has_detail_display_date"] = TenderSiae.objects.filter(
                 tender=tender, siae__in=self.request.user.siaes.all(), detail_display_date__isnull=False
             ).exists()


### PR DESCRIPTION
### Quoi ?

Pour les utilisateurs anonymes (potentiellement des structures ayant reçu le besoin par e-mail)
- leur donner accès à la page détail (sans devoir passer par la page de connexion)
- le bouton "Afficher les coordonnées" ouvre une nouvelle modale freemium (orienté structure intéressée)