### PR TITLE
Dépôt de besoin : afficher les coordonnées : indiquer un message aux utilisateurs sans structures

### DIFF
--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -73,25 +73,25 @@
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% elif user.kind == user.KIND_PARTNER %}
                     <div class="alert alert-info" role="alert">
-                        <p>
+                        <p class="mb-1">
                             <i class="ri-lightbulb-line ri-lg"></i>
-                            <strong>Coordonnées</strong>
+                            <strong>Comment contacter le client ?</strong>
                         </p>
                         <p class="mb-0">
-                            Contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite du site pour être mis en relation avec l'acheteur.
+                            Pour être mis en relation avec l'acheteur, contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite.
                         </p>
                     </div>
                 {% elif user.kind == user.KIND_SIAE and not user.has_siae %}
                     <div class="alert alert-info" role="alert">
-                        <p>
+                        <p class="mb-1">
                             <i class="ri-lightbulb-line ri-lg"></i>
-                            <strong>Coordonnées</strong>
+                            <strong>Comment contacter le client ?</strong>
                         </p>
                         <p class="mb-0">
                             Pour accéder aux coordonnées du client, veuillez d'abord vous <a id="add-siae-btn" href="{% url 'dashboard:siae_search_by_siret' %}">rattacher à votre structure</a>.
                         </p>
                         <p>
-                            Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite
+                            Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite.
                         </p>
                     </div>
                 {% else %}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -72,9 +72,15 @@
                 {% if tender.author == request.user or user_has_contact_click_date or user_can_display_tender_contact_details %}
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% elif user.kind == user.KIND_PARTNER %}
-                    <p>
-                        Contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite du site pour être mis en relation avec l'acheteur.
-                    </p>
+                    <div class="alert alert-info" role="alert">
+                        <p>
+                            <i class="ri-lightbulb-line ri-lg"></i>
+                            <strong>Coordonnées</strong>
+                        </p>
+                        <p class="mb-0">
+                            Contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite du site pour être mis en relation avec l'acheteur.
+                        </p>
+                    </div>
                 {% elif user.kind == user.KIND_SIAE and not user.has_siae %}
                     <div class="alert alert-info" role="alert">
                         <p>

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -75,6 +75,19 @@
                     <p>
                         Contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite du site pour être mis en relation avec l'acheteur.
                     </p>
+                {% elif user.kind == user.KIND_SIAE and not user.has_siae %}
+                    <div class="alert alert-info" role="alert">
+                        <p>
+                            <i class="ri-lightbulb-line ri-lg"></i>
+                            <strong>Coordonnées</strong>
+                        </p>
+                        <p class="mb-0">
+                            Pour accéder aux coordonnées du client, veuillez d'abord vous <a id="add-siae-btn" href="{% url 'dashboard:siae_search_by_siret' %}">rattacher à votre structure</a>.
+                        </p>
+                        <p>
+                            Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite
+                        </p>
+                    </div>
                 {% else %}
                     <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#contact_click_confirm_modal" title="Répondre à cette opportunité">
                         Répondre à cette opportunité

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -276,6 +276,9 @@ class User(AbstractUser):
             return f"{self.first_name.upper()[:1]}. {self.last_name.upper()}"
         return ""
 
+    def has_siae(self):
+        return self.siaes.exists()
+
     def has_tender_siae(self, tender=None):
         from lemarche.tenders.models import TenderSiae
 


### PR DESCRIPTION
### Quoi ?

voir le titre

### Pourquoi ?

Les utilisateurs sans structures ne peuvent actuellement pas voir les coordonnées de l'acheteur. On leur indique ici que ces utilisateurs doivent d'abord se rattacher à leur structure.

### Captures d'écran

![Screenshot from 2022-11-30 13-28-20](https://user-images.githubusercontent.com/7147385/204800791-fb132438-cc00-47bd-9448-25acd2fcbc7d.png)
