### PR TITLE
Dépôt de besoin : améliorations suite à l'accès aux utilisateurs anonymes

### DIFF
--- a/lemarche/templates/tenders/create_step_contact.html
+++ b/lemarche/templates/tenders/create_step_contact.html
@@ -11,8 +11,11 @@
         {% bootstrap_field form.contact_first_name form_group_class="form-group col-12 col-md-6" %}
         {% bootstrap_field form.contact_last_name form_group_class="form-group col-12 col-md-6" %}
     </div>
-    {% bootstrap_field form.contact_email %}
-    {% bootstrap_field form.contact_phone %}
+    {% bootstrap_field form.contact_company_name %}
+    <div class="form-row">
+        {% bootstrap_field form.contact_email form_group_class="form-group col-12 col-md-6" %}
+        {% bootstrap_field form.contact_phone form_group_class="form-group col-12 col-md-6" %}
+    </div>
     {% bootstrap_field form.response_kind %}
     {% bootstrap_field form.deadline_date %}
 </fieldset>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block modals %}
-    {% include "auth/_login_or_signup_siae_tender_modal.html" %}
+{% include "auth/_login_or_signup_siae_tender_modal.html" %}
 {% endblock %}
 
 {% block extra_js %}

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -88,12 +88,16 @@ class AddTenderStepContactForm(forms.ModelForm):
     # fields from previous step
     max_deadline_date = None
     external_link = None
+    user_is_anonymous = None
+    user_does_not_have_company_name = None
 
     response_kind = forms.MultipleChoiceField(
         label="Comment répondre",
         choices=Tender._meta.get_field("response_kind").base_field.choices,
         widget=forms.CheckboxSelectMultiple,
     )
+
+    contact_company_name = forms.CharField(label="Votre entreprise", widget=forms.HiddenInput(), required=False)
 
     class Meta:
         model = Tender
@@ -102,6 +106,7 @@ class AddTenderStepContactForm(forms.ModelForm):
             "contact_last_name",
             "contact_email",
             "contact_phone",
+            "contact_company_name",
             "response_kind",
             "deadline_date",
         ]
@@ -109,14 +114,28 @@ class AddTenderStepContactForm(forms.ModelForm):
             "deadline_date": forms.widgets.DateInput(attrs={"class": "form-control", "type": "date"}),
         }
 
-    def __init__(self, max_deadline_date, external_link, *args, **kwargs):
+    def __init__(
+        self,
+        max_deadline_date,
+        external_link,
+        user_is_anonymous=False,
+        user_does_not_have_company_name=False,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.max_deadline_date = max_deadline_date
         self.external_link = external_link
+        self.user_is_anonymous = user_is_anonymous
+        self.user_does_not_have_company_name = user_does_not_have_company_name
         # required fields
         self.fields["contact_first_name"].required = True
         self.fields["contact_last_name"].required = True
-        self.fields["contact_email"].required = True
+        if self.user_is_anonymous:
+            self.fields["contact_email"].required = True
+        if user_does_not_have_company_name:
+            self.fields["contact_company_name"].widget = forms.TextInput()
+            self.fields["contact_company_name"].required = True
 
     def clean(self):
         super().clean()

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -34,6 +34,7 @@ TITLE_KIND_SOURCING_SIAE = "Consultation en vue d’un achat"
 
 
 def create_tender_from_dict(tender_dict: dict):
+    tender_dict.pop("contact_company_name")
     perimeters = tender_dict.pop("perimeters", [])
     sectors = tender_dict.pop("sectors", [])
     tender = Tender(**tender_dict)
@@ -122,6 +123,12 @@ class TenderCreateMultiStepView(SessionWizardView):
                 "start_working_date"
             )
             kwargs["external_link"] = self.get_cleaned_data_for_step(self.STEP_DESCRIPTION).get("external_link")
+            if not self.request.user.is_authenticated:
+                kwargs["user_is_anonymous"] = True
+            if not self.request.user.is_authenticated or (
+                self.request.user.is_authenticated and not self.request.user.company_name
+            ):
+                kwargs["user_does_not_have_company_name"] = True
         return kwargs
 
     def done(self, form_list, form_dict, **kwargs):
@@ -134,6 +141,7 @@ class TenderCreateMultiStepView(SessionWizardView):
                     "first_name": cleaned_data["contact_first_name"],
                     "last_name": cleaned_data["contact_last_name"],
                     "phone": cleaned_data["contact_phone"],
+                    "company_name": cleaned_data["contact_company_name"],
                     "kind": User.KIND_BUYER,  # not necessarily true, could be a PARTNER
                     "source": User.SOURCE_TENDER_FORM,
                 },


### PR DESCRIPTION
### Quoi ?

Suite de #426 

Lors d'un dépôt de besoin, on a besoin de champs particuliers : 
- `User.company_name` est toujours nécessaire (anonyme ou pas)
- `Tender.contact_email` n'est pas obligatoire si l'utilisateur est connecté
