### PR TITLE
Dépôt de besoin : ajustement sur la recherche par périmètre

### DIFF
--- a/lemarche/perimeters/models.py
+++ b/lemarche/perimeters/models.py
@@ -24,12 +24,15 @@ class Perimeter(models.Model):
     REGION_CHOICES = REGIONS.items()
 
     name = models.CharField(verbose_name="Nom", max_length=255, db_index=True)
-    # Note for CITIES: we add the department_code at the end to avoid duplicates
-    # Note for REGIONS: some have the same name as a DEPARTMENT. So we add '-region' at their end
+
+    # Note for cities: we add the department_code at the end to avoid duplicates
+    # Note for regions: some have the same name as a DEPARTMENT. So we add '-region' at their end
     slug = models.SlugField(verbose_name="Slug", max_length=255, unique=True)
 
-    kind = models.CharField(verbose_name="Type de périmètre", max_length=20, choices=KIND_CHOICES)
-    # Note: REGION insee_codes are prefixed with a 'R' to avoid conflicts with DEPARTMENT
+    kind = models.CharField(verbose_name="Type de périmètre", choices=KIND_CHOICES, max_length=20)
+
+    # Note for departments: expects DEPARTMENT_CHOICES
+    # Note for regions: expects REGION_CHOICES, but prefixed with a 'R' to avoid conflicts with DEPARTMENT_CHOICES
     insee_code = models.CharField(verbose_name="Code INSEE", max_length=5, unique=True)
 
     # only for cities

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -44,9 +44,7 @@ GEO_RANGE_COUNTRY = "COUNTRY"
 
 
 def get_filter_city(perimeter, with_country=False):
-    filters = Q(post_code__in=perimeter.post_codes) | (
-        Q(geo_range=GEO_RANGE_DEPARTMENT) & Q(department=perimeter.department_code)
-    )
+    filters = Q(post_code__in=perimeter.post_codes) | Q(department=perimeter.department_code)
     if perimeter.coords:
         filters |= (
             Q(geo_range=GEO_RANGE_CUSTOM)

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -385,47 +385,47 @@ class SiaePerimeterSearchFilterTest(TestCase):
     def test_search_perimeter_city(self):
         """
         We should return:
-        - all the Siae exactly in this city+department (4 SIAE)
-        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (2 SIAE: Grenoble & La Tronche. Chamrousse is outside)  # noqa
-        + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department=38 (1 SIAE)
+        - all the Siae exactly in the city - Grenoble (4 Siae)
+        + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
+        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 new Siae: La Tronche. Chamrousse is outside)  # noqa
         """
         form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter.slug]})
         self.assertTrue(form.is_valid())
         qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 2 + 2 + 1)
+        self.assertEqual(qs.count(), 4 + 0 + 1)
 
     def test_search_perimeter_city_2(self):
         """
         We should return:
-        - all the Siae exactly in this city+department (1 SIAE)
-        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 SIAE: Chamrousse. Grenoble & La Tronche are outside)  # noqa
-        + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department=38 (1 SIAE)
+        - all the Siae exactly in the city - Chamrousse (1 Siae)
+        + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (3 new Siae)
+        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 Siae, 0 new: Chamrousse. Grenoble & La Tronche are outside)  # noqa
         """
         form = SiaeSearchForm({"perimeters": [self.chamrousse_perimeter]})
         qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 0 + 1 + 1)
+        self.assertEqual(qs.count(), 1 + 3 + 0)
 
     def test_search_perimeter_multiperimeter_1(self):
         """
         We should return:
-        - all the Siae exactly in this city+department of Grenoble or Chamrousse (2 SIAE)
-        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Chamrousse (2 SIAE) # noqa
-        + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department of Grenoble or chamrousse (2 SIAE)
+        - all the Siae exactly in these cities - Grenoble & Chamrousse (4 + 1 Siae)
+        + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
+        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Chamrousse (2 Siae, 1 new) # noqa
         """
         form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter, self.chamrousse_perimeter]})
         qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 2 + 2 + 2)
+        self.assertEqual(qs.count(), 5 + 0 + 1)
 
     def test_search_perimeter_multiperimeter_2(self):
         """
         We should return:
-        - all the Siae exactly in this city+department of Grenoble or quimper (2 SIAE)
-        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Quimper (2 SIAE) # noqa
-        + all the Siae with geo_range=GEO_RANGE_DEPARTMENT + department of Grenoble or Quimper (3 SIAE)
+        - all the Siae exactly in these cities - Grenoble & Quimper (4 + 4)
+        + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere & 29 (0 new Siae)
+        + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Quimper (1 new Siae) # noqa
         """
         form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter, self.quimper_perimeter]})
         qs = form.filter_queryset()
-        self.assertEqual(qs.count(), 2 + 2 + 3)
+        self.assertEqual(qs.count(), 8 + 0 + 1)
 
     def test_search_perimeter_multiperimeter_error(self):
         """


### PR DESCRIPTION
### Quoi ?

Lorsqu'une recherche par ville est effectuée, on renvoye maintenant aussi toutes les structures dans le même département
