### PR TITLE
Dépôt de besoin : rajouter une confirmation pour les structures intéressées par un besoin

### DIFF
--- a/lemarche/templates/tenders/_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_contact_click_confirm_modal.html
@@ -1,0 +1,24 @@
+<div class="modal fade modal-siae" id="contact_click_confirm_modal" tabindex="-1" role="dialog" aria-modal="true" data-backdrop="static" data-keyboard="false" aria-labelledby="modalTitle">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="modalTitle">Signaler votre intérêt à l'acheteur ?</h3>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fermer">
+                    <i class="ri-close-line"></i>
+                </button>
+            </div>
+            <form method="POST" action="{% url 'tenders:detail-contact-click-stat' tender.slug %}">
+                {% csrf_token %}
+                <div class="modal-body home-content-body">
+                    <p>
+                        Pour répondre à cette opportunité, vous devez signaler votre intérêt à l'acheteur.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-sm btn-link" name="contact_click_confirm" value="false">Non</button>
+                    <button type="submit" class="btn btn-sm btn-primary" name="contact_click_confirm" value="true">Oui</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -37,28 +37,5 @@
 
 {% block modals %}
 {% include "auth/_login_or_signup_siae_tender_modal.html" %}
-{% endblock %}
-
-{% block extra_js %}
-<script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function() {
-    var tenderContactCollapseButton = document.getElementById('show-tender-contact-btn');
-    var tenderContactCollapseContent = document.getElementById('show-tender-contact-content');
-    if (tenderContactCollapseButton) {
-        tenderContactCollapseButton.addEventListener('click', function() {
-            // hide button, show content
-            tenderContactCollapseButton.style.display = 'none';
-            tenderContactCollapseContent.style.display = '';
-            // send click stat to backend
-            fetch(`${window.location.href}/contact-click-stat`, {
-                method: 'POST',
-                headers: {
-                    'X-CSRFToken': '{{ csrf_token }}'
-                },
-                body: JSON.stringify({}),
-            });
-        });
-    }
-});
-</script>
+{% include "tenders/_contact_click_confirm_modal.html" %}
 {% endblock %}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -72,7 +72,7 @@
                 {% if tender.author == request.user or user_has_contact_click_date %}
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% else %}
-                    <button type="button" id="show-tender-contact-btn" class="btn btn-primary float-right mb-4" style="display:block">
+                    <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#contact_click_confirm_modal" title="Répondre à cette opportunité">
                         Répondre à cette opportunité
                     </button>
                     <div id="show-tender-contact-content" class="py-2" style="display:none">

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -119,6 +119,7 @@ class SiaeSearchForm(forms.Form):
         if networks:
             qs = qs.filter_networks(networks)
 
+        # un auteur d'un dépôt de besoin peut exporter la liste des structures intéressées
         tender = self.cleaned_data.get("tender", None)
         if tender:
             qs = qs.filter(tendersiae__tender=tender, tendersiae__contact_click_date__isnull=False)

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -35,7 +35,7 @@ def send_tender_emails_to_siaes(tender: Tender):
     for siae in tender.siaes.all():
         send_tender_email_to_siae(tender, siae)
 
-    tender.tendersiae_set.update(email_send_date=timezone.now())
+    tender.tendersiae_set.update(email_send_date=timezone.now(), updated_at=timezone.now())
     # will be moved on global action in backoffice admin
     match_tender_for_partners(tender=tender, send_email_func=send_tender_email_to_partner)
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -309,7 +309,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
     def get_success_message(self, contact_click_confirm):
         if contact_click_confirm:
             return "<strong>Bravo !</strong><br />Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur. Assurez-vous d'avoir une fiche commerciale bien renseignée."  # noqa
-        return "<strong>Répondre au besoin</strong><br />Pour répondre au besoin, vous devez accepter d'être mis en relation avec l'acheteur depuis le marché."  # noqa
+        return "<strong>Répondre à cette opportunité</strong><br />Pour répondre à cette opportunité, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
 
 
 class TenderSiaeInterestedListView(TenderOwnerRequiredMixin, ListView):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -244,7 +244,7 @@ class TenderDetailView(DetailView):
             tender = self.get_object()
             TenderSiae.objects.filter(
                 tender=tender, siae__in=user.siaes.all(), detail_display_date__isnull=True
-            ).update(detail_display_date=timezone.now())
+            ).update(detail_display_date=timezone.now(), updated_at=timezone.now())
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -292,7 +292,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
                 tender = self.get_object()
                 TenderSiae.objects.filter(
                     tender=tender, siae__in=self.request.user.siaes.all(), contact_click_date__isnull=True
-                ).update(contact_click_date=timezone.now())
+                ).update(contact_click_date=timezone.now(), updated_at=timezone.now())
                 # notify the tender author
                 send_siae_interested_email_to_author(tender)
                 # redirect

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -2,12 +2,12 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
-from django.http import HttpResponseForbidden, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django.views.generic import DetailView, ListView, View
+from django.views.generic import DetailView, ListView, UpdateView
 from formtools.wizard.views import SessionWizardView
 
 from lemarche.tenders import constants as tender_constants
@@ -272,26 +272,44 @@ class TenderDetailView(DetailView):
         return context
 
 
-class TenderDetailContactClickStat(LoginRequiredMixin, View):
+class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
     """
     Endpoint to track contact_clicks by interested Siaes
     We might also send a notification to the buyer
     """
 
+    template_name = "tenders/_contact_click_confirm_modal.html"
+    model = Tender
+
     def get_object(self):
         return get_object_or_404(Tender, slug=self.kwargs.get("slug"))
 
     def post(self, request, *args, **kwargs):
+        contact_click_confirm = self.request.POST.get("contact_click_confirm", False) == "true"
         if self.request.user.kind == User.KIND_SIAE:
-            # update contact_click_date
-            tender = self.get_object()
-            TenderSiae.objects.filter(
-                tender=tender, siae__in=self.request.user.siaes.all(), contact_click_date__isnull=True
-            ).update(contact_click_date=timezone.now())
-            send_siae_interested_email_to_author(tender)
-            return JsonResponse({"message": "success"})
+            if contact_click_confirm:
+                # update contact_click_date
+                tender = self.get_object()
+                TenderSiae.objects.filter(
+                    tender=tender, siae__in=self.request.user.siaes.all(), contact_click_date__isnull=True
+                ).update(contact_click_date=timezone.now())
+                # notify the tender author
+                send_siae_interested_email_to_author(tender)
+                # redirect
+                messages.add_message(self.request, messages.SUCCESS, self.get_success_message(contact_click_confirm))
+            else:
+                messages.add_message(self.request, messages.WARNING, self.get_success_message(contact_click_confirm))
+            return HttpResponseRedirect(self.get_success_url())
         else:
             return HttpResponseForbidden()
+
+    def get_success_url(self):
+        return reverse_lazy("tenders:detail", args=[self.kwargs.get("slug")])
+
+    def get_success_message(self, contact_click_confirm):
+        if contact_click_confirm:
+            return "<strong>Bravo !</strong><br />Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur. Assurez-vous d'avoir une fiche commerciale bien renseignée."  # noqa
+        return "<strong>Répondre au besoin</strong><br />Pour répondre au besoin, vous devez accepter d'être mis en relation avec l'acheteur depuis le marché."  # noqa
 
 
 class TenderSiaeInterestedListView(TenderOwnerRequiredMixin, ListView):


### PR DESCRIPTION
### Quoi ?

Permettre à une structure de confirmer son intérêt pour un besoin, à travers une modale.

v2 de https://github.com/betagouv/itou-marche/pull/447 (simplification et clarification)

### Pourquoi ?

Rajouter un peu de friction pour augmenter le nombre de mises en relation "pertinentes".

### Captures d'écran (optionnel)


