### PR TITLE
Admin : améliorations sur les champs count & readonly

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -78,11 +78,11 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "siret",
         "kind",
         "city",
-        "nb_users",
-        "nb_offers",
-        "nb_labels",
-        "nb_cient_references",
-        "nb_images",
+        "user_count_with_link",
+        "offer_count_with_link",
+        "label_count_with_link",
+        "client_reference_count_with_link",
+        "image_count_with_link",
         "created_at",
     ]
     list_filter = [
@@ -102,13 +102,14 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
     autocomplete_fields = ["sectors", "networks", "groups"]
     # prepopulated_fields = {"slug": ("name",)}
     readonly_fields = [field for field in Siae.READONLY_FIELDS if field not in ("coords")] + [
-        "sector_count",
-        "network_count",
-        "nb_offers",
-        "nb_labels",
-        "nb_cient_references",
-        "nb_users",
-        "nb_images",
+        # "user_count",
+        "sector_count_with_link",
+        "network_count_with_link",
+        "offer_count_with_link",
+        "label_count_with_link",
+        "client_reference_count_with_link",
+        "user_count_with_link",
+        "image_count_with_link",
         "coords_display",
         "logo_url",
         "logo_url_display",
@@ -171,13 +172,13 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                 "fields": (
                     "description",
                     "sectors",
-                    "sector_count",
+                    "sector_count_with_link",
                     "networks",
-                    "network_count",
-                    "nb_offers",
-                    "nb_labels",
-                    "nb_cient_references",
-                    "nb_images",
+                    "network_count_with_link",
+                    "offer_count_with_link",
+                    "label_count_with_link",
+                    "client_reference_count_with_link",
+                    "image_count_with_link",
                     "groups",
                 )
             },
@@ -201,7 +202,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                     "contact_phone",
                     "contact_website",
                     "contact_social_website",
-                    "nb_users",
+                    "user_count_with_link",
                 )
             },
         ),
@@ -273,13 +274,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                 "fields": (
                     "description",
                     "sectors",
-                    # "sector_count",
                     "networks",
-                    # "network_count",
-                    # "nb_offers",
-                    # "nb_labels",
-                    # "nb_cient_references",
-                    # "nb_images",
                     # "groups",
                 )
             },
@@ -303,7 +298,6 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                     "contact_phone",
                     "contact_website",
                     "contact_social_website",
-                    # "nb_users",
                 )
             },
         ),
@@ -351,40 +345,54 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
             return True
         return super().lookup_allowed(lookup, *args, **kwargs)
 
-    def nb_users(self, siae):
+    def user_count_with_link(self, siae):
         url = reverse("admin:users_user_changelist") + f"?siaes__in={siae.id}"
         return format_html(f'<a href="{url}">{siae.user_count}</a>')
 
-    nb_users.short_description = "Nombre d'utilisateurs"
-    nb_users.admin_order_field = "user_count"
+    user_count_with_link.short_description = "Nombre d'utilisateurs"
+    user_count_with_link.admin_order_field = "user_count"
 
-    def nb_offers(self, siae):
+    def sector_count_with_link(self, siae):
+        url = reverse("admin:sectors_sector_changelist") + f"?siaes__in={siae.id}"
+        return format_html(f'<a href="{url}">{siae.sector_count}</a>')
+
+    sector_count_with_link.short_description = "Nbr de secteurs"
+    sector_count_with_link.admin_order_field = "sector_count"
+
+    def network_count_with_link(self, siae):
+        url = reverse("admin:networks_network_changelist") + f"?siaes__in={siae.id}"
+        return format_html(f'<a href="{url}">{siae.network_count}</a>')
+
+    network_count_with_link.short_description = "Nbr de réseaux"
+    network_count_with_link.admin_order_field = "network_count"
+
+    def offer_count_with_link(self, siae):
         url = reverse("admin:siaes_siaeoffer_changelist") + f"?siae__id__exact={siae.id}"
         return format_html(f'<a href="{url}">{siae.offer_count}</a>')
 
-    nb_offers.short_description = "Nbr de prestations"
-    nb_offers.admin_order_field = "offer_count"
+    offer_count_with_link.short_description = "Nbr de prestations"
+    offer_count_with_link.admin_order_field = "offer_count"
 
-    def nb_labels(self, siae):
+    def label_count_with_link(self, siae):
         url = reverse("admin:siaes_siaelabel_changelist") + f"?siae__id__exact={siae.id}"
         return format_html(f'<a href="{url}">{siae.label_count}</a>')
 
-    nb_labels.short_description = "Nbr de labels"
-    nb_labels.admin_order_field = "label_count"
+    label_count_with_link.short_description = "Nbr de labels"
+    label_count_with_link.admin_order_field = "label_count"
 
-    def nb_cient_references(self, siae):
+    def client_reference_count_with_link(self, siae):
         url = reverse("admin:siaes_siaeclientreference_changelist") + f"?siae__id__exact={siae.id}"
         return format_html(f'<a href="{url}">{siae.client_reference_count}</a>')
 
-    nb_cient_references.short_description = "Nbr de réf. clients"
-    nb_cient_references.admin_order_field = "client_reference_count"
+    client_reference_count_with_link.short_description = "Nbr de réf. clients"
+    client_reference_count_with_link.admin_order_field = "client_reference_count"
 
-    def nb_images(self, siae):
+    def image_count_with_link(self, siae):
         url = reverse("admin:siaes_siaeimage_changelist") + f"?siae__id__exact={siae.id}"
         return format_html(f'<a href="{url}">{siae.image_count}</a>')
 
-    nb_images.short_description = "Nbr d'images"
-    nb_images.admin_order_field = "image_count"
+    image_count_with_link.short_description = "Nbr d'images"
+    image_count_with_link.admin_order_field = "image_count"
 
     def coords_display(self, siae):
         if siae.coords:

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -102,7 +102,6 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
     autocomplete_fields = ["sectors", "networks", "groups"]
     # prepopulated_fields = {"slug": ("name",)}
     readonly_fields = [field for field in Siae.READONLY_FIELDS if field not in ("coords")] + [
-        # "user_count",
         "sector_count_with_link",
         "network_count_with_link",
         "offer_count_with_link",

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -48,10 +48,10 @@ class TenderAdmin(admin.ModelAdmin):
         "kind",
         "deadline_date",
         "start_working_date",
-        "nb_siae",
-        "nb_siae_email_send",
-        "nb_siae_detail_display",
-        "nb_siae_contact_click",
+        "siae_count_with_link",
+        "siae_email_send_count_with_link",
+        "siae_detail_display_count_with_link",
+        "siae_contact_click_count_with_link",
         "created_at",
     ]
     list_filter = ["kind", "deadline_date", "start_working_date", ResponseKindFilter]
@@ -61,12 +61,11 @@ class TenderAdmin(admin.ModelAdmin):
     ordering = ["-created_at"]
 
     autocomplete_fields = ["perimeters", "sectors", "author"]
-    readonly_fields = [
-        "nb_siae",
-        "nb_siae_email_send",
-        "nb_siae_detail_display",
-        "nb_siae_contact_click",
-        "siae_interested_list_last_seen_date",
+    readonly_fields = [field.name for field in Tender._meta.fields if field.name.endswith("_last_seen_date")] + [
+        "siae_count_with_link",
+        "siae_email_send_count_with_link",
+        "siae_detail_display_count_with_link",
+        "siae_contact_click_count_with_link",
         "logs_display",
         "created_at",
         "updated_at",
@@ -107,10 +106,10 @@ class TenderAdmin(admin.ModelAdmin):
             "Stats",
             {
                 "fields": (
-                    "nb_siae",
-                    "nb_siae_email_send",
-                    "nb_siae_detail_display",
-                    "nb_siae_contact_click",
+                    "siae_count_with_link",
+                    "siae_email_send_count_with_link",
+                    "siae_detail_display_count_with_link",
+                    "siae_contact_click_count_with_link",
                     "siae_interested_list_last_seen_date",
                     "logs_display",
                 ),
@@ -145,42 +144,42 @@ class TenderAdmin(admin.ModelAdmin):
     user_with_link.short_description = "Auteur"
     user_with_link.admin_order_field = "author"
 
-    def nb_siae(self, tender):
+    def siae_count_with_link(self, tender):
         url = reverse("admin:siaes_siae_changelist") + f"?tenders__in={tender.id}"
         return format_html(f'<a href="{url}">{getattr(tender, "siae_count", 0)}</a>')
 
-    nb_siae.short_description = "Structures concernées"
-    nb_siae.admin_order_field = "siae_count"
+    siae_count_with_link.short_description = "Structures concernées"
+    siae_count_with_link.admin_order_field = "siae_count"
 
-    def nb_siae_email_send(self, tender):
+    def siae_email_send_count_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__email_send_date__isnull=False"
         )
         return format_html(f'<a href="{url}">{getattr(tender, "siae_email_send_count", 0)}</a>')
 
-    nb_siae_email_send.short_description = "S. contactées"
-    nb_siae_email_send.admin_order_field = "siae_email_send_count"
+    siae_email_send_count_with_link.short_description = "S. contactées"
+    siae_email_send_count_with_link.admin_order_field = "siae_email_send_count"
 
-    def nb_siae_detail_display(self, tender):
+    def siae_detail_display_count_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
         )
         return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_display_count", 0)}</a>')
 
-    nb_siae_detail_display.short_description = "S. vues"
-    nb_siae_detail_display.admin_order_field = "siae_detail_display_count"
+    siae_detail_display_count_with_link.short_description = "S. vues"
+    siae_detail_display_count_with_link.admin_order_field = "siae_detail_display_count"
 
-    def nb_siae_contact_click(self, tender):
+    def siae_contact_click_count_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__contact_click_date__isnull=False"
         )
         return format_html(f'<a href="{url}">{getattr(tender, "siae_contact_click_count", 0)}</a>')
 
-    nb_siae_contact_click.short_description = "S. intéressées"
-    nb_siae_contact_click.admin_order_field = "siae_contact_click_count"
+    siae_contact_click_count_with_link.short_description = "S. intéressées"
+    siae_contact_click_count_with_link.admin_order_field = "siae_contact_click_count"
 
     def logs_display(self, tender=None):
         if tender:

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -85,7 +85,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
     form = UserChangeForm
     model = User
 
-    list_display = ["id", "first_name", "last_name", "kind", "nb_siaes", "last_login", "created_at"]
+    list_display = ["id", "first_name", "last_name", "kind", "siae_count_with_link", "last_login", "created_at"]
     list_filter = [
         "kind",
         HasSiaeFilter,
@@ -105,7 +105,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         + [f"{field}_last_updated" for field in User.TRACK_UPDATE_FIELDS]
         + [field.name for field in User._meta.fields if field.name.endswith("_last_seen_date")]
         + [
-            "nb_siaes",
+            "siae_count_with_link",
             "user_favorite_list",
             "last_login",
             "image_url",
@@ -219,14 +219,14 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         qs = qs.annotate(siae_count=Count("siaes", distinct=True))
         return qs
 
-    def nb_siaes(self, user):
+    def siae_count_with_link(self, user):
         if user.siae_count:
             url = reverse("admin:siaes_siae_changelist") + f"?users__in={user.id}"
             return format_html(f'<a href="{url}">{user.siae_count}</a>')
         return "-"
 
-    nb_siaes.short_description = "Nombre de structures"
-    nb_siaes.admin_order_field = "siae_count"
+    siae_count_with_link.short_description = "Nombre de structures"
+    siae_count_with_link.admin_order_field = "siae_count"
 
     def user_favorite_list(self, user):
         favorite_lists = user.favorite_lists.all()

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -101,15 +101,15 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
 
     # autocomplete_fields = ["siaes"]
     readonly_fields = (
-        [f"{field}_last_updated" for field in User.TRACK_UPDATE_FIELDS]
-        + [field.name for field in User._meta.fields if field.name.startswith("c4_")]
+        [field.name for field in User._meta.fields if field.name.startswith("c4_")]
+        + [f"{field}_last_updated" for field in User.TRACK_UPDATE_FIELDS]
+        + [field.name for field in User._meta.fields if field.name.endswith("_last_seen_date")]
         + [
             "nb_siaes",
             "user_favorite_list",
             "last_login",
             "image_url",
             "image_url_display",
-            "dashboard_last_seen_date",
             "created_at",
             "updated_at",
         ]


### PR DESCRIPTION
### Quoi ?

Petites améliorations sur certains champs des modèles `User`, `Siae` & `Tender`
- renommer les champs count pour plus de clareté
- mettre en readonly certains champs qui ne l'étaient pas
