### PR TITLE
Dépôt de besoin : cacher le CTA si le besoin est clôturé

### DIFF
--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -1,8 +1,14 @@
-{% if tender.author == request.user %}
-    <h2>Coordonnées</h2>
-{% else %}
-    <h2>Pour plus d'information et/ou afin de répondre, utilisez les coordonnées suivantes :</h2>
-{% endif %}
+
+<h2>
+    {% if tender.author == request.user %}
+        Coordonnées
+    {% else %}
+        Pour plus d'information et/ou afin de répondre, utilisez les coordonnées suivantes :
+    {% endif %}
+    {% if tender.deadline_date_outdated %}
+        <span class="badge badge-sm badge-base badge-pill badge-pilotage float-right">Clôturé</span>
+    {% endif %}
+</h2>
 
 <div class="row">
     {% if tender.contact_full_name %}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -78,6 +78,12 @@
                             Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite.
                         </p>
                     </div>
+                {% elif tender.deadline_date_outdated %}
+                    <div class="row">
+                        <div class="col-12">
+                            <span class="badge badge-sm badge-base badge-pill badge-pilotage float-right">Clôturé</span>
+                        </div>
+                    </div>
                 {% else %}
                     <div class="row">
                         <div class="col-12">


### PR DESCRIPTION
### Quoi ?

Suite de #551 

- pour une SIAE, cacher le CTA si le date de réponse est dépassée (et ajouter le badge 'Clôturé' à la place)
- si la structure s'est montrée intéressée, toujours afficher les contact mais rajouter le badge 'Clôturé'