### PR TITLE
Dépôt de besoin : détail : infobulle pour les contact

### DIFF
--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -3,7 +3,7 @@
     {% if tender.author == request.user %}
         Coordonnées
     {% else %}
-        Pour plus d'information et/ou afin de répondre, utilisez les coordonnées suivantes :
+        Contactez le client dès maintenant
     {% endif %}
 </h2>
 

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -30,7 +30,7 @@
         <div class="col-12 col-lg-8">
             {% include "tenders/detail_card.html" with tender=tender is_draft=is_draft %}
         </div>
-        {% if user_siae_has_contact_click_date %}
+        {% if user_siae_has_contact_click_date and not tender.deadline_date_outdated %}
             <div class="col-12 col-lg-4">
                 <div class="alert alert-info mt-3 mt-lg-0" role="alert">
                     <p class="mb-1">

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -30,6 +30,20 @@
         <div class="col-12 col-lg-8">
             {% include "tenders/detail_card.html" with tender=tender is_draft=is_draft %}
         </div>
+        {% if user_siae_has_contact_click_date %}
+            <div class="col-12 col-lg-4">
+                <div class="alert alert-info mt-3 mt-lg-0" role="alert">
+                    <p class="mb-1">
+                        <i class="ri-information-line ri-lg"></i>
+                        <strong>Conseil</strong>
+                    </p>
+                    <p class="mb-0 fs-sm">
+                        N'attendez pas et contactez dès maintenant le client.
+                        En fonction, envoyez lui un devis, une plaquette commerciale ou répondez à son marché.
+                    </p>
+                </div>
+            </div>
+        {% endif %}
     </div>
 </section>
 {% endblock %}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -139,7 +139,13 @@
         {% if source_form or tender.author == request.user or tender.accept_share_amount %}
             <hr class="my-5">
 
-            <h2>Montant du marché</h2>
+            <h2>
+                {% if tender.author == request.user %}
+                    Montant du marché
+                {% else %}
+                    Budget du client
+                {% endif %}
+            </h2>
             <p>{{ tender.get_amount_display|default:"-" }}</p>
             {% if source_form or tender.author == request.user %}
                 <p>{{ tender.accept_share_amount_display }}</p>

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -6,6 +6,7 @@ import factory.fuzzy
 from django.utils import timezone
 from factory.django import DjangoModelFactory
 
+from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import PartnerShareTender, Tender
 from lemarche.users.factories import UserFactory
 
@@ -40,7 +41,7 @@ class TenderFactory(DjangoModelFactory):
     contact_last_name = factory.Sequence("last_name{0}".format)
     contact_email = factory.Sequence("email_contact_tender{0}@example.com".format)
     contact_phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
-    # amount = tender_constants.AMOUNT_RANGE_1000_MORE
+    amount = tender_constants.AMOUNT_RANGE_100_150
     # marche_benefits = factory.fuzzy.FuzzyChoice([key for (key, _) in constants.MARCHE_BENEFIT_CHOICES])
 
     @factory.post_generation

--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -6,7 +6,6 @@ import factory.fuzzy
 from django.utils import timezone
 from factory.django import DjangoModelFactory
 
-from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import PartnerShareTender, Tender
 from lemarche.users.factories import UserFactory
 
@@ -41,7 +40,7 @@ class TenderFactory(DjangoModelFactory):
     contact_last_name = factory.Sequence("last_name{0}".format)
     contact_email = factory.Sequence("email_contact_tender{0}@example.com".format)
     contact_phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
-    amount = tender_constants.AMOUNT_RANGE_100_150
+    # amount = tender_constants.AMOUNT_RANGE_100_150
     # marche_benefits = factory.fuzzy.FuzzyChoice([key for (key, _) in constants.MARCHE_BENEFIT_CHOICES])
 
     @factory.post_generation

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -430,7 +430,7 @@ class TenderDetailViewTest(TestCase):
         self.client.force_login(self.siae_user_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertContains(response, "utilisez les coordonnées suivantes")
+        self.assertContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # siae user not concerned
         self.client.force_login(self.siae_user_2)
@@ -463,7 +463,7 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
         response = self.client.get(url)
         self.assertContains(response, "Clôturé")
-        self.assertNotContains(response, "utilisez les coordonnées suivantes")
+        self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # siae user not concerned
         self.client.force_login(self.siae_user_2)
@@ -484,7 +484,7 @@ class TenderDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "Clôturé")
         self.assertContains(response, "Coordonnées")
-        self.assertNotContains(response, "utilisez les coordonnées suivantes")
+        self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
 
     def test_some_partners_can_display_contact_details(self):
@@ -493,7 +493,7 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "via le chat de discussion")
-        self.assertNotContains(response, "utilisez les coordonnées suivantes")
+        self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # this one can!
         user_partner_2 = UserFactory(kind=User.KIND_PARTNER, can_display_tender_contact_details=True)
@@ -501,7 +501,7 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertNotContains(response, "via le chat de discussion")
-        self.assertContains(response, "utilisez les coordonnées suivantes")
+        self.assertContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
 
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.contrib.gis.geos import Point
 from django.test import TestCase
@@ -261,14 +261,14 @@ class TenderListViewTest(TestCase):
         cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
         cls.user_partner = UserFactory(kind=User.KIND_PARTNER)
-        cls.tender = TenderFactory(author=cls.user_buyer_1, validated_at=date.today(), perimeters=[perimeter])
+        cls.tender = TenderFactory(author=cls.user_buyer_1, validated_at=timezone.now(), perimeters=[perimeter])
         cls.tender_2 = TenderFactory(
-            author=cls.user_buyer_1, deadline_date=date.today() - timedelta(days=5), perimeters=[perimeter]
+            author=cls.user_buyer_1, deadline_date=timezone.now() - timedelta(days=5), perimeters=[perimeter]
         )
         cls.tender_3 = TenderFactory(
             author=cls.user_buyer_1,
-            validated_at=date.today(),
-            deadline_date=date.today() - timedelta(days=5),
+            validated_at=timezone.now(),
+            deadline_date=timezone.now() - timedelta(days=5),
             perimeters=[perimeter],
         )
         cls.tendersiae_3_1 = TenderSiae.objects.create(


### PR DESCRIPTION
### Quoi ?

- afficher une infobulle pour inciter les structures intéressées à entre en contact avec l'acheteur
- modifier le wording de la section montant : "Budget du client" pour les utilisateurs autres que l'auteur
- ajout de tests

### Capture d'écran

![Screenshot from 2022-12-14 10-08-41](https://user-images.githubusercontent.com/7147385/207553854-76221a8a-b100-4456-b8f3-0bf9b5d42f21.png)
