### PR TITLE
Dépôt de besoin : envoyer le TENDER_TITLE dans les variables des emails

### DIFF
--- a/lemarche/templates/tenders/create_notification_email_admin_body.txt
+++ b/lemarche/templates/tenders/create_notification_email_admin_body.txt
@@ -3,8 +3,8 @@ Le marché de l'inclusion (C4) : dépôt de besoin, ajout d'un nouveau {{ tender
 ---
 titre : {{ tender_title|safe }}
 type : {{ tender_kind|safe }}
-contact : {{ tender_contact|safe }}
-entreprise : {{ tender_company|safe }}
+contact : {{ tender_author_full_name|safe }}
+entreprise : {{ tender_author_company|safe }}
 ---
 
 Lien dans l'admin : {{ tender_admin_url }}

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -63,6 +63,7 @@ def send_tender_email_to_partner(tender: Tender, partner: PartnerShareTender):
     recipient_list = whitelist_recipient_list(partner.contact_email_list)
     if recipient_list:
         variables = {
+            "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_SECTORS": tender.sectors_list_string,
             "TENDER_PERIMETERS": tender.perimeters_list_string,
@@ -139,6 +140,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae):
             "SIAE_CONTACT_FIRST_NAME": siae.contact_first_name,
             "SIAE_SECTORS": siae.sectors_list_string,
             "SIAE_PERIMETER": siae.geo_range_pretty_display,
+            "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string,

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -257,8 +257,8 @@ def notify_admin_tender_created(tender: Tender):
             "tender_id": tender.id,
             "tender_title": tender.title,
             "tender_kind": tender.get_kind_display(),
-            "tender_contact": tender.contact_full_name,
-            "tender_company": tender.author.company_name,
+            "tender_author_full_name": tender.contact_full_name,
+            "tender_author_company": tender.author.company_name,
             "tender_admin_url": tender_admin_url,
         },
     )


### PR DESCRIPTION
### Quoi ?

voir titre

### Pourquoi ?

Pour pouvoir afficher le titre du besoin dans les emails
