### PR TITLE
Dépôt de besoin : améliorer la génération du slug

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -271,7 +271,7 @@ class Tender(models.Model):
         The slug field should be unique.
         """
         if not self.slug:
-            self.slug = f"{slugify(self.title)[:40]}-{str(self.author.company_name or '')}"
+            self.slug = slugify(f"{self.title}-{str(self.author.company_name or '')}")[:40]
         if with_uuid:
             self.slug += f"-{str(uuid4())[:4]}"
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -31,6 +31,18 @@ class TenderModelTest(TestCase):
         tender = TenderFactory(title=str_test)
         self.assertEqual(str(tender), str_test)
 
+    def test_set_slug(self):
+        tender = TenderFactory(title="Un besoin")
+        self.assertEqual(tender.slug, "un-besoin")
+        # with author
+        user_1 = UserFactory(kind=User.KIND_BUYER)
+        tender = TenderFactory(title="Un autre besoin", author=user_1)
+        self.assertEqual(tender.slug, "un-autre-besoin")
+        # with author.company_name
+        user_2 = UserFactory(kind=User.KIND_BUYER, company_name="L'entreprise A")
+        tender = TenderFactory(title="Un 3e besoin", author=user_2)
+        self.assertEqual(tender.slug, "un-3e-besoin-lentreprise-a")
+
     # todo : update with testing form
     # def test_deadline_start_before_today(self):
     #     today = datetime.date.today()


### PR DESCRIPTION
### Quoi ?

Actuellement, on rajoute dans le slug l'entreprise de l'auteur du besoin, mais sans le "slugifier". Donc le champ est malformé si le nom de l'entreprise contient des espaces ou des apostrophes.
