### PR TITLE
Dépôt de besoin : réduire l'affichage des secteurs d'activité

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -870,9 +870,12 @@ class Siae(models.Model):
         score_percent = round(score / total, 2) * 100
         return round_by_base(score_percent, base=5)
 
-    @cached_property
-    def sectors_list_string(self):
-        return ", ".join(self.sectors.values_list("name", flat=True))
+    def sectors_list_string(self, display_max=5):
+        sectors_name_list = self.sectors.values_list("name", flat=True)
+        if display_max and len(sectors_name_list) > display_max:
+            sectors_name_list = sectors_name_list[:display_max]
+            sectors_name_list.append("…")
+        return ", ".join(sectors_name_list)
 
     @cached_property
     def stat_view_count_last_3_months(self):

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -871,11 +871,14 @@ class Siae(models.Model):
         return round_by_base(score_percent, base=5)
 
     def sectors_list_string(self, display_max=5):
-        sectors_name_list = self.sectors.values_list("name", flat=True)
+        sectors_name_list = self.sectors.form_filter_queryset().values_list("name", flat=True)
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]
             sectors_name_list.append("…")
         return ", ".join(sectors_name_list)
+
+    def sectors_full_list_string(self):
+        return self.sectors_list_string(display_max=None)
 
     @cached_property
     def stat_view_count_last_3_months(self):

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -1,4 +1,4 @@
-{% load static siae_sectors_display humanize %}
+{% load static humanize %}
 
 <div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -24,28 +24,27 @@
             <h2 class="py-2">{{ tender.title }}</h2>
         </a>
 
-        {% if tender.sectors_list_string or tender.perimeters_list_string or tender.amount %}
-            <hr>
-            <div class="row">
-                {% if tender.sectors_list_string %}
-                    <div class="col-md-4">
-                        <i class="ri-award-line"></i>
-                        {{ tender.sectors_list_string }}
-                    </div>
-                {% endif %}
-                {% if tender.perimeters_list_string %}
-                    <div class="col-md-4 text-center">
-                        <i class="ri-map-pin-2-line"></i>
-                        {{ tender.perimeters_list_string }}
-                    </div>
-                {% endif %}
-                {% if tender.amount %}
-                    <div class="col-md-4 text-center">
-                        <i class="ri-money-euro-circle-line"></i>
-                        {{ tender.get_amount_display|default:"-" }}
-                    </div>
+        <hr />
+
+        <div class="row">
+            <div class="col-md-4" title="Secteurs d'activité">
+                {% if tender.sectors.count %}
+                    <i class="ri-award-line"></i>
+                    {% siae_sectors_display tender display_max=3 %}
                 {% endif %}
             </div>
-        {% endif %}
+            <div class="col-md-4 text-center" title="Lieu d'intervention">
+                {% if tender.perimeters_list_string %}
+                    <i class="ri-map-pin-2-line"></i>
+                    {{ tender.perimeters_list_string }}
+                {% endif %}
+            </div>
+            <div class="col-md-4 text-center">
+                {% if tender.amount %}
+                    <i class="ri-money-euro-circle-line"></i>
+                    {{ tender.get_amount_display|default:"-" }}
+                {% endif %}
+            </div>
+        </div>
     </div>
 </div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -1,4 +1,4 @@
-{% load static siae_sectors_display humanize %}
+{% load static humanize %}
 
 <div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
@@ -30,7 +30,7 @@
             <div class="col-md-4" title="Secteurs d'activité">
                 {% if tender.sectors.count %}
                     <i class="ri-award-line"></i>
-                    {% siae_sectors_display tender display_max=3 %}
+                    {{ tender.sectors_list_string }}
                 {% endif %}
             </div>
             <div class="col-md-4 text-center" title="Lieu d'intervention">

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -29,7 +29,7 @@
             </div>
         </div>
         <div class="row text-bold">
-            <div class="col" title="Secteurs d'activité">
+            <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string }}">
                 <i class="ri-award-line"></i>
                 {{ tender.sectors_list_string }}
             </div>

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -29,11 +29,11 @@
             </div>
         </div>
         <div class="row text-bold">
-            <div class="col">
+            <div class="col" title="Secteurs d'activité">
                 <i class="ri-award-line"></i>
                 {{ tender.sectors_list_string }}
             </div>
-            <div class="col">
+            <div class="col" title="Lieu d'éxécution">
                 <i class="ri-map-pin-2-line"></i>
                 {% if tender.is_country_area %}
                     France entière
@@ -45,7 +45,7 @@
                 {% endif %}
             </div>
             {% if tender.presta_type %}
-                <div class="col">
+                <div class="col" title="Type de prestation">
                     <i class="ri-briefcase-4-line"></i>
                     {% array_choices_display tender 'presta_type' %}
                 </div>

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -109,7 +109,8 @@
                     {% include "includes/_pagination.html" %}
                     {% if not tenders %}
                         <p class="text-muted">
-                            Désolé, nous avons aucune opportunités à vous présenter pour le moment.<br>
+                            Désolé, nous n'avons aucune opportunités à vous présenter pour le moment.
+                            <br />
                             Si ce n'est pas déjà fait, pensez à <a href="{% url 'dashboard:home' %}">compléter votre fiche structure</a>
                             pour optimiser vos chances de trouver de nouvelles opportunités.
                         </p>

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -350,9 +350,12 @@ class Tender(models.Model):
     def contact_full_name(self):
         return f"{self.contact_first_name} {self.contact_last_name}"
 
-    @cached_property
-    def sectors_list_string(self):
-        return ", ".join(self.sectors.values_list("name", flat=True))
+    def sectors_list_string(self, display_max=5):
+        sectors_name_list = self.sectors.values_list("name", flat=True)
+        if display_max and len(sectors_name_list) > display_max:
+            sectors_name_list = sectors_name_list[:display_max]
+            sectors_name_list.append("…")
+        return ", ".join(sectors_name_list)
 
     @cached_property
     def perimeters_list_string(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -351,11 +351,14 @@ class Tender(models.Model):
         return f"{self.contact_first_name} {self.contact_last_name}"
 
     def sectors_list_string(self, display_max=5):
-        sectors_name_list = self.sectors.values_list("name", flat=True)
+        sectors_name_list = self.sectors.form_filter_queryset().values_list("name", flat=True)
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]
             sectors_name_list.append("…")
         return ", ".join(sectors_name_list)
+
+    def sectors_full_list_string(self):
+        return self.sectors_list_string(display_max=None)
 
     @cached_property
     def perimeters_list_string(self):

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -67,7 +67,7 @@ def generate_siae_row(siae: Siae, siae_field_list):
             col_value = "Oui" if getattr(siae, field_name, None) else "Non"
         # ManyToManyFields
         elif field_name == "sectors":
-            col_value = siae.sectors_list_string
+            col_value = siae.sectors_list_string(display_max=None)
         # Custom fields
         elif field_name == "Inscrite":
             col_value = "Oui" if siae.user_count else "Non"

--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -67,7 +67,7 @@ def generate_siae_row(siae: Siae, siae_field_list):
             col_value = "Oui" if getattr(siae, field_name, None) else "Non"
         # ManyToManyFields
         elif field_name == "sectors":
-            col_value = siae.sectors_list_string(display_max=None)
+            col_value = siae.sectors_full_list_string()
         # Custom fields
         elif field_name == "Inscrite":
             col_value = "Oui" if siae.user_count else "Non"

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -62,7 +62,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
         variables = {
             "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
-            "TENDER_SECTORS": tender.sectors_list_string,
+            "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location.name_display,
             "TENDER_URL": get_share_url_object(tender),
         }
@@ -134,12 +134,12 @@ def send_tender_email_to_siae(email_subject: str, tender: Tender, siae: Siae):
 
         variables = {
             "SIAE_CONTACT_FIRST_NAME": siae.contact_first_name,
-            "SIAE_SECTORS": siae.sectors_list_string,
+            "SIAE_SECTORS": siae.sectors_list_string(),
             "SIAE_PERIMETER": siae.geo_range_pretty_display,
             "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_KIND": tender.get_kind_display(),
-            "TENDER_SECTORS": tender.sectors_list_string,
+            "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location.name_display,
             "TENDER_URL": get_share_url_object(tender),
         }


### PR DESCRIPTION
### Quoi ?

Il y a parfois trop de secteurs d'activité à afficher, ce qui prend beaucoup de place.
Limiter l'affichage à 5 (comme c'est déjà le cas pour les secteurs d'une fiche structure)

--> modifié la méthode `sectors_list_string()` pour pouvoir prendre un paramètre `display_max` (default : 5)

### Todo

avoir l'option d'afficher la liste complète avec un lien "Voir plus" ?
