### PR TITLE
Dépôt de besoins: Désélectionner par défaut la question “Utilité du Marché”

### DIFF
--- a/lemarche/utils/fields.py
+++ b/lemarche/utils/fields.py
@@ -75,3 +75,18 @@ def pretty_print_readonly_jsonfield(jsonfield_data):
         result = mark_safe(f"<pre>{escape(result)}</pre>")
 
     return result
+
+
+class BooleanNotEmptyField(forms.BooleanField):
+    def to_python(self, value):
+        if isinstance(value, str) and value.lower() in ("false", "0"):
+            value = False
+        elif isinstance(value, str) and value.lower() in ("true", "1"):
+            value = True
+        else:
+            value = None
+        return value
+
+    def validate(self, value):
+        if value not in (0, 1) and self.required:
+            raise forms.ValidationError(self.error_messages["required"], code="required")

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -4,7 +4,7 @@ from django import forms
 
 from lemarche.sectors.models import Sector
 from lemarche.tenders.models import Tender
-from lemarche.utils.fields import GroupedModelMultipleChoiceField
+from lemarche.utils.fields import BooleanNotEmptyField, GroupedModelMultipleChoiceField
 
 
 class AddTenderStepGeneralForm(forms.ModelForm):
@@ -187,11 +187,10 @@ class AddTenderStepContactForm(forms.ModelForm):
 
 
 class AddTenderStepConfirmationForm(forms.Form):
-    is_marche_useful = forms.BooleanField(
+    is_marche_useful = BooleanNotEmptyField(
         label=Tender._meta.get_field("is_marche_useful").help_text,
         widget=forms.RadioSelect(choices=[(True, "Oui"), (False, "Non")]),
-        required=False,  # if a BooleanField is required, then it won't allow a False value...
-        initial=True,  # ...so we initialize it
+        required=True,
     )
     marche_benefits = forms.MultipleChoiceField(
         label=Tender._meta.get_field("marche_benefits").help_text,


### PR DESCRIPTION
### Quoi ?

Dans la dernière étape du dépôt de besoins, désélectionner par défaut la question “Utilité du Marché”.

### Captures d'écran (optionnel)

![image](https://user-images.githubusercontent.com/12339682/200898348-8e8c4ab7-3e96-4f6f-86c1-8430c99c3344.png)
