### PR TITLE
Dépôt de besoin : mieux filtrer les besoins affichés aux structures

### DIFF
--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -34,6 +34,12 @@ class SiaeFactory(DjangoModelFactory):
     contact_email = factory.Sequence("email{0}@example.com".format)
 
     @factory.post_generation
+    def users(self, create, extracted, **kwargs):
+        if extracted:
+            # Add the iterable of groups using bulk addition
+            self.users.add(*extracted)
+
+    @factory.post_generation
     def sectors(self, create, extracted, **kwargs):
         if extracted:
             # Add the iterable of groups using bulk addition

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -1,5 +1,5 @@
-import datetime
 import random
+from datetime import date, timedelta
 
 import factory.fuzzy
 from django.utils import timezone
@@ -24,7 +24,7 @@ class TenderFactory(DjangoModelFactory):
     )
     description = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
     constraints = factory.Faker("paragraph", nb_sentences=5, locale="fr_FR")
-    deadline_date = datetime.date.today() + datetime.timedelta(days=10)
+    deadline_date = date.today() + timedelta(days=10)
     author = factory.SubFactory(UserFactory)
     validated_at = timezone.now()
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -1,4 +1,5 @@
 # import datetime
+from datetime import timedelta
 from importlib import import_module
 from random import randint
 
@@ -35,12 +36,12 @@ class TenderModelTest(TestCase):
     # def test_deadline_start_before_today(self):
     #     today = datetime.date.today()
     #     tender = TenderFactory()
-    #     tender.deadline_date = today - datetime.timedelta(days=1)
+    #     tender.deadline_date = today - timedelta(days=1)
     #     self.assertNotRaises(ValidationError, tender.clean)
 
     # def test_deadline_start_after_start_working_date(self):
     #     tender = TenderFactory()
-    #     tender.start_working_date = tender.deadline_date - datetime.timedelta(days=1)
+    #     tender.start_working_date = tender.deadline_date - timedelta(days=1)
     #     self.assertRaises(ValidationError, tender.clean)
 
     def test_not_empty_deadline(self):
@@ -58,6 +59,17 @@ class TenderModelQuerysetTest(TestCase):
         TenderFactory(author=user)
         TenderFactory()
         self.assertEqual(Tender.objects.by_user(user).count(), 1)
+
+    def test_validated_queryset(self):
+        TenderFactory(validated_at=timezone.now())
+        TenderFactory(validated_at=None)
+        self.assertEqual(Tender.objects.validated().count(), 1)
+
+    def test_is_live_queryset(self):
+        TenderFactory(deadline_date=timezone.now() + timedelta(days=1))
+        TenderFactory(deadline_date=timezone.now() - timedelta(days=1))
+        # TenderFactory(deadline_date=None)  # cannot be None
+        self.assertEqual(Tender.objects.is_live().count(), 1)
 
     def test_in_sectors_queryset(self):
         sector_1 = SectorFactory(name="Un secteur")

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -98,8 +98,7 @@ class DashboardHomeView(LoginRequiredMixin, DetailView):
         if r_user.kind == User.KIND_SIAE:
             siaes = r_user.siaes.all()
             if siaes:
-                # context["last_3_tenders"] = Tender.objects.filter_with_siae(siaes).is_live()[:3]
-                context["last_3_tenders"] = Tender.objects.filter(tendersiae__siae__in=siaes).is_live().distinct()[:3]
+                context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes)[:3]
         else:
             context["last_3_tenders"] = Tender.objects.filter(author=r_user)[:3]
             context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -117,17 +117,12 @@ class TenderMatchingTest(TestCase):
         siae.sectors.add(self.sectors[0])
         siae_found_list_marseille = Siae.objects.filter_with_tender(tender_marseille)
         self.assertEqual(len(siae_found_list_marseille), 1)
-        opportunities_for_siae = Tender.objects.filter_with_siae(siae_found_list_marseille[:1])
-        #
-        self.assertEqual(len(opportunities_for_siae), 1)
 
     def test_with_no_contact_email(self):
         tender = TenderFactory(sectors=self.sectors, perimeters=self.perimeters)
-        siae = SiaeFactory(is_active=True, geo_range=GEO_RANGE_COUNTRY, contact_email="", sectors=[self.sectors[0]])
+        SiaeFactory(is_active=True, geo_range=GEO_RANGE_COUNTRY, contact_email="", sectors=[self.sectors[0]])
         siae_found_list = Siae.objects.filter_with_tender(tender)
         self.assertEqual(len(siae_found_list), 2 + 0)
-        opportunities_for_siae = Tender.objects.filter_with_siae([siae])
-        self.assertEqual(len(opportunities_for_siae), 1)
 
     # def test_number_queries(self):
     #     tender = TenderFactory(sectors=self.sectors)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -208,7 +208,7 @@ class TenderListView(LoginRequiredMixin, ListView):
             # TODO: manage many siaes
             siaes = user.siaes.all()
             if siaes:
-                queryset = Tender.objects.filter_with_siae(siaes).is_live()
+                queryset = Tender.objects.filter_with_siaes(siaes)
         else:
             queryset = Tender.objects.by_user(user).with_siae_stats()
         return queryset


### PR DESCRIPTION
### Quoi ?

Suite au hotfix : https://github.com/betagouv/itou-marche/commit/faf73ae9b70b2fe00d985c3885cce267da977601 / #382
- cleanup de `Tender.objects.filter_with_siaes()`
- ajout de tests
