### PR TITLE
Supportix: Changer le wording pour le contact des  partenaire 

### DIFF
--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -67,7 +67,10 @@
                             <strong>Comment contacter le client ?</strong>
                         </p>
                         <p class="mb-0">
-                            Pour être mis en relation avec l'acheteur, contactez Sofiane ou Abdessamad via le chat de discussion qui se trouve en bas à droite.
+                            Contactez Sofiane via
+                            <a href="mailto:lemarche@inclusion.beta.gouv.fr?subject=Demande d'information pour {{tender.title}}">
+                                lemarche@inclusion.beta.gouv.fr</a>
+                            pour être mis en relation avec le client.
                         </p>
                     </div>
                 {% elif user.kind == user.KIND_SIAE and not user.has_siae %}

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -68,8 +68,8 @@
                         </p>
                         <p class="mb-0">
                             Contactez Sofiane via
-                            <a href="mailto:lemarche@inclusion.beta.gouv.fr?subject=Demande d'information pour {{tender.title}}">
-                                lemarche@inclusion.beta.gouv.fr</a>
+                            <a href="mailto:{{CONTACT_EMAIL}}?subject=Demande d'information pour {{tender.title}}">
+                                {{CONTACT_EMAIL}}</a>
                             pour être mis en relation avec le client.
                         </p>
                     </div>

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -18,6 +18,7 @@ def expose_settings(request):
         "MATOMO_TAG_MANAGER_CONTAINER_ID": settings.MATOMO_TAG_MANAGER_CONTAINER_ID,
         "CRISP_ID": settings.CRISP_ID,
         "API_GOUV_URL": settings.API_GOUV_URL,
+        "CONTACT_EMAIL": settings.CONTACT_EMAIL,
         # forms & docs
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,
         "FACILITATOR_LIST": settings.FACILITATOR_LIST,

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -537,7 +537,7 @@ class TenderDetailViewTest(TestCase):
         self.client.force_login(self.user_partner)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertContains(response, "via le chat de discussion")
+        self.assertContains(response, "pour être mis en relation avec le client.")
         self.assertNotContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
         # this one can!
@@ -545,7 +545,7 @@ class TenderDetailViewTest(TestCase):
         self.client.force_login(user_partner_2)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertNotContains(response, "via le chat de discussion")
+        self.assertNotContains(response, "pour être mis en relation avec le client.")
         self.assertContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, "Répondre à cette opportunité")
 


### PR DESCRIPTION
### Quoi ?

Changer le wording pour le contact des  partenaire (“Contacter Sofiane ou Abdess”)
