### PR TITLE
Afficher 20 ESI sur la carte suite à une recherche

### DIFF
--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -167,7 +167,7 @@
                     {% for siae in siaes %}
                         {% include "siaes/_card_search_result.html" with siae=siae %}
                         <!-- insert to nudge tender creation -->
-                        {% if forloop.counter == 5 and page_obj.number == 1 %}
+                        {% if forloop.counter in position_promote_tenders and page_obj.number == 1 %}
                             {% include "siaes/_card_suggest_tender.html" %}
                         {% endif %}
                     {% endfor %}

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -33,7 +33,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
     form_class = SiaeSearchForm
     # queryset = Siae.objects.all()
     context_object_name = "siaes"
-    paginate_by = 10
+    paginate_by = 20
     paginator_class = Paginator
 
     def get_queryset(self):
@@ -56,6 +56,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         - set the paginator range
         """
         context = super().get_context_data(**kwargs)
+        context["position_promote_tenders"] = [5, 15]
         if len(self.request.GET.keys()):
             siae_search_form = self.filter_form if self.filter_form else SiaeSearchForm(data=self.request.GET)
             context["form"] = siae_search_form


### PR DESCRIPTION
### Quoi ?

Afficher 20 ESI sur la carte suite à une recherche.

### Pourquoi ?

Pour répondre à la demande des utilisateurs, avoir plus de contenu sans recharge.
