### PR TITLE
Dépôt de besoin : afficher les contraintes spécifiques seulement si présentes

### DIFF
--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -58,12 +58,14 @@
             <p>{{ tender.description|linebreaks }}</p>
         </div>
 
-        <hr class="my-5">
+        {% if source_form or not source_form and tender.constraints %}
+            <hr class="my-5">
 
-        <div class="py-2">
-            <h2>Contraintes techniques spécifiques</h2>
-            <p>{{ tender.constraints|default:"-"|linebreaks }}</p>
-        </div>
+            <div class="py-2">
+                <h2>Contraintes techniques spécifiques</h2>
+                <p>{{ tender.constraints|default:"-"|linebreaks }}</p>
+            </div>
+        {% endif %}
 
         {% if source_form or tender.author == request.user or tender.accept_share_amount %}
             <hr class="my-5">

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -348,6 +348,19 @@ class TenderDetailViewTest(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 
+    def test_tender_constraints_display(self):
+        # tender with constraints: section should be visible
+        url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Contraintes techniques spécifiques")
+        # tender without constraints: section should be hidden
+        tender_2 = TenderFactory(author=self.user_buyer_2, constraints="")
+        url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Contraintes techniques spécifiques")
+
     def test_tender_author_has_additional_stats(self):
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})


### PR DESCRIPTION
### Quoi ?

Le champ "Contraintes techniques spécifiques" est facultatif.
Sur la page détail du besoin, on cache cette section si le champ est vide.
(mais on l'affiche dans tous les cas si on est dans le formulaire de création/édition)