### PR TITLE
Dépôt de besoin : séparer l'envoi d'emails aux Structures et aux Partenaires

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -11,7 +11,11 @@ from lemarche.perimeters.admin import PerimeterRegionFilter
 from lemarche.tenders.forms import TenderAdminForm
 from lemarche.tenders.models import PartnerShareTender, Tender
 from lemarche.utils.fields import pretty_print_readonly_jsonfield
-from lemarche.www.tenders.tasks import send_confirmation_published_email_to_author, send_tender_emails_to_siaes
+from lemarche.www.tenders.tasks import (
+    send_confirmation_published_email_to_author,
+    send_tender_emails_to_partners,
+    send_tender_emails_to_siaes,
+)
 
 
 class ResponseKindFilter(admin.SimpleListFilter):
@@ -33,9 +37,10 @@ def update_and_send_tender_task(tender: Tender):
     tender.validated_at = datetime.now()
     tender.save()
     # 2) find the matching Siaes? done in Tender post_save signal
-    # 3) send the tender to all matching Siaes
-    send_tender_emails_to_siaes(tender)
     send_confirmation_published_email_to_author(tender, nb_matched_siaes=tender.siaes.count())
+    # 3) send the tender to all matching Siaes & Partners
+    send_tender_emails_to_siaes(tender)
+    send_tender_emails_to_partners(tender)
 
 
 @admin.register(Tender, site=admin_site)

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -17,10 +17,9 @@ from lemarche.siaes.factories import SiaeFactory
 from lemarche.siaes.models import Siae
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.factories import PartnerShareTenderFactory, TenderFactory
-from lemarche.tenders.models import Tender, TenderSiae
+from lemarche.tenders.models import PartnerShareTender, Tender, TenderSiae
 from lemarche.users.factories import UserFactory
 from lemarche.users.models import User
-from lemarche.www.tenders.tasks import match_tender_for_partners
 
 
 class TenderModelTest(TestCase):
@@ -286,39 +285,39 @@ class TenderPartnerMatchingTest(TestCase):
     def test_tender_country_matching(self):
         # partners with perimeters=[]
         tender = TenderFactory(is_country_area=True)
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4)
 
     def test_tender_perimeters_matching(self):
         # partners with perimeters=[] + aura
         tender = TenderFactory(perimeters=[self.auvergne_rhone_alpes_perimeter])
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4 + 1)
         # partners with perimeters=[] + isere + aura
         tender = TenderFactory(perimeters=[self.rhone_perimeter])
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4 + 1 + 1)
         # partners with perimeters=[] + isere/rhone + aura
         tender = TenderFactory(perimeters=[self.isere_perimeter, self.rhone_perimeter])
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4 + 2 + 1)
         # partners with perimeters=[] + grenoble + isere/rhone + aura
         tender = TenderFactory(perimeters=[self.grenoble_perimeter])
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4 + 1 + 2 + 1)
 
     def test_tender_country_and_amount_matching(self):
         # partners with perimeters=[] & (amount_in empty or >=AMOUNT_RANGE_0_1)
         tender = TenderFactory(is_country_area=True, amount=tender_constants.AMOUNT_RANGE_0_1)
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 4)
         # partners with perimeters=[] & (amount_in empty or >=AMOUNT_RANGE_10_15)
         tender = TenderFactory(is_country_area=True, amount=tender_constants.AMOUNT_RANGE_10_15)
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 3)
         # partners with perimeters=[] & (amount_in empty or >=AMOUNT_RANGE_1000_MORE)
         tender = TenderFactory(is_country_area=True, amount=tender_constants.AMOUNT_RANGE_1000_MORE)
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 1)
 
     def test_tender_perimeters_and_amount_matching(self):
@@ -326,9 +325,9 @@ class TenderPartnerMatchingTest(TestCase):
         tender = TenderFactory(
             perimeters=[self.auvergne_rhone_alpes_perimeter], amount=tender_constants.AMOUNT_RANGE_0_1
         )
-        result = match_tender_for_partners(tender)
+        result = PartnerShareTender.objects.filter_by_tender(tender)
         self.assertEqual(len(result), 2 + 3)
         # partners with (perimeters=[] or isere overlap) & (amount_in empty or >=AMOUNT_RANGE_10_15)
         tender_3 = TenderFactory(perimeters=[self.isere_perimeter], amount=tender_constants.AMOUNT_RANGE_10_15)
-        result = match_tender_for_partners(tender_3)
+        result = PartnerShareTender.objects.filter_by_tender(tender_3)
         self.assertEqual(len(result), 3 + 3)

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -9,24 +9,6 @@ from lemarche.utils.emails import EMAIL_SUBJECT_PREFIX, send_mail_async, whiteli
 from lemarche.utils.urls import get_admin_url_object, get_share_url_object
 
 
-def match_tender_for_partners(tender: Tender, send_email_func=None):
-    """Manage the matching from tender to partners
-
-    Args:
-        tender (Tender): _description_
-        send_email_func : function which takes two arguments tender, and dict of partner (see PARTNERS_FILTERS)
-
-    Returns:
-        list<Dict>: list of partners
-    """
-    partners = PartnerShareTender.objects.filter_by_tender(tender)
-    for partner in partners:
-        if send_email_func:
-            send_email_func(tender, partner)
-
-    return partners
-
-
 # @task()
 def send_tender_emails_to_siaes(tender: Tender):
     """
@@ -36,8 +18,15 @@ def send_tender_emails_to_siaes(tender: Tender):
         send_tender_email_to_siae(tender, siae)
 
     tender.tendersiae_set.update(email_send_date=timezone.now(), updated_at=timezone.now())
-    # will be moved on global action in backoffice admin
-    match_tender_for_partners(tender=tender, send_email_func=send_tender_email_to_partner)
+
+
+def send_tender_emails_to_partners(tender: Tender):
+    """
+    All corresponding partners (PartnerShareTender) will be contacted
+    """
+    partners = PartnerShareTender.objects.filter_by_tender(tender)
+    for partner in partners:
+        send_tender_email_to_partner(tender, partner)
 
 
 def send_tender_email_to_partner(tender: Tender, partner: PartnerShareTender):


### PR DESCRIPTION
### Quoi ?

Cleanup pour bien séparer `send_tender_emails_to_siaes()` & `send_tender_emails_to_partners()`
