### PR TITLE
Ajout d'une petite margin-bottom sur les badge des périmètres

### DIFF
--- a/lemarche/static/js/perimeters_autocomplete_fields.js
+++ b/lemarche/static/js/perimeters_autocomplete_fields.js
@@ -22,7 +22,7 @@ function createHiddenInputPerimeter(resultId, resultName) {
   }).appendTo(perimetersContainer);
   let button = $('<button>', {
       type: 'button',
-      class: "badge badge-base badge-pill badge-outline-primary mr-1",
+      class: "badge badge-base badge-pill badge-outline-primary mr-1 mb-1",
       title: `Retirer ${resultName}`,
       text: `${resultName}`,
       'data-refInput': resultIdString,

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -67,7 +67,7 @@
                                     </button>
                                 </div>
                             </div>
-                            <div class="row mt-lg-3">
+                            <div class="row">
                                 <div class="col-12 col-md-6 col-lg-3">
                                     {% bootstrap_field form.kind %}
                                 </div>


### PR DESCRIPTION
### Quoi ?

Tout est dans le titre :)

Aussi : sur la page recherche, j'ai enlevé la margin supplémentaire qui était présente entre les 2 rows de filtre (pour gagner un peu de place et éviter au maximum le scroll)

### Pourquoi ?

Pour éviter qu'ils se chevauchent

### Captures d'écran (optionnel)

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-23 15-20-33](https://user-images.githubusercontent.com/7147385/203570968-0e7f0549-f92b-449a-92af-3c33fdaa95c4.png)|![Screenshot from 2022-11-23 15-17-45](https://user-images.githubusercontent.com/7147385/203571006-d3c6a4f8-3523-4285-9934-c34b7192530f.png)|