### PR TITLE
Optimisation des tests

### DIFF
--- a/lemarche/users/factories.py
+++ b/lemarche/users/factories.py
@@ -1,12 +1,19 @@
+import functools
 import string
 
 import factory.fuzzy
+from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
 
 from lemarche.users.models import User
 
 
 DEFAULT_PASSWORD = "P4ssw0rd!*"
+
+
+@functools.cache
+def default_password():
+    return make_password(DEFAULT_PASSWORD)
 
 
 class UserFactory(DjangoModelFactory):
@@ -16,7 +23,7 @@ class UserFactory(DjangoModelFactory):
     first_name = factory.Sequence("first_name{0}".format)
     last_name = factory.Sequence("last_name{0}".format)
     email = factory.Sequence("email{0}@example.com".format)
-    password = factory.PostGenerationMethodCall("set_password", DEFAULT_PASSWORD)
+    password = factory.LazyFunction(default_password)
     phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
     kind = User.KIND_SIAE
 

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -9,7 +9,7 @@ from lemarche.sectors.factories import SectorFactory
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.factories import SiaeFactory, SiaeOfferFactory
 from lemarche.siaes.models import Siae
-from lemarche.users.factories import DEFAULT_PASSWORD, UserFactory
+from lemarche.users.factories import UserFactory
 from lemarche.www.siaes.forms import SiaeSearchForm
 
 
@@ -630,7 +630,7 @@ class SiaeDetailTest(TestCase):
 
     def test_should_display_contact_fields_to_authenticated_users(self):
         siae = SiaeFactory(name="Ma boite", contact_email="contact@example.com")
-        self.client.login(email=self.user.email, password=DEFAULT_PASSWORD)
+        self.client.force_login(self.user)
         url = reverse("siae:detail", args=[siae.slug])
         response = self.client.get(url)
         self.assertContains(response, siae.contact_email)


### PR DESCRIPTION
### Quoi ?

Inspiré de https://github.com/betagouv/itou-communaute-django/pull/64

Modifications apportées : 
1. remplacer `self.client.login(user.email, user.password)` par `self.client.force_login(user)`
2. UserFactory : générer séparément + mettre en cache le password

### Pourquoi ?

Pour accélérer les tests

|Env|Avant|Après|
|---|---|---|
|Local|390s|350s|
|Github Action|||