### PR TITLE
Fix de l'erreur d'envoi d'email des dépôts de besoin à J+30

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -579,10 +579,10 @@ CONNECTION_MODES_HUEY = {
     },
 }
 
-CONNECTION_MODE_TASKS = env.str("CONNECTION_MODE_TASKS", "redis")
+CONNECTION_MODE_TASKS = env.str("CONNECTION_MODE_TASKS", "direct")
 CC_WORKER_ENV = env.str("CC_WORKER_COMMAND", None)
 
-CONF_HUEY = CONNECTION_MODES_HUEY.get(CONNECTION_MODE_TASKS, CONNECTION_MODES_HUEY["sqlite"])
+CONF_HUEY = CONNECTION_MODES_HUEY.get(CONNECTION_MODE_TASKS)
 
 # Huey instance
 # If any performance issue, increasing the number of workers *can* be a good idea

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,7 +16,7 @@ import environ
 from django.contrib.messages import constants as messages
 
 
-locale.setlocale(locale.LC_ALL, "")
+locale.setlocale(locale.LC_ALL, "fr_FR.UTF-8")
 
 # django-environ eases the application of twelve-factor methodology :
 # it makes it easier and less error-prone to integrate

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,7 +16,7 @@ import environ
 from django.contrib.messages import constants as messages
 
 
-locale.setlocale(locale.LC_ALL, "fr_FR")
+locale.setlocale(locale.LC_ALL, "")
 
 # django-environ eases the application of twelve-factor methodology :
 # it makes it easier and less error-prone to integrate

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,7 +16,7 @@ import environ
 from django.contrib.messages import constants as messages
 
 
-locale.setlocale(locale.LC_ALL, "fr_FR.UTF-8")
+locale.setlocale(locale.LC_TIME, "fr_FR")
 
 # django-environ eases the application of twelve-factor methodology :
 # it makes it easier and less error-prone to integrate

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -9,11 +9,14 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+import locale
 import os
 
 import environ
 from django.contrib.messages import constants as messages
 
+
+locale.setlocale(locale.LC_ALL, "fr_FR")
 
 # django-environ eases the application of twelve-factor methodology :
 # it makes it easier and less error-prone to integrate

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,7 +16,11 @@ import environ
 from django.contrib.messages import constants as messages
 
 
-locale.setlocale(locale.LC_TIME, "fr_FR")
+locale.setlocale(locale.LC_TIME, "")
+# locale.setlocale(locale.LC_ALL, "fr_FR")
+# this contig doesn't work, produce this error
+# locale.Error: unsupported locale setting
+
 
 # django-environ eases the application of twelve-factor methodology :
 # it makes it easier and less error-prone to integrate

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -85,7 +85,7 @@ def send_tenders_author_feedback_30_days(tender: Tender):
 
         variables = {
             "TENDER_TITLE": tender.title,
-            "TENDER_VALIDATE_AT": tender.validated_at.strftime("%d/%m/%Y %H:%M"),
+            "TENDER_VALIDATE_AT": tender.validated_at.strftime("%d %B %Y"),
             "USER_FIRST_NAME": author_tender.full_name,
         }
 

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -85,7 +85,7 @@ def send_tenders_author_feedback_30_days(tender: Tender):
 
         variables = {
             "TENDER_TITLE": tender.title,
-            "TENDER_VALIDATE_AT": tender.validated_at,
+            "TENDER_VALIDATE_AT": tender.validated_at.strftime("%d/%m/%Y %H:%M"),
             "USER_FIRST_NAME": author_tender.full_name,
         }
 


### PR DESCRIPTION
### Quoi ?

Fix de l'erreur d'envoi d'email des dépôts de besoin à J+30

### Pourquoi ?

Problème d'encodage.
