### PR TITLE
Améliorer l'affichage des secteurs d'activité

### DIFF
--- a/lemarche/sectors/models.py
+++ b/lemarche/sectors/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.db.models import Value
-from django.db.models.functions import NullIf
+from django.db.models.functions import Left, NullIf
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 
@@ -39,8 +39,8 @@ class SectorQuerySet(models.QuerySet):
         """
         return (
             self.select_related("group")
-            .exclude(group=None)  # sector must have a group !
-            .annotate(sector_is_autre=NullIf("name", Value("Autre")))
+            .exclude(group=None)  # sector must have a group!
+            .annotate(sector_is_autre=NullIf(Left("name", 5), Value("Autre")))  # bring "Autre" to the bottom
             .order_by("group__id", "sector_is_autre")
         )
 

--- a/lemarche/sectors/tests.py
+++ b/lemarche/sectors/tests.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
 
 from lemarche.sectors.factories import SectorFactory, SectorGroupFactory
+from lemarche.sectors.models import Sector
 
 
-class NetworkModelTest(TestCase):
+class SectorModelTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.sector_group = SectorGroupFactory(name="Un groupe")
@@ -16,3 +17,27 @@ class NetworkModelTest(TestCase):
 
     def test_str(self):
         self.assertEqual(str(self.sector), "Un secteur")
+
+
+class SectorQuerysetModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sector_group_1 = SectorGroupFactory(name="Informatique")
+        cls.sector_group_2 = SectorGroupFactory(name="Bricolage")
+        cls.sector_1_1 = SectorFactory(name="Développement de logiciel", group=cls.sector_group_1)
+        cls.sector_1_2 = SectorFactory(name="Dépannage informatique", group=cls.sector_group_1)
+        cls.sector_1_3 = SectorFactory(name="Autre", group=cls.sector_group_1)
+        cls.sector_2_1 = SectorFactory(name="Plomberie", group=cls.sector_group_2)
+        cls.sector_2_2 = SectorFactory(name="Autre (Bricolage)", group=cls.sector_group_2)
+        cls.sector_3 = SectorFactory(name="Un secteur seul", group=None)
+
+    def test_form_filter_queryset(self):
+        sectors = Sector.objects.form_filter_queryset()
+        # remove sectors without groups
+        self.assertEqual(sectors.count(), 3 + 2)
+        # order by group id
+        self.assertEqual(sectors[0].group, self.sector_group_1)
+        # and then by name (but with Autre at the end)
+        self.assertEqual(sectors[0], self.sector_1_2)
+        self.assertEqual(sectors[2], self.sector_1_3)
+        self.assertEqual(sectors[4], self.sector_2_2)


### PR DESCRIPTION
### Quoi ?

On a récemment renommé les secteurs `Autre` en `Autre (nom du group parent)`, ce qui a "cassé" notre ordering.
(ces secteurs sont affichés dans les formulaires, mais aussi la liste des secteurs affichés par structure)

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-14 15-56-38](https://user-images.githubusercontent.com/7147385/201692146-5075337c-813a-488c-9891-3d674ae19aa6.png)|![Screenshot from 2022-11-14 15-57-11](https://user-images.githubusercontent.com/7147385/201692149-96277c63-1b82-4745-ac6e-31477b98ce15.png)|
