### PR TITLE
Remplacer l'icone de téléchargement

### DIFF
--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -98,7 +98,7 @@
                     </div>
                     <div class="card-footer pt-0 bg-white">
                         <a href="{{ FACILITATOR_LIST }}" id="track_dashboard_partners_facilitator_list" class="btn btn-outline-primary btn-ico width-100 width-lg-auto" target="_blank" rel="noopener">
-                            <i class="ri-download-2-line ri-lg"></i>
+                            <i class="ri-download-line ri-lg"></i>
                             <span>Télécharger l'annuaire</span>
                         </a>
                     </div>


### PR DESCRIPTION
### Quoi ?

Changer de version d'icone de téléchargment de remix icon

### Pourquoi ?
Pour harmoniser avec le thème et répondre à cette demande UX
https://www.notion.so/Modifier-l-icon-download-2d03a2efc1164ee59f4191c4109badd6 

### Comment ?

En remplacant la classe `ri-download-2-line` par `ri-download-line`

![capture 2022-11-07 à 16 01 23](https://user-images.githubusercontent.com/3874024/200342613-659cd326-44a0-46bd-ab60-c01d2da1fc08.png)
![capture 2022-11-07 à 16 01 30](https://user-images.githubusercontent.com/3874024/200342616-cfd9669c-ffca-4a2a-b006-829c72ad626a.png)
