### PR TITLE
API : enlever les référence au CMS

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -517,6 +517,7 @@ SPECTACULAR_SETTINGS = {
         "name": "Une question ? Contactez-nous via notre formulaire",
         "url": "https://lemarche.inclusion.beta.gouv.fr/contact/",
     },
+    "PREPROCESSING_HOOKS": ["lemarche.api.utils.custom_preprocessing_hook"],
     "ENUM_NAME_OVERRIDES": {
         "kind": "lemarche.siaes.models.Siae.KIND_CHOICES",
         "department": "lemarche.siaes.models.Siae.DEPARTMENT_CHOICES",

--- a/lemarche/api/utils.py
+++ b/lemarche/api/utils.py
@@ -20,3 +20,16 @@ def check_user_token(token):
         return User.objects.get(api_key=token)
     except (User.DoesNotExist, AssertionError):
         raise Unauthorized
+
+
+def custom_preprocessing_hook(endpoints):
+    """
+    Only show /api/* in the generated documentation
+    Helps to filter out /cms/* stuff
+    https://github.com/tfranzel/drf-spectacular/issues/655
+    """
+    filtered = []
+    for (path, path_regex, method, callback) in endpoints:
+        if path.startswith("/api/"):
+            filtered.append((path, path_regex, method, callback))
+    return filtered


### PR DESCRIPTION
### Quoi ?

Le CMS est un usage interne, les endoint ne devraient pas être visible dans la doc de l'API

https://github.com/tfranzel/drf-spectacular/issues/655
