### PR TITLE
Dépôt de besoin : indiquer si le besoin a une date de réponse dépassée (v2)

### DIFF
--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -52,10 +52,7 @@
                             {% for tender in last_3_tenders %}
                                 <ul class="list-group list-group-flush list-group-link">
                                     <li class="list-group-item list-group-item-action">
-                                        <div>
-                                            <time class="fs-sm d-block" aria-label="Date de clôture">{{ tender.deadline_date|default:"" }}</time>
-                                            <a href="{% url 'tenders:detail' tender.slug %}" class="d-block font-weight-bold stretched-link">{{ tender.title }}</a>
-                                        </div>
+                                        {% include "tenders/_card_list_item.html" with tender=tender %}
                                     </li>
                                 </ul>
                             {% endfor %}

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -102,10 +102,7 @@
                         {% for tender in last_3_tenders %}
                             <ul class="list-group list-group-flush list-group-link">
                                 <li class="list-group-item list-group-item-action">
-                                    <div>
-                                        <time class="fs-sm d-block" aria-label="Date de clôture">{{ tender.deadline_date|default:"" }}</time>
-                                        <a href="{% url 'tenders:detail' tender.slug %}" class="d-block font-weight-bold stretched-link">{{ tender.title }}</a>
-                                    </div>
+                                    {% include "tenders/_card_list_item.html" with tender=tender %}
                                 </li>
                             </ul>
                         {% endfor %}

--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -2,7 +2,7 @@
     <time class="fs-sm d-block" aria-label="Date de clôture">
         <span>{{ tender.deadline_date|default:"" }}</span>
         {% if tender.deadline_date_outdated %}
-            <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
         {% endif %}
     </time>
     <a href="{% url 'tenders:detail' tender.slug %}" class="d-block font-weight-bold stretched-link">{{ tender.title }}</a>

--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -1,0 +1,9 @@
+<div>
+    <time class="fs-sm d-block" aria-label="Date de clôture">
+        <span>{{ tender.deadline_date|default:"" }}</span>
+        {% if tender.deadline_date_outdated %}
+            <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+        {% endif %}
+    </time>
+    <a href="{% url 'tenders:detail' tender.slug %}" class="d-block font-weight-bold stretched-link">{{ tender.title }}</a>
+</div>

--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -2,7 +2,7 @@
     <time class="fs-sm d-block" aria-label="Date de clôture">
         <span>{{ tender.deadline_date|default:"" }}</span>
         {% if tender.deadline_date_is_outdated %}
-            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Clôturé</span>
         {% endif %}
     </time>
     <a href="{% url 'tenders:detail' tender.slug %}" class="d-block font-weight-bold stretched-link">{{ tender.title }}</a>

--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -1,7 +1,7 @@
 <div>
     <time class="fs-sm d-block" aria-label="Date de clôture">
         <span>{{ tender.deadline_date|default:"" }}</span>
-        {% if tender.deadline_date_outdated %}
+        {% if tender.deadline_date_is_outdated %}
             <span class="badge badge-xs badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
         {% endif %}
     </time>

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -6,6 +6,9 @@
             <div class="col-md-8" style="border-right:1px solid">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
+                    {% if tender.deadline_date_outdated %}
+                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+                    {% endif %}
                     {% if tender.status == STATUS_VALIDATED %}
                         <span class="float-right badge badge-base badge-pill badge-outline-warning">
                             <i class="ri-mail-send-line"></i>Envoyé

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -7,7 +7,7 @@
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
                     {% if tender.deadline_date_is_outdated %}
-                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
                     {% if tender.status == STATUS_VALIDATED %}
                         <span class="float-right badge badge-base badge-pill badge-outline-warning">

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -6,7 +6,7 @@
             <div class="col-md-8" style="border-right:1px solid">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_outdated %}
+                    {% if tender.deadline_date_is_outdated %}
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
                     {% endif %}
                     {% if tender.status == STATUS_VALIDATED %}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -6,7 +6,7 @@
             <div class="col-md-12">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_outdated %}
+                    {% if tender.deadline_date_is_outdated %}
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
                     {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -7,7 +7,7 @@
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
                     {% if tender.deadline_date_is_outdated %}
-                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -6,6 +6,9 @@
             <div class="col-md-12">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
+                    {% if tender.deadline_date_outdated %}
+                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+                    {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}
                             {{ title_kind_sourcing_siae }}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -15,7 +15,7 @@
     <p class="text-right text-white bg-tertiary fs-sm rounded-top rounded-lg p-3 mb-0">
         Date limite de réponse : {{ tender.deadline_date|default:"" }}
         {% if not source_form and tender.deadline_date_outdated %}
-            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Clôturé</span>
         {% endif %}
     </p>
 

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -12,8 +12,11 @@
 </div>
 {% endif %}
 <div class="card c-card c-card--marche siae-card rounded-lg shadow-lg">
-    <p class="text-right text-white bg-tertiary fs-sm rounded-top rounded-lg py-3 px-5 mb-0">
+    <p class="text-right text-white bg-tertiary fs-sm rounded-top rounded-lg p-3 mb-0">
         Date limite de réponse : {{ tender.deadline_date|default:"" }}
+        {% if not source_form and tender.deadline_date_outdated %}
+            <span class="badge badge-xs badge-base badge-pill badge-pilotage">Délai de réponse dépassé</span>
+        {% endif %}
     </p>
 
     <div class="card-body pb-5 px-5">

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -36,7 +36,7 @@
                     </a>
                 </div>
                 {% endif %}
-                <div class="col-12 my-5 py-3">
+                <div class="col-12 my-5">
                     <!-- "buyer": display tenders which the user is the author -->
                     {% if user.kind != user.KIND_SIAE %}
                     {% block htmx %}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -368,6 +368,12 @@ class Tender(models.Model):
             return self.TENDER_ACCEPT_SHARE_AMOUNT_TRUE
         return self.TENDER_ACCEPT_SHARE_AMOUNT_FALSE
 
+    @cached_property
+    def deadline_date_outdated(self):
+        if self.deadline_date and self.deadline_date < timezone.now().date():
+            return True
+        return False
+
     def set_hubspot_id(self, hubspot_deal_id, with_save=True):
         self.extra_data.update({"hubspot_deal_id": hubspot_deal_id})
         if with_save:

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -97,9 +97,9 @@ class DashboardHomeView(LoginRequiredMixin, DetailView):
         if user.kind == User.KIND_SIAE:
             siaes = user.siaes.all()
             if siaes:
-                context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes)[:3]
+                context["last_3_tenders"] = Tender.objects.filter_with_siaes(siaes).order_by_deadline_date()[:3]
         else:
-            context["last_3_tenders"] = Tender.objects.filter(author=user)[:3]
+            context["last_3_tenders"] = Tender.objects.filter(author=user).order_by_deadline_date()[:3]
             context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
             context["siae_count"] = Siae.objects.is_live().count()
             context["tender_count"] = Tender.objects.validated().count() + 30  # historic number (before form)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -361,6 +361,17 @@ class TenderDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Contraintes techniques spécifiques")
 
+    def test_tender_deadline_date_display(self):
+        # tender is not outdated by default
+        url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
+        response = self.client.get(url)
+        self.assertNotContains(response, "Clôturé")
+        # new tender with outdated deadline_date
+        tender_2 = TenderFactory(deadline_date=timezone.now() - timedelta(days=1))
+        url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
+        response = self.client.get(url)
+        self.assertContains(response, "Clôturé")
+
     def test_tender_author_has_additional_stats(self):
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/546
v2 de la PR https://github.com/betagouv/itou-marche/pull/471

Si `Tender.deadline_date` est dépassé, mettre un badge pour indiquer "Délai de réponse dépassé" (edit : renommé depuis à "Clôturé")

### Captures d'écran

||Avant|Après|
|---|---|---|
|Tableau de bord|![Screenshot from 2022-12-07 13-06-59](https://user-images.githubusercontent.com/7147385/206175637-6da8e3d5-6365-4948-8b14-1cf36856bae9.png)|![Screenshot from 2022-12-07 13-06-41](https://user-images.githubusercontent.com/7147385/206175691-a0944b8e-f8d3-4ee1-bec9-5857e1a53388.png)|
|Tender list|![Screenshot from 2022-12-07 13-11-23](https://user-images.githubusercontent.com/7147385/206176244-34b83557-c31a-47d2-b4e1-546a5f712f35.png)|![Screenshot from 2022-12-07 13-11-06](https://user-images.githubusercontent.com/7147385/206176289-3b96e8cb-e21a-4f74-ba88-ff555b3003bf.png)|
|Tender detail|![Screenshot from 2022-12-07 13-07-47](https://user-images.githubusercontent.com/7147385/206175721-762e4b29-9fa9-4a9e-a331-5f13df015df6.png)|![Screenshot from 2022-12-07 13-08-18](https://user-images.githubusercontent.com/7147385/206175755-0aa6a3ca-16ba-4599-8b18-f1853bbcc56d.png)|

