### PR TITLE
Dépôt de besoin : fix sur le tri par deadline

### DIFF
--- a/lemarche/siaes/management/commands/sync_c1_c4.py
+++ b/lemarche/siaes/management/commands/sync_c1_c4.py
@@ -351,8 +351,8 @@ class Command(BaseCommand):
         - all the ones who have is_active as False
         """
         if not dry_run:
-            yesterday = datetime.now() - timedelta(days=1)
+            date_yesterday = datetime.now() - timedelta(days=1)
             Siae.objects.exclude(c1_sync_skip=True).filter(
-                c1_last_sync_date__lt=timezone.make_aware(yesterday)
+                c1_last_sync_date__lt=timezone.make_aware(date_yesterday)
             ).update(is_delisted=True)
             Siae.objects.filter(is_active=False).update(is_delisted=True)

--- a/lemarche/siaes/management/commands/sync_c2_c4.py
+++ b/lemarche/siaes/management/commands/sync_c2_c4.py
@@ -64,10 +64,10 @@ class Command(BaseCommand):
 
             # count after
             siae_etp_count_after = Siae.objects.filter(c2_etp_count__isnull=False).count()
-            yesterday = datetime.now() - timedelta(days=1)
+            date_yesterday = datetime.now() - timedelta(days=1)
             siae_etp_updated = (
                 Siae.objects.filter(c2_etp_count__isnull=False)
-                .filter(c2_etp_count_last_sync_date__gte=timezone.make_aware(yesterday))
+                .filter(c2_etp_count_last_sync_date__gte=timezone.make_aware(date_yesterday))
                 .count()
             )
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -65,7 +65,7 @@ class TenderQuerySet(models.QuerySet):
 
     def with_deadline_date_is_outdated(self, limit_date=datetime.today()):
         return self.annotate(
-            deadline_date_is_outdated=ExpressionWrapper(Q(deadline_date__gte=limit_date), output_field=BooleanField())
+            deadline_date_is_outdated=ExpressionWrapper(Q(deadline_date__lt=limit_date), output_field=BooleanField())
         )
 
     def order_by_deadline_date(self, limit_date=datetime.today()):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -70,7 +70,7 @@ class TenderQuerySet(models.QuerySet):
 
     def order_by_deadline_date(self, limit_date=datetime.today()):
         return self.with_deadline_date_is_outdated(limit_date=limit_date).order_by(
-            "-deadline_date_is_outdated", "deadline_date", "-updated_at"
+            "deadline_date_is_outdated", "deadline_date", "-updated_at"
         )
 
     def with_siae_stats(self):


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/547

Modifications apportées : 
- répare le calcul de `deadline_date_is_outdated` : True si deadline_date < today
- répare l'ordre de `order_by_deadline_date` : afficher en premier les besoins non-outdated et avec une deadline_date la plus proche de today
- ajoute des tests