### PR TITLE
Permettre saut de ligne dans le champ “Contrainte technique”

### DIFF
--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -51,7 +51,7 @@
 
         <div class="py-2">
             <h2>Contraintes techniques spécifiques</h2>
-            <p>{{ tender.constraints|default:"-" }}</p>
+            <p>{{ tender.constraints|default:"-"|linebreaks }}</p>
         </div>
 
         {% if source_form or tender.author == request.user or tender.accept_share_amount %}


### PR DESCRIPTION
### Quoi ?

Permettre saut de ligne dans le champ “Contrainte technique”.

### Pourquoi ?

Pour plus de clarté.
