### PR TITLE
Admin : pour chaque utilisateur, afficher le nombre et lien vers leur dépôt de besoin

### DIFF
--- a/lemarche/fixtures/django/12_favorite_lists.json
+++ b/lemarche/fixtures/django/12_favorite_lists.json
@@ -1,0 +1,13 @@
+[
+    {
+        "model": "favorites.favoritelist",
+        "pk": 1,
+        "fields": {
+            "name": "Ma séléction",
+            "slug": "ma-selection",
+            "user": 2,
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-10-26T22:26:47.569Z"
+        }
+    }
+]

--- a/lemarche/fixtures/django/13_favorite_list_items.json
+++ b/lemarche/fixtures/django/13_favorite_list_items.json
@@ -1,0 +1,22 @@
+[
+    {
+        "model": "favorites.favoriteitem",
+        "pk": 1,
+        "fields": {
+            "favorite_list": 1,
+            "siae": 2653,
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    },
+    {
+        "model": "favorites.favoriteitem",
+        "pk": 2,
+        "fields": {
+            "favorite_list": 1,
+            "siae": 3850,
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    }
+]

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -19,6 +19,10 @@ class UserQueryset(models.QuerySet):
         """Only return users who are linked to Siae(s)."""
         return self.filter(siaes__isnull=False).distinct()
 
+    def has_tender(self):
+        """Only return users who have Tender(s)."""
+        return self.filter(tenders__isnull=False).distinct()
+
     def has_favorite_list(self):
         """Only return users who have FavoriteList(s)."""
         return self.filter(favorite_lists__isnull=False).distinct()
@@ -67,6 +71,10 @@ class UserManager(BaseUserManager):
     def has_siae(self):
         """Only return users who are linked to Siae(s)."""
         return self.get_queryset().has_siae()
+
+    def has_tender(self):
+        """Only return users who have Tender(s)."""
+        return self.get_queryset().has_tender()
 
     def has_favorite_list(self):
         """Only return users who have FavoriteList(s)."""

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -2,13 +2,15 @@ from django.test import TestCase
 
 from lemarche.favorites.factories import FavoriteListFactory
 from lemarche.siaes.factories import SiaeFactory
+from lemarche.tenders.factories import TenderFactory
 from lemarche.users.factories import UserFactory
 from lemarche.users.models import User
 
 
 class UserModelTest(TestCase):
-    def setUp(self):
-        pass
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
 
     def test_str(self):
         user = UserFactory(email="coucou@example.com")
@@ -19,22 +21,25 @@ class UserModelTest(TestCase):
         self.assertEqual(user.full_name, "Paul Anploi")
 
     def test_has_siae_queryset(self):
-        UserFactory()
         user = UserFactory()
         siae = SiaeFactory()
         siae.users.add(user)
         self.assertEqual(User.objects.count(), 2)
         self.assertEqual(User.objects.has_siae().count(), 1)
 
+    def test_has_tender_queryset(self):
+        user = UserFactory()
+        TenderFactory(author=user)
+        self.assertEqual(User.objects.count(), 2)
+        self.assertEqual(User.objects.has_tender().count(), 1)
+
     def test_has_favorite_list_queryset(self):
-        UserFactory()
         user = UserFactory()
         FavoriteListFactory(user=user)
         self.assertEqual(User.objects.count(), 2)
         self.assertEqual(User.objects.has_favorite_list().count(), 1)
 
     def test_with_api_key_queryset(self):
-        UserFactory()
         UserFactory(api_key="coucou")
         self.assertEqual(User.objects.count(), 2)
         self.assertEqual(User.objects.with_api_key().count(), 1)


### PR DESCRIPTION
### Quoi ?

Dans l'admin, sur la liste des utilisateurs, avoir le `tender_count` par utilisateur (comme on a le `siae_count` actuellement)