### PR TITLE
Téléchargement x Tracker : fix sur le results_count

### DIFF
--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -114,7 +114,11 @@ class TrackerMiddleware:
 
             elif page == reverse("siae:search_results_download"):  # download csv action
                 action = "directory_csv"
-                extra_data = {"results_count": response.headers.get("Context-Data-Results-Count", None)}
+                extra_data = {
+                    "results_count": int(response.headers.get("Context-Data-Results-Count"))
+                    if response.headers.get("Context-Data-Results-Count", None)
+                    else None
+                }
                 meta = self.extract_meta_from_request_get(request, context_data=context_data, extra_data=extra_data)
 
             elif page == reverse("dashboard:siae_search_by_siret"):  # adopted search action

--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -114,9 +114,7 @@ class TrackerMiddleware:
 
             elif page == reverse("siae:search_results_download"):  # download csv action
                 action = "directory_csv"
-                extra_data = {
-                    "results_count": context_data.get("paginator").count if context_data.get("paginator") else None
-                }
+                extra_data = {"results_count": response.headers.get("Context-Data-Results-Count", None)}
                 meta = self.extract_meta_from_request_get(request, context_data=context_data, extra_data=extra_data)
 
             elif page == reverse("dashboard:siae_search_by_siret"):  # adopted search action

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -129,8 +129,6 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         if not len(request_params):
             file_path = f"{API_CONNECTION_DICT['endpoint_url']}/{settings.S3_STORAGE_BUCKET_NAME}/{settings.SIAE_EXPORT_FOLDER_NAME}/{filename_with_extension}"  # noqa
             response = HttpResponseRedirect(file_path)
-            response.context_data = {"results_count": siae_list.count()}
-            return response
 
         else:
             if format == "csv":
@@ -146,8 +144,10 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
 
                 wb = export_siae_to_excel(siae_list, with_contact_info)
                 wb.save(response)
-            response.context_data = {"results_count": siae_list.count()}
-            return response
+
+        # HttpResponse doesn't have a context. so we pass the data via the response header
+        response["Context-Data-Results-Count"] = siae_list.count()
+        return response
 
 
 class SiaeDetailView(DetailView):


### PR DESCRIPTION
### Quoi ?

Actuellement les téléchargements renvoie un results_count `None`, car le HttpResponse générées n'ont pas de context data

Fix en passant par la valeur dans les headers
