### PR TITLE
Mise a jour du dockerfile

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------
 # Base-image
 # ----------------------------------------------------
-FROM python:3.9-slim-buster as common-base
+FROM python:3.10-slim-buster as common-base
 # Django directions: https://blog.ploetzli.ch/2020/efficient-multi-stage-build-django-docker/
 # Pip on docker : https://pythonspeed.com/articles/multi-stage-docker-python/
 # https://blog.mikesir87.io/2018/07/leveraging-multi-stage-builds-single-dockerfile-dev-prod/
@@ -17,7 +17,7 @@ ENV PYTHONFAULTHANDLER=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_VERSION=1.1.1 \
+    POETRY_VERSION=1.1.4 \
     NODE_VERSION=15
 
 ENV HOST=0.0.0.0 \
@@ -35,7 +35,7 @@ FROM common-base AS dependencies
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install "poetry==$POETRY_VERSION"
+RUN pip install poetry==$POETRY_VERSION
 RUN pip install -I uwsgi
 
 #     apt-get install build-essential -y


### PR DESCRIPTION
### Quoi ?

Correction des erreurs d'installation poetry via docker

### Pourquoi ?

Depuis un moment il m'était impossible d'installer la version docker en local car j'avais de nombreuses erreurs a l'install. En cherchant je me suis rendu compte que mon poetry en local était en 1.2.2 alors que la version du dockerfile était en 1.1.1.
 
L'installation de poetry du dockerfile n'était pas prise en compte (surement à cause des `"` en ligne  38).
En retirant les `"` elle était bien prise en compte, mais la version 1.1.1 était trop vielle pour certaines dépendances, donc je suis passé à la 1.1.4 (version de rupture d'un truc apparemment)

Malgré ça l'installation se passait mal car poetry nécessitait une version python > 3.10, alors j'ai aussi mis a jour l'image de python du docker. Et maintenant, ça tourne crème 🎯

Par contre, j'espère que ça passera aussi chez Madjid car il utilise aussi docker pour postgres je crois
 