### PR TITLE
Dépôt de besoin : rendre le formulaire accessible aux utilisateurs anonymes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -301,6 +301,9 @@ CONTACT_EMAIL = env("CONTACT_EMAIL", default="contact@example.com")
 NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")
 
 # Transactional email templates
+# -- new user password reset
+MAILJET_NEW_USER_PASSWORD_RESET_ID = env.int("MAILJET_NEW_USER_PASSWORD_RESET_ID", 4216730)
+
 # -- user invitation emails
 MAILJET_SIAEUSERREQUEST_ASSIGNEE_TEMPLATE_ID = env.int("MAILJET_SIAEUSERREQUEST_ASSIGNEE_TEMPLATE_ID", 3658653)
 MAILJET_SIAEUSERREQUEST_INITIATOR_RESPONSE_POSITIVE_TEMPLATE_ID = env.int(

--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -28,17 +28,10 @@
                     </li>
                 </ul>
                 <p class="mb-0 mt-5">
-                    {% if user.is_authenticated %}
-                        <a href="{% url 'tenders:create' %}" id="home-demande" class="btn btn-primary btn-ico d-block d-md-inline-block mb-2">
-                            <i class="ri-mail-send-line ri-lg"></i>
-                            <span>Publier un besoin d'achat</span>
-                        </a>
-                    {% else %}
-                        <a href="#" id="home-demande-modal-btn" class="btn btn-primary btn-ico" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'tenders:create' %}">
-                            <i class="ri-mail-send-line ri-xl"></i>
-                            <span>Publier un besoin d'achat</span>
-                        </a>
-                    {% endif %}
+                    <a href="{% url 'tenders:create' %}" id="home-demande" class="btn btn-primary btn-ico d-block d-md-inline-block mb-2">
+                        <i class="ri-mail-send-line ri-lg"></i>
+                        <span>Publier un besoin d'achat</span>
+                    </a>
                     <span class="d-block d-sm-inline pl-4 py-2">ou</span>
                     <a href="{% url 'siae:search_results' %}" id="home-siae-search" class="btn btn-link btn-ico">
                         <i class="ri-search-line ri-xl"></i>

--- a/lemarche/templates/pages/home_sections/_tenders_studies_case.html
+++ b/lemarche/templates/pages/home_sections/_tenders_studies_case.html
@@ -6,17 +6,10 @@
             <div class="col-sm-6 col-md-3 my-4 my-sm-auto">
                 <h2>100% des besoins ont reçu des réponses en 24h</h2>
                 <p>Gagnez du temps en utilisant le marché.</p>
-                {% if user.is_authenticated %}
-                    <a href="{% url 'tenders:create' %}" id="home-studie-cases" class="btn btn-sm btn-primary btn-ico d-block d-md-inline-block mb-2">
-                        <i class="ri-mail-send-line"></i>
-                        <span>Publier un besoin d'achat</span>
-                    </a>
-                {% else %}
-                    <a href="#" id="home-studie-cases-modal-btn" class="btn btn-sm btn-primary btn-ico" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'tenders:create' %}">
-                        <i class="ri-mail-send-line"></i>
-                        <span>Publier un besoin d'achat</span>
-                    </a>
-                {% endif %}
+                <a href="{% url 'tenders:create' %}" id="home-studie-cases" class="btn btn-sm btn-primary btn-ico d-block d-md-inline-block mb-2">
+                    <i class="ri-mail-send-line"></i>
+                    <span>Publier un besoin d'achat</span>
+                </a>
             </div>
             <div class="col-sm-6 col-md-3 my-4 my-sm-auto">
                 <div class="card">

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -177,17 +177,10 @@
                         <p>
                             Obtenez des réponses en moins de 24 heures (en moyenne).
                         </p>
-                        {% if user.is_authenticated %}
-                            <a href="{% url 'tenders:create' %}" id="siae-search-empty-demande" class="btn btn-primary btn-ico d-block d-md-inline-block mb-2">
-                                <i class="ri-mail-send-line ri-lg"></i>
-                                <span>Publier un besoin d'achat</span>
-                            </a>
-                        {% else %}
-                            <a href="#" id="siae-search-empty-demande-modal-btn" class="btn btn-primary btn-ico" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'tenders:create' %}">
-                                <i class="ri-mail-send-line ri-xl"></i>
-                                <span>Publier un besoin d'achat</span>
-                            </a>
-                        {% endif %}
+                        <a href="{% url 'tenders:create' %}" id="siae-search-empty-demande" class="btn btn-primary btn-ico d-block d-md-inline-block mb-2">
+                            <i class="ri-mail-send-line ri-lg"></i>
+                            <span>Publier un besoin d'achat</span>
+                        </a>
                     </div>
                 {% endif %}
                 </div>

--- a/lemarche/templates/tenders/create_base.html
+++ b/lemarche/templates/tenders/create_base.html
@@ -11,8 +11,10 @@
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
+                        {% if user.is_authenticated %}
+                            <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Besoins en cours</a></li>
+                        {% endif %}
                         <li class="breadcrumb-item active" aria-current="page">Publier un besoin</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/tenders/create_step_confirmation.html
+++ b/lemarche/templates/tenders/create_step_confirmation.html
@@ -7,6 +7,14 @@
 
 {% block content_form %}
 {% include "tenders/detail_card.html" with tender=tender hide_cta="true" %}
+
+{% if not user.is_authenticated %}
+    <div class="alert alert-info" role="alert">
+        Un compte sera créé avec l'e-mail <strong>{{ tender.contact_email }}</strong>.
+        <br />
+        Il vous permettra (entre autre !) de suivre les réponses à votre besoin.
+    </div>
+{% endif %}
 {% endblock %}
 
 {% block submit_btn %}

--- a/lemarche/templates/tenders/create_step_confirmation.html
+++ b/lemarche/templates/tenders/create_step_confirmation.html
@@ -8,15 +8,6 @@
 {% block content_form %}
 {% include "tenders/detail_card.html" with tender=tender hide_cta="true" %}
 
-{% if not user.is_authenticated %}
-    <div class="alert alert-info" role="alert">
-        Un compte sera créé avec l'e-mail <strong>{{ tender.contact_email }}</strong>.
-        <br />
-        Il vous permettra (entre autre !) de suivre les réponses à votre besoin.
-    </div>
-{% endif %}
-{% endblock %}
-
 {% block submit_btn %}
 <button type="submit" id="tender-create-form-submit-btn" class="btn btn-primary btn-ico float-right">
     <i class="ri-mail-send-line ri-lg"></i>

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -113,6 +113,10 @@ class AddTenderStepContactForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.max_deadline_date = max_deadline_date
         self.external_link = external_link
+        # required fields
+        self.fields["contact_first_name"].required = True
+        self.fields["contact_last_name"].required = True
+        self.fields["contact_email"].required = True
 
     def clean(self):
         super().clean()

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -22,24 +22,21 @@ class TenderCreateViewTest(TestCase):
         cls.user_siae = UserFactory(kind=User.KIND_SIAE)
         cls.user_buyer = UserFactory(kind=User.KIND_BUYER)
 
-    def test_anonymous_user_cannot_create_tender(self):
+    def test_any_user_can_create_tender(self):
+        # anonymous
         url = reverse("tenders:create")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
-
-    def test_only_non_siae_users_can_create_tender(self):
-        # allowed
+        self.assertEqual(response.status_code, 200)
+        # buyer
         self.client.login(email=self.user_buyer.email, password=DEFAULT_PASSWORD)
         url = reverse("tenders:create")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        # not allowed
+        # siae
         self.client.login(email=self.user_siae.email, password=DEFAULT_PASSWORD)
         url = reverse("tenders:create")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/besoins/")
+        self.assertEqual(response.status_code, 200)
 
 
 class TenderMatchingTest(TestCase):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -14,6 +14,7 @@ from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
+from lemarche.www.auth.tasks import send_new_user_password_reset_link
 from lemarche.www.dashboard.mixins import TenderOwnerRequiredMixin
 from lemarche.www.tenders.forms import (
     AddTenderStepConfirmationForm,
@@ -136,6 +137,8 @@ class TenderCreateMultiStepView(SessionWizardView):
                     "kind": User.KIND_BUYER,
                 },
             )
+            if created:
+                send_new_user_password_reset_link(user)
         else:
             user = self.request.user
         # when it's done we save the tender


### PR DESCRIPTION
### Quoi ?

Il faut actuellement être connecté pour pouvoir accéder au formulaire de dépôt de besoin.
Cette PR ouvre les portes à tout le monde.

### Comment ?
