### PR TITLE
Mise à jour de l'ui de la page de résultat de recherche

### DIFF
--- a/lemarche/static/itou_marche/components/_maparea.scss
+++ b/lemarche/static/itou_marche/components/_maparea.scss
@@ -10,18 +10,14 @@
 	width: 100%;
 }
 
-// #map-siae-list
-.siae-info-sticky .map-holder {
+// siae search results view
+#searchResults .map-holder {
 	height: 19rem;
 	border-radius: 5px;
 	border: $gray-500 solid 1px;
 }
 
-// #map-siae
+// siae detail view
 #sidebar .map-holder {
 	height: 200px;
-	width: 100%;
 }
-
-// #map-siae-edit
-// see defaults

--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -15,12 +15,10 @@
 }
 
 .s-siae-02 {
-	background-color: $gray-400;
-	padding-top: 1.5rem;
-	padding-bottom: 1.5rem;
+	padding-top: 0.5rem;
+	padding-bottom: 3rem;
 
 	@media (min-width:992px) {
-		padding-top: 2rem;
 		padding-bottom: 5rem;
 	}
 
@@ -354,7 +352,7 @@ $purple-marche: #6C38D9;
     background-color: $purple-marche!important;
 }
 
-.text-marche-purple{
+.text-marche-purple {
 	color: $purple-marche;
 }
 

--- a/lemarche/templates/includes/_pagination.html
+++ b/lemarche/templates/includes/_pagination.html
@@ -1,7 +1,7 @@
 {% load url_add_query %}
 
 {% if is_paginated %}
-<nav class="nav-pagination mb-5">
+<nav class="nav-pagination mb-3 mb-md-5">
     {% if paginator.num_pages > 1 %}
         <ul class="pagination justify-content-center">
             {% if page_obj.number > 1 %}

--- a/lemarche/templates/pages/company-reference-calculator.html
+++ b/lemarche/templates/pages/company-reference-calculator.html
@@ -82,7 +82,7 @@
                                 Bravo ! Votre entreprise travaille déjà avec <strong>{{ results.count }}</strong> prestataires inclusifs.
                             </p>
                             <div class="d-block d-lg-inline-block">
-                                <a href="{% url 'siae:search_results' %}?{{ current_search_query }}#searchContent" id="company-reference-calculator-siae-list-btn" class="btn btn-block btn-outline-primary btn-ico" target="_blank">
+                                <a href="{% url 'siae:search_results' %}?{{ current_search_query }}#searchResults" id="company-reference-calculator-siae-list-btn" class="btn btn-block btn-outline-primary btn-ico" target="_blank">
                                     <span>Découvrir ces prestataires</span>
                                     <i class="ri-arrow-right-s-line"></i>
                                 </a>

--- a/lemarche/templates/pages/impact-calculator.html
+++ b/lemarche/templates/pages/impact-calculator.html
@@ -97,7 +97,7 @@
                             et plus de <b>{{ results_aggregated.employees_insertion__sum|intcomma }}</b> salariés en insertion.
                         </p>
                         <div class="d-block d-lg-inline-block">
-                            <a href="{% url 'siae:search_results' %}?{{ current_search_query }}#searchContent" id="calibrate-calculator-siae-list-btn" class="btn btn-block btn-outline-primary btn-ico" target="_blank">
+                            <a href="{% url 'siae:search_results' %}?{{ current_search_query }}#searchResults" id="calibrate-calculator-siae-list-btn" class="btn btn-block btn-outline-primary btn-ico" target="_blank">
                                 <span>Découvrir ces prestataires</span>
                                 <i class="ri-arrow-right-s-line ri-lg"></i>
                             </a>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -15,7 +15,7 @@
         <div class="col">
             <div class="card-body">
                 <a href="{% url 'siae:detail' siae.slug %}" target="_blank" id="search-results-siae-card" class="text-decoration-none stretched-link">
-                    <h2 class="mb-3 mr-5">
+                    <h2 class="h4 mb-3 mr-5">
                         {{ siae.name_display }}
                         {% if not siae.user_count %}
                             <span class="fs-sm font-weight-normal">(bientôt inscrite sur le marché)</span>

--- a/lemarche/templates/siaes/_card_suggest_tender.html
+++ b/lemarche/templates/siaes/_card_suggest_tender.html
@@ -1,7 +1,7 @@
 {% comment %} {% load static bootstrap4 %} {% endcomment %}
 
 <div class="c-box mb-4">
-    <div class="row justify-content-center">
+    <div class="row">
         <div class="col-md">
             <span class="badge badge-sm badge-pill badge-warning-light mb-2">Information pratique</span>
             <h2 class="h2 mb-2">Pas de temps à perdre ?</h1>
@@ -10,42 +10,42 @@
                 <i class="ri-mail-send-line ri-lg"></i>&nbsp;Publier un besoin d'achat
             </a>
         </div>
-        {% if current_perimeters %}
+        {% if current_perimeters or current_sectors %}
             <div class="col-md">
-                {% with perimeters_length=current_perimeters|length %}
-                    <h5>Lieu{{ perimeters_length|pluralize:"x" }} d'intervention</h5>
-                    {% for perimeter in current_perimeters %}
-                        <span class="badge badge-base badge-outline-primary mr-1">{{ perimeter.name }}</span>
-                        {% if forloop.counter == 2 and perimeters_length > 2 %}
-                            <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#perimetersSearchHidden" role="button" aria-expanded="false" aria-controls="perimetersSearchHidden">
-                                Afficher les {{ perimeters_length|add:"-2" }} autres lieux d'interventions
-                            </a>
-                            <div id="perimetersSearchHidden" class="collapse">
-                        {% endif %}
-                        {% if forloop.counter == perimeters_length and perimeters_length > 2 %}
-                            </div>
-                        {% endif %}
-                    {% endfor %}
-                {% endwith %}
-            </div>
-        {% endif %}
-        {% if current_sectors %}
-            <div class="col-md">
-                {% with sectors_length=current_sectors|length %}
-                    <h5 class="mt-4">Secteur{{ sectors_length|pluralize }} d'activité</h5>
-                    {% for sector in current_sectors %}
-                        <span class="badge badge-base badge-outline-primary ml-0 mb-1">{{ sector.name|truncatechars:42 }}</span><br>
-                        {% if forloop.counter == 2 and sectors_length > 2 %}
-                            <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#sectorsSearchHidden" role="button" aria-expanded="false" aria-controls="sectorsSearchHidden">
-                                Afficher les {{ sectors_length|add:"-2" }} autres secteurs
-                            </a>
-                            <div id="sectorsSearchHidden" class="collapse">
-                        {% endif %}
-                        {% if forloop.counter == sectors_length and sectors_length > 2  %}
-                            </div>
-                        {% endif %}
-                    {% endfor %}
-                {% endwith %}
+                {% if current_perimeters %}
+                    {% with perimeters_length=current_perimeters|length %}
+                        <h5 class="mb-2">Lieu{{ perimeters_length|pluralize:"x" }} d'intervention</h5>
+                        {% for perimeter in current_perimeters %}
+                            <span class="badge badge-base badge-outline-primary mr-1">{{ perimeter.name }}</span>
+                            {% if forloop.counter == 2 and perimeters_length > 2 %}
+                                <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#perimetersSearchHidden" role="button" aria-expanded="false" aria-controls="perimetersSearchHidden">
+                                    Afficher les {{ perimeters_length|add:"-2" }} autres lieux d'interventions
+                                </a>
+                                <div id="perimetersSearchHidden" class="collapse">
+                            {% endif %}
+                            {% if forloop.counter == perimeters_length and perimeters_length > 2 %}
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    {% endwith %}
+                {% endif %}
+                {% if current_sectors %}
+                    {% with sectors_length=current_sectors|length %}
+                        <h5 class="{% if current_perimeters %}mt-4{% endif %} mb-2">Secteur{{ sectors_length|pluralize }} d'activité</h5>
+                        {% for sector in current_sectors %}
+                            <span class="badge badge-base badge-outline-primary ml-0 mb-1">{{ sector.name|truncatechars:42 }}</span><br>
+                            {% if forloop.counter == 2 and sectors_length > 2 %}
+                                <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#sectorsSearchHidden" role="button" aria-expanded="false" aria-controls="sectorsSearchHidden">
+                                    Afficher les {{ sectors_length|add:"-2" }} autres secteurs
+                                </a>
+                                <div id="sectorsSearchHidden" class="collapse">
+                            {% endif %}
+                            {% if forloop.counter == sectors_length and sectors_length > 2  %}
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    {% endwith %}
+                {% endif %}
             </div>
         {% endif %}
     </div>

--- a/lemarche/templates/siaes/_card_suggest_tender.html
+++ b/lemarche/templates/siaes/_card_suggest_tender.html
@@ -1,48 +1,52 @@
 {% comment %} {% load static bootstrap4 %} {% endcomment %}
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <span class="badge badge-sm badge-pill badge-warning-light mb-2">Information pratique</span>
-        <h2 class="h2 mb-2">Pas de temps à perdre ?</h1>
-        <p>Confiez-nous votre recherche (ou sourcing) et recevez des réponses de prestataires inclusifs en moins de 24h.</p>
-        <a href="{% url 'tenders:create' %}" id="siae-search-insert-tender-create-btn" class="btn btn-primary btn-sm btn-ico d-block d-md-inline-block mb-2">
-            <i class="ri-mail-send-line ri-lg"></i>&nbsp;Publier un besoin d'achat
-        </a>
-    </div>
-    <div class="col-md-6">
+<div class="c-box mb-4">
+    <div class="row justify-content-center">
+        <div class="col-md">
+            <span class="badge badge-sm badge-pill badge-warning-light mb-2">Information pratique</span>
+            <h2 class="h2 mb-2">Pas de temps à perdre ?</h1>
+            <p>Confiez-nous votre recherche (ou sourcing) et recevez des réponses de prestataires inclusifs en moins de 24h.</p>
+            <a href="{% url 'tenders:create' %}" id="siae-search-insert-tender-create-btn" class="btn btn-primary btn-sm btn-ico d-block d-md-inline-block mb-2">
+                <i class="ri-mail-send-line ri-lg"></i>&nbsp;Publier un besoin d'achat
+            </a>
+        </div>
         {% if current_perimeters %}
-            {% with perimeters_length=current_perimeters|length %}
-                <h5>Lieu{{ perimeters_length|pluralize:"x" }} d'intervention</h5>
-                {% for perimeter in current_perimeters %}
-                    <span class="badge badge-base badge-outline-primary mr-1">{{ perimeter.name }}</span>
-                    {% if forloop.counter == 2 and perimeters_length > 2 %}
-                        <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#perimetersSearchHidden" role="button" aria-expanded="false" aria-controls="perimetersSearchHidden">
-                            Afficher les {{ perimeters_length|add:"-2" }} autres lieux d'interventions
-                        </a>
-                        <div id="perimetersSearchHidden" class="collapse">
-                    {% endif %}
-                    {% if forloop.counter == perimeters_length and perimeters_length > 2 %}
-                        </div>
-                    {% endif %}
-                {% endfor %}
-            {% endwith %}
+            <div class="col-md">
+                {% with perimeters_length=current_perimeters|length %}
+                    <h5>Lieu{{ perimeters_length|pluralize:"x" }} d'intervention</h5>
+                    {% for perimeter in current_perimeters %}
+                        <span class="badge badge-base badge-outline-primary mr-1">{{ perimeter.name }}</span>
+                        {% if forloop.counter == 2 and perimeters_length > 2 %}
+                            <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#perimetersSearchHidden" role="button" aria-expanded="false" aria-controls="perimetersSearchHidden">
+                                Afficher les {{ perimeters_length|add:"-2" }} autres lieux d'interventions
+                            </a>
+                            <div id="perimetersSearchHidden" class="collapse">
+                        {% endif %}
+                        {% if forloop.counter == perimeters_length and perimeters_length > 2 %}
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                {% endwith %}
+            </div>
         {% endif %}
         {% if current_sectors %}
-            {% with sectors_length=current_sectors|length %}
-                <h5 class="mt-4">Secteur{{ sectors_length|pluralize }} d'activité</h5>
-                {% for sector in current_sectors %}
-                    <span class="badge badge-base badge-outline-primary ml-0 mb-1">{{ sector.name|truncatechars:42 }}</span><br>
-                    {% if forloop.counter == 2 and sectors_length > 2 %}
-                        <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#sectorsSearchHidden" role="button" aria-expanded="false" aria-controls="sectorsSearchHidden">
-                            Afficher les {{ sectors_length|add:"-2" }} autres secteurs
-                        </a>
-                        <div id="sectorsSearchHidden" class="collapse">
-                    {% endif %}
-                    {% if forloop.counter == sectors_length and sectors_length > 2  %}
-                        </div>
-                    {% endif %}
-                {% endfor %}
-            {% endwith %}
+            <div class="col-md">
+                {% with sectors_length=current_sectors|length %}
+                    <h5 class="mt-4">Secteur{{ sectors_length|pluralize }} d'activité</h5>
+                    {% for sector in current_sectors %}
+                        <span class="badge badge-base badge-outline-primary ml-0 mb-1">{{ sector.name|truncatechars:42 }}</span><br>
+                        {% if forloop.counter == 2 and sectors_length > 2 %}
+                            <a class="w-100 d-block text-decoration-none has-collapse-caret collapsed" data-toggle="collapse" href="#sectorsSearchHidden" role="button" aria-expanded="false" aria-controls="sectorsSearchHidden">
+                                Afficher les {{ sectors_length|add:"-2" }} autres secteurs
+                            </a>
+                            <div id="sectorsSearchHidden" class="collapse">
+                        {% endif %}
+                        {% if forloop.counter == sectors_length and sectors_length > 2  %}
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                {% endwith %}
+            </div>
         {% endif %}
     </div>
 </div>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -41,7 +41,7 @@
                             <div class="gallery-small col-12 col-lg-3">
                                 <div class="img-container">
                                     {% if siae.logo_url %}
-                                        <img src="{{ siae.logo_url }}" class="img-fluid" alt="Logo de la structure {{ siae.name }}" />
+                                        <img src="{{ siae.logo_url }}" class="img-fluid" alt="Logo du prestataire {{ siae.name }}" />
                                     {% else %}
                                         <img src="{% static 'img/default-listing.png' %}" class="img-fluid" alt="{{ siae.name }}" />
                                     {% endif %}
@@ -254,7 +254,7 @@
                                     <img src="{% static_theme_images 'ico-bicro-marche-descript-act.svg' %}" alt="" height="32" />
                                 </div>
                                 <div class="il-r">
-                                    <h3 class="h2 mb-1 mt-1">Présentation de la structure</h3>
+                                    <h3 class="h2 mb-1 mt-1">Présentation du prestataire</h3>
                                     <div>
                                         {% if siae.description %}
                                             {{ siae.description|linebreaks }}

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -122,7 +122,7 @@
 <section class="s-siae-02">
     <div class="container">
         <div id="dir_list">
-            <div id="searchContent" class="row dir_list-row">
+            <div id="searchResults" class="row dir_list-row">
                 <div class="col-12 col-lg-8">
                     <div class="c-box mb-3">
                         <div class="d-flex align-items-center mb-3">
@@ -130,7 +130,7 @@
                                 <h1 class="h4 mb-0">
                                     {% with paginator.count as siae_count %}
                                         {% if siae_count > 0 %}
-                                        {{ siae_count }} prestataire{% siae_count|pluralize %} correspond{% siae_count|pluralize:"ent" %} à vos critères
+                                        {{ siae_count }} prestataire{{ siae_count|pluralize }} correspond{{ siae_count|pluralize:"ent" }} à vos critères
                                         {% else %}
                                             Oups, aucun prestataire trouvé !
                                         {% endif %}
@@ -169,16 +169,17 @@
                         {% endif %}
                     </div>
                 </div>
+                <!-- sidebar -->
                 <div class="col-12 col-lg-4 siae-info mt-6 mt-sm-0">
+                    <div class="map-holder mb-4">
+                        <div id="map-siae-list" class="map-canvas"></div>
+                    </div>
+
+                    {% cms_advert layout="card" %}
+
                     <div class="siae-info-sticky c-box bg-light mb-3">
-                        <div class="map-holder mb-4">
-                            <div id="map-siae-list" class="map-canvas"></div>
-                        </div>
-
-                        {% cms_advert layout="card" %}
-
                         <div class="si-ideas">
-                            <h3 class="h4 my-3">Idées reçues</h3>
+                            <h3 class="h4">Idées reçues</h3>
                             <p>
                                 <span>
                                     <i class="ri-check-fill ri-xl font-weight-bold"></i>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load static bootstrap4 wagtailcore_tags advert_cms %}
 
-{% block title %}Trouvez votre prestataire parmi 8600 structures inclusives{{ block.super }}{% endblock %}
+{% block title %}Trouvez votre prestataire parmi 8600 prestataires inclusifs{{ block.super }}{% endblock %}
 {% block meta_description %}
     <meta name="description" content="Recherchez en fonction de votre segment d'achats, périmètre géographique et types de prestation afin de trouver le prestataire idéal.">
 {% endblock %}
@@ -49,7 +49,7 @@
                 </ul>
                 <div class="tab-content">
                     <div class="tab-pane fade" id="search-filter" role="tabpanel" aria-labelledby="search-filter-tab">
-                        <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                        <form method="GET" action="{% url 'siae:search_results' %}" id="filter-search-form" aria-label="Rechercher des prestataires de l'insertion et du handicap" role="search">
                             {% bootstrap_form_errors form type="all" %}
                             <div class="row align-items-start">
                                 <div class="col-12 col-md-6 col-lg-4">
@@ -93,7 +93,7 @@
                         </form>
                     </div>
                     <div class="tab-pane fade" id="search-text" role="tabpanel" aria-labelledby="search-text-tab">
-                        <form method="GET" action="{% url 'siae:search_results' %}" id="text-search-form" aria-label="Rechercher des structures de l’insertion et du handicap" role="search">
+                        <form method="GET" action="{% url 'siae:search_results' %}" id="text-search-form" aria-label="Rechercher des prestataires de l'insertion et du handicap" role="search">
                             {% bootstrap_form_errors form type="all" %}
                             <div class="row">
                                 <div class="col-12 col-lg-8">
@@ -185,8 +185,8 @@
                                     <i class="ri-check-fill ri-xl font-weight-bold"></i>
                                 </span>
                                 <span class="ml-2">
-                                    La structure est trop petite pour répondre à mon besoin…
-                                    <b>Mais elle est sûrement ouverte à la co-traitance.</b>
+                                    Le prestataire est trop petit pour répondre à mon besoin…
+                                    <b>Mais il est sûrement ouvert à la co-traitance.</b>
                                 </span>
                             </p>
                             <p>
@@ -194,7 +194,7 @@
                                     <i class="ri-check-fill ri-xl font-weight-bold"></i>
                                 </span>
                                 <span class="ml-2">
-                                    Son chiffre d’affaire est trop bas et je ne veux pas être
+                                    Son chiffre d'affaire est trop bas et je ne veux pas être
                                     son seul client… <b>Mais Vous pouvez commencer par lui confier
                                     un marché de plus faible périmètre, sans prendre de risque,
                                     puis faire grandir ce partenariat si vous en êtes satisfait.</b>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -3,8 +3,10 @@
 
 {% block title %}Trouvez votre prestataire parmi 8600 structures inclusives{{ block.super }}{% endblock %}
 {% block meta_description %}
-<meta name="description" content="Recherchez en fonction de votre segment d'achats, périmètre géographique et types de prestation afin de trouver le prestataire idéal.">
+    <meta name="description" content="Recherchez en fonction de votre segment d'achats, périmètre géographique et types de prestation afin de trouver le prestataire idéal.">
 {% endblock %}
+
+{% block body_class %}bg-light{% endblock %}"
 
 {% block breadcrumbs %}
 <section>
@@ -120,70 +122,63 @@
 <section class="s-siae-02">
     <div class="container">
         <div id="dir_list">
-            <div id="searchContent" class="row">
-                <div class="col-12 col-lg-8 d-flex mb-3 mb-md-5">
-                    <div class="row align-items-center">
-                        <div class="col-12 col-lg">
-                            <h1 class="h2 mb-1">
-                                {% with paginator.count as siae_count %}
-                                    {% if siae_count > 0 %}
-                                        {{ siae_count }} structure{% if siae_count > 1 %}s{% endif %} correspond{% if siae_count > 1 %}ent{% endif %} à vos critères
-                                    {% else %}
-                                        Oups, nous n'avons pas trouvé de prestataires !
-                                    {% endif %}
-                                {% endwith %}
-                            </h1>
+            <div id="searchContent" class="row dir_list-row">
+                <div class="col-12 col-lg-8">
+                    <div class="c-box mb-3">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="flex-grow-1">
+                                <h1 class="h4 mb-0">
+                                    {% with paginator.count as siae_count %}
+                                        {% if siae_count > 0 %}
+                                        {{ siae_count }} prestataire{% siae_count|pluralize %} correspond{% siae_count|pluralize:"ent" %} à vos critères
+                                        {% else %}
+                                            Oups, aucun prestataire trouvé !
+                                        {% endif %}
+                                    {% endwith %}
+                                </h1>
+                            </div>
+                            {% if siaes %}
+                                <div class="col-12 col-lg-auto">
+                                    {% include "siaes/_share_search_results.html" %}
+                                </div>
+                            {% endif %}
                         </div>
                         {% if siaes %}
-                            <div class="col-12 col-lg-auto">
-                                {% include "siaes/_share_search_results.html" %}
-                            </div>
+                            {% for siae in siaes %}
+                                {% include "siaes/_card_search_result.html" with siae=siae %}
+                                <!-- insert to nudge tender creation -->
+                                {% if forloop.counter in position_promote_tenders and page_obj.number == 1 %}
+                                    {% include "siaes/_card_suggest_tender.html" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% include "includes/_pagination.html" %}
+                        {% else %}
+                            <!-- no results -->
+                            <p>
+                                Il y a encore de l'espoir ❤️
+                            </p>
+                            <p>
+                                Publiez votre besoin, et on s'occupe de vous trouver des prestataires inclusifs.
+                            </p>
+                            <p>
+                                Obtenez des réponses en moins de 24 heures (en moyenne).
+                            </p>
+                            <a href="{% url 'tenders:create' %}" id="siae-search-empty-demande" class="btn btn-primary d-block d-md-inline-block mb-2">
+                                <i class="ri-mail-send-line ri-lg mr-2"></i>Publier un besoin d'achat
+                            </a>
                         {% endif %}
                     </div>
-                </div>
-            </div>
-            <div class="row dir_list-row">
-                <div class="col-12 col-lg-8">
-                {% if siaes %}
-                    {% for siae in siaes %}
-                        {% include "siaes/_card_search_result.html" with siae=siae %}
-                        <!-- insert to nudge tender creation -->
-                        {% if forloop.counter in position_promote_tenders and page_obj.number == 1 %}
-                            {% include "siaes/_card_suggest_tender.html" %}
-                        {% endif %}
-                    {% endfor %}
-
-                    {% include "includes/_pagination.html" %}
-                {% else %}
-                    <!-- no results -->
-                    <div>
-                        <p>
-                            Il y a encore de l'espoir ❤️
-                        </p>
-                        <p>
-                            Publiez votre besoin, et on s'occupe de vous trouver des prestataires inclusifs.
-                        </p>
-                        <p>
-                            Obtenez des réponses en moins de 24 heures (en moyenne).
-                        </p>
-                        <a href="{% url 'tenders:create' %}" id="siae-search-empty-demande" class="btn btn-primary d-block d-md-inline-block mb-2">
-                            <i class="ri-mail-send-line ri-lg mr-2"></i>Publier un besoin d'achat
-                        </a>
-                    </div>
-                {% endif %}
                 </div>
                 <div class="col-12 col-lg-4 siae-info mt-6 mt-sm-0">
-                    <div class="siae-info-sticky">
-
+                    <div class="siae-info-sticky c-box bg-light mb-3">
                         <div class="map-holder mb-4">
                             <div id="map-siae-list" class="map-canvas"></div>
                         </div>
-                        <hr />
 
                         {% cms_advert layout="card" %}
 
                         <div class="si-ideas">
-                            <h3 class="h2 my-3">Idées reçues</h3>
+                            <h3 class="h4 my-3">Idées reçues</h3>
                             <p>
                                 <span>
                                     <i class="ri-check-fill ri-xl font-weight-bold"></i>


### PR DESCRIPTION
### Quoi ?

- mise à jour de l'ui de la page de résultat de recherche
- renommé "structures" en "prestataires"

### Pourquoi ?

Pour réponde a ce ticket https://www.notion.so/Page-recherche-C4-5998f004ef5c419c9c517023c856766d

### Comment ?

Templating / DOM

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-04-03 12-20-58](https://user-images.githubusercontent.com/7147385/229483403-a39aac07-6b29-4787-bab8-b9dee2d8cf96.png)|![Screenshot from 2023-04-03 12-21-25](https://user-images.githubusercontent.com/7147385/229483442-d2d0f4e4-49a8-48d9-a1eb-482e827f85e8.png)|

### Autre (optionnel)

Je me suis permis en même temps de revoir l'ui de la partie `card_suggest_tender` mais si ça ne convient pas, je le vire.
![capture 2022-12-09 à 10 33 57](https://user-images.githubusercontent.com/3874024/206672862-77c40a9c-8f8a-46d9-a445-6ad57ae3465d.png)



