### PR TITLE
Dépôt de besoin : remonter les informations de contact (CTA, détails)

### DIFF
--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -77,13 +77,13 @@
                     </div>
                 {% else %}
                     <div class="row">
-                        <div class="col">
+                        <div class="col-12">
                             <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#contact_click_confirm_modal" title="Répondre à cette opportunité">
                                 Répondre à cette opportunité
                             </button>
                         </div>
                     </div>
-                    <div id="show-tender-contact-content" class="py-2" style="display:none">
+                    <div id="show-tender-contact-content" style="display:none">
                         {% include "tenders/_detail_contact.html" with tender=tender %}
                     </div>
                 {% endif %}
@@ -99,7 +99,7 @@
                 {% endif %}
             {% else %}
                 <div class="row">
-                    <div class="col">
+                    <div class="col-12">
                         <a href="#" id="show-tender-contact-modal-btn" class="btn btn-primary float-right mb-4" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
                             <span>Répondre à cette opportunité</span>
                         </a>
@@ -110,35 +110,29 @@
 
         <hr class="my-5">
 
-        <div class="py-2">
-            <h2>
-                Description
-                {% if tender.start_working_date %}
-                    <span class="float-right fs-sm text-muted">Début d'intervention : {{ tender.start_working_date }}</span>
-                {% endif %}
-            </h2>
-            <p>{{ tender.description|linebreaks }}</p>
-        </div>
+        <h2>
+            Description
+            {% if tender.start_working_date %}
+                <span class="float-right fs-sm text-muted">Début d'intervention : {{ tender.start_working_date }}</span>
+            {% endif %}
+        </h2>
+        <p>{{ tender.description|linebreaks }}</p>
 
         {% if source_form or not source_form and tender.constraints %}
             <hr class="my-5">
 
-            <div class="py-2">
-                <h2>Contraintes techniques spécifiques</h2>
-                <p>{{ tender.constraints|default:"-"|linebreaks }}</p>
-            </div>
+            <h2>Contraintes techniques spécifiques</h2>
+            <p>{{ tender.constraints|default:"-"|linebreaks }}</p>
         {% endif %}
 
         {% if source_form or tender.author == request.user or tender.accept_share_amount %}
             <hr class="my-5">
 
-            <div class="py-2">
-                <h2>Montant du marché</h2>
-                <p>{{ tender.get_amount_display|default:"-" }}</p>
-                {% if source_form or tender.author == request.user %}
-                    <p>{{ tender.accept_share_amount_display }}</p>
-                {% endif %}
-            </div>
+            <h2>Montant du marché</h2>
+            <p>{{ tender.get_amount_display|default:"-" }}</p>
+            {% if source_form or tender.author == request.user %}
+                <p>{{ tender.accept_share_amount_display }}</p>
+            {% endif %}
         {% endif %}
     </div>
 


### PR DESCRIPTION
### Quoi ?

Sur la page détail d'un besoin, remonter les informations de contact.
J'en ai profité pour améliorer le rendu et enlever du padding inutile