### PR TITLE
Page détail : changer le CTA vers les partenaires

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -887,7 +887,7 @@ class Siae(models.Model):
 
     @property
     def kind_is_esat_or_ea(self):
-        return (self.kind == Siae.KIND_ESAT) or (self.kind == Siae.KIND_EA)
+        return self.kind in [Siae.KIND_ESAT, Siae.KIND_EA]
 
     @property
     def completion_percent(self):

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -886,6 +886,10 @@ class Siae(models.Model):
             return "l'ASP"
 
     @property
+    def kind_is_esat_or_ea(self):
+        return (self.kind == Siae.KIND_ESAT) or (self.kind == Siae.KIND_EA)
+
+    @property
     def completion_percent(self):
         score, total = 0, 0
         for key, value in SIAE_COMPLETION_SCORE_GRID.items():

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -91,6 +91,14 @@ class SiaeModelTest(TestCase):
         siae_full_2.save()  # to update stats
         self.assertFalse(siae_full_2.is_missing_content)
 
+    def test_kind_is_esat_or_ea_property(self):
+        siae_esat = SiaeFactory(kind=Siae.KIND_ESAT)
+        self.assertTrue(siae_esat.kind_is_esat_or_ea)
+        siae_ea = SiaeFactory(kind=Siae.KIND_EA)
+        self.assertTrue(siae_ea.kind_is_esat_or_ea)
+        siae_ei = SiaeFactory(kind=Siae.KIND_EI)
+        self.assertFalse(siae_ei.kind_is_esat_or_ea)
+
 
 class SiaeModelSaveTest(TestCase):
     def setUp(self):

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -1,7 +1,9 @@
+{% load wagtailcore_tags %}
+
 <h2 class="h3 my-3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
 
 {% if siae.kind_is_esat_or_ea %}
-    <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+    <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
 {% else %}
     <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
 {% endif %}

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -3,7 +3,7 @@
 <h2 class="h3 my-3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
 
 {% if siae.kind_is_esat_or_ea %}
-    <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+    <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" id="track_siae_detail_partners_esat_ea" class="btn btn-outline-primary">Découvrez-les maintenant</a>
 {% else %}
     <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
 {% endif %}

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -1,0 +1,7 @@
+<h2 class="h3 my-3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
+
+{% if siae.kind_is_esat_or_ea %}
+    <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+{% else %}
+    <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+{% endif %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -234,8 +234,7 @@
                     </div>
                     <div class="partners d-none d-lg-block">
                         <div class="si-separator"></div>
-                        <h2 class="h3 my-3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
-                        <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+                        {% include "siaes/_detail_partner_cta.html" with siae=siae %}
                     </div>
                 </aside>
 
@@ -438,8 +437,7 @@
         <div class="row partners-md d-lg-none">
             <div class="col-12">
                 <hr />
-                <h3 class="h3 my-3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h3>
-                <a href="{% url 'pages:partenaires' %}" id="track_siae_detail_partners" class="btn btn-outline-primary">Découvrez-les maintenant</a>
+                {% include "siaes/_detail_partner_cta.html" with siae=siae %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Quoi ?

Sur la page détail d'une fiche, modification du CTA qui pointe vers les partenaires : 
- le mettre dans son propre template
- pointer vers un autre lien si la structure est une ESAT ou EA
