### PR TITLE
Admin : avoir accès aux besoins concernés par chaque structure

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -83,6 +83,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "label_count_with_link",
         "client_reference_count_with_link",
         "image_count_with_link",
+        "tender_count_with_link",
         "created_at",
     ]
     list_filter = [
@@ -112,6 +113,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "coords_display",
         "logo_url",
         "logo_url_display",
+        "tender_count_with_link",
         "signup_date",
         "content_filled_basic_date",
         # "import_raw_object",
@@ -215,6 +217,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
                 )
             },
         ),
+        ("Besoins des acheteurs", {"fields": ("tender_count_with_link",)}),
         (
             "Stats",
             {
@@ -301,6 +304,11 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
             },
         ),
     ]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.with_tender_stats()
+        return qs
 
     def get_readonly_fields(self, request, obj=None):
         """
@@ -417,6 +425,13 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         return "-"
 
     import_raw_object_display.short_description = "Donnée brute importée"
+
+    def tender_count_with_link(self, siae):
+        url = reverse("admin:tenders_tender_changelist") + f"?siaes__in={siae.id}"
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_count", 0)}</a>')
+
+    tender_count_with_link.short_description = "Besoins concernées"
+    tender_count_with_link.admin_order_field = "tender_count"
 
 
 @admin.register(SiaeUserRequest, site=admin_site)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -323,6 +323,14 @@ class SiaeQuerySet(models.QuerySet):
         # return
         return qs.distinct()
 
+    def with_tender_stats(self):
+        """
+        Enrich each Siae with stats on their linked Tender
+        """
+        return self.annotate(
+            tender_count=Count("tenders", distinct=True),
+        )
+
 
 class Siae(models.Model):
     READONLY_FIELDS_FROM_C1 = [


### PR DESCRIPTION
### Quoi ?

Dans l'admin, sur une fiche structure, avoir accès au nombre et à la liste des besoins concernés
