### PR TITLE
Fix l'affichage des type de prestation (multiselect)

### DIFF
--- a/lemarche/static/js/presta_type_multiselect_field.js
+++ b/lemarche/static/js/presta_type_multiselect_field.js
@@ -5,7 +5,7 @@ function initMultiselect(){
 
      const FORM_INPUT_ID = "id_presta_type";
      const FORM_MULTISELECT_ID = `${FORM_INPUT_ID}_multiselect`;
-     const FORM_ELEMENT = document.querySelector(`#${FORM_INPUT_ID}`);
+     const FORM_ELEMENT = document.querySelector(`.use-multiselect #${FORM_INPUT_ID}`);
      const FORM_PLACEHOLDER = 'Mise à disposition, Prestation';
      const buttonTextAndTitle = function(options, select) {
          if (options.length === 0) {

--- a/lemarche/templates/dashboard/siae_edit_search.html
+++ b/lemarche/templates/dashboard/siae_edit_search.html
@@ -17,8 +17,7 @@
         <div class="col-12 col-lg-8">
             <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
                 <fieldset>
-                    <label class="h4">{{ form.presta_type.label }} <strong class="fs-base">*</strong></label>
-                    {% bootstrap_field form.presta_type show_label=False %}
+                    {% bootstrap_field form.presta_type %}
                 </fieldset>
             </div>
         </div>

--- a/lemarche/templates/pages/impact-calculator.html
+++ b/lemarche/templates/pages/impact-calculator.html
@@ -58,7 +58,7 @@
                                     <div id="perimeters-selected" class="mt-2"></div>
                                     {{ current_perimeters|json_script:"current-perimeters" }}
                                 </div>
-                                {% bootstrap_field form.presta_type %}
+                                {% bootstrap_field form.presta_type form_group_class="form-group use-multiselect" %}
 
                                 <button type="submit" class="btn btn-primary">
                                     Lancer la recherche

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -71,7 +71,7 @@
                                     {% bootstrap_field form.kind %}
                                 </div>
                                 <div class="col-12 col-md-6 col-lg-3">
-                                    {% bootstrap_field form.presta_type %}
+                                    {% bootstrap_field form.presta_type form_group_class="form-group use-multiselect" %}
                                 </div>
                                 <div class="col-12 col-md-6 col-lg-3">
                                     {% bootstrap_field form.territory %}

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -10,7 +10,7 @@
     {% bootstrap_field form.kind form_group_class="form-group form-group-required" %}
     {% bootstrap_field form.title form_group_class="form-group form-group-required" %}
     {% bootstrap_field form.sectors form_group_class="form-group form-group-required use-multiselect" %}
-    {% bootstrap_field form.presta_type %}
+    {% bootstrap_field form.presta_type form_group_class="form-group form-group-required use-multiselect" %}
     <div class="form-group form-group-required {% if form.perimeters.errors %}is-invalid{% endif %}">
         <label for="id_perimeters">{{ form.perimeters.label }}</label>
         <div id="dir_form_perimeters" data-input-name="general-perimeters"></div>


### PR DESCRIPTION
### Quoi ?

Utiliser le multiselect pour le champ "Type de prestatation" seulement quand on l'indique explicitement.
(même comportement que pour `network` & `sectors`)