### PR TITLE
Dépôt de besoin : rendre le champ 'amount' obligatoire (si 'appel d'offre')

### DIFF
--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -37,8 +37,10 @@ class AddTenderStepGeneralForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["perimeters"].to_field_name = "slug"
+        # required fields
         self.fields["sectors"].required = True
         # self.fields["perimeters"].required = True  # JS
+        # label, placeholder & help_text
         self.fields["title"].widget.attrs["placeholder"] = "Ex : Devis rénovation façade"
         self.fields["sectors"].help_text = Tender._meta.get_field("sectors").help_text  # else doesn't appear
 
@@ -54,6 +56,9 @@ class AddTenderStepGeneralForm(forms.ModelForm):
 
 
 class AddTenderStepDescriptionForm(forms.ModelForm):
+    # fields from previous step
+    kind = None
+
     class Meta:
         model = Tender
         fields = [
@@ -67,16 +72,23 @@ class AddTenderStepDescriptionForm(forms.ModelForm):
             "start_working_date": forms.widgets.DateInput(attrs={"class": "form-control", "type": "date"}),
         }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, kind, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.kind = kind
+        # required fields
         self.fields["description"].required = True
+        if self.kind == Tender.TENDER_KIND_TENDER:
+            self.fields["amount"].required = True
+        # label, placeholder & help_text
         self.fields["external_link"].widget.attrs["placeholder"] = "https://www.example.fr"
         self.fields["constraints"].widget.attrs["placeholder"] = "Ex : Déplacements"
 
 
 class AddTenderStepContactForm(forms.ModelForm):
+    # fields from previous step
     max_deadline_date = None
     external_link = None
+
     response_kind = forms.MultipleChoiceField(
         label="Comment répondre",
         choices=Tender._meta.get_field("response_kind").base_field.choices,

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -113,6 +113,8 @@ class TenderCreateMultiStepView(NotSiaeUserRequiredMixin, SessionWizardView):
 
     def get_form_kwargs(self, step):
         kwargs = super().get_form_kwargs(step)
+        if step == self.STEP_DESCRIPTION:
+            kwargs["kind"] = self.get_cleaned_data_for_step(self.STEP_GENERAL).get("kind")
         if step == self.STEP_CONTACT:
             kwargs["max_deadline_date"] = self.get_cleaned_data_for_step(self.STEP_DESCRIPTION).get(
                 "start_working_date"


### PR DESCRIPTION
### Quoi ?

Rendre le champ `Tender.amount` obligatoire dans certains cas

### Information supplémentaire

suite de https://github.com/betagouv/itou-marche/pull/422
