### PR TITLE
Dépôt de besoin : homogénéiser l'affichage du champ 'location'

### DIFF
--- a/lemarche/api/perimeters/tests.py
+++ b/lemarche/api/perimeters/tests.py
@@ -16,6 +16,7 @@ class PerimeterListFilterApiTest(TestCase):
             department_code="38",
             region_code="84",
             post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
         )
         cls.perimeter_department = PerimeterFactory(
             name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84"
@@ -56,6 +57,7 @@ class PerimetersAutocompleteFilterApiTest(TestCase):
             department_code="38",
             region_code="84",
             post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
         )
         cls.perimeter_department = PerimeterFactory(
             name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84"

--- a/lemarche/perimeters/tests.py
+++ b/lemarche/perimeters/tests.py
@@ -8,7 +8,13 @@ class PerimeterModelTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.perimeter_city = PerimeterFactory(
-            name="Grenoble", kind=Perimeter.KIND_CITY, insee_code="38185", department_code="38", region_code="84"
+            name="Grenoble",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38185",
+            department_code="38",
+            region_code="84",
+            post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
         )
         cls.perimeter_department = PerimeterFactory(
             name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84"

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -35,14 +35,7 @@
             </div>
             <div class="col" title="Lieu d'éxécution">
                 <i class="ri-map-pin-2-line"></i>
-                {% if tender.is_country_area %}
-                    France entière
-                {% elif tender.location %}
-                    {{ tender.location.name_display }}
-                {% else %}
-                    {% comment %} maintain legacy perimeters display {% endcomment %}
-                    {{tender.perimeters_list_string}}
-                {% endif %}
+                {{ tender.location_display }}
             </div>
             {% if tender.presta_type %}
                 <div class="col" title="Type de prestation">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -374,6 +374,16 @@ class Tender(models.Model):
         return ", ".join(self.perimeters.values_list("name", flat=True))
 
     @cached_property
+    def location_display(self):
+        if self.is_country_area:
+            return "France entière"
+        elif self.location:
+            return self.location.name_display
+        else:
+            # maintain legacy perimeters display
+            return self.perimeters_list_string
+
+    @cached_property
     def can_display_contact_email(self):
         return self.RESPONSE_KIND_EMAIL in self.response_kind and self.contact_email
 

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -28,14 +28,47 @@ date_last_week = datetime.now() - timedelta(days=7)
 
 
 class TenderModelTest(TestCase):
-    def setUp(self):
-        pass
-
     def test_str(self):
         str_test = "Mon test"
         tender = TenderFactory(title=str_test)
         self.assertEqual(str(tender), str_test)
 
+
+class TenderModelPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.grenoble_perimeter = PerimeterFactory(
+            name="Grenoble",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38185",
+            department_code="38",
+            region_code="84",
+            post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
+        )
+        cls.chamrousse_perimeter = PerimeterFactory(
+            name="Chamrousse",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38567",
+            department_code="38",
+            region_code="84",
+            post_codes=["38410"],
+            # coords=Point(5.8862, 45.1106),
+        )
+
+    def test_location_display(self):
+        tender_country_area = TenderFactory(title="Besoin 1", is_country_area=True)
+        self.assertEqual(tender_country_area.location_display, "France entière")
+        tender_location = TenderFactory(title="Besoin 2", location=self.grenoble_perimeter)
+        self.assertTrue("Grenoble" in tender_location.location_display)
+        tender_perimeters = TenderFactory(
+            title="Besoin 3", perimeters=[self.grenoble_perimeter, self.chamrousse_perimeter]
+        )
+        self.assertTrue("Grenoble" in tender_perimeters.location_display)
+        self.assertTrue("Chamrousse" in tender_perimeters.location_display)
+
+
+class TenderModelSaveTest(TestCase):
     def test_set_slug(self):
         tender = TenderFactory(title="Un besoin")
         self.assertEqual(tender.slug, "un-besoin")
@@ -67,8 +100,26 @@ class TenderModelTest(TestCase):
 
 
 class TenderModelQuerysetTest(TestCase):
-    def setUp(self):
-        pass
+    @classmethod
+    def setUpTestData(cls):
+        cls.grenoble_perimeter = PerimeterFactory(
+            name="Grenoble",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38185",
+            department_code="38",
+            region_code="84",
+            post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
+        )
+        cls.chamrousse_perimeter = PerimeterFactory(
+            name="Chamrousse",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38567",
+            department_code="38",
+            region_code="84",
+            post_codes=["38410"],
+            # coords=Point(5.8862, 45.1106),
+        )
 
     def test_by_user_queryset(self):
         user = UserFactory()
@@ -107,29 +158,11 @@ class TenderModelQuerysetTest(TestCase):
         isere_perimeter = PerimeterFactory(
             name="Isère", kind=Perimeter.KIND_DEPARTMENT, insee_code="38", region_code="84"
         )
-        grenoble_perimeter = PerimeterFactory(
-            name="Grenoble",
-            kind=Perimeter.KIND_CITY,
-            insee_code="38185",
-            department_code="38",
-            region_code="84",
-            post_codes=["38000", "38100", "38700"],
-            # coords=Point(5.7301, 45.1825),
-        )
-        chamrousse_perimeter = PerimeterFactory(
-            name="Chamrousse",
-            kind=Perimeter.KIND_CITY,
-            insee_code="38567",
-            department_code="38",
-            region_code="84",
-            post_codes=["38410"],
-            # coords=Point(5.8862, 45.1106),
-        )
         TenderFactory(perimeters=[auvergne_rhone_alpes_perimeter])
         TenderFactory(perimeters=[isere_perimeter])
-        TenderFactory(perimeters=[grenoble_perimeter])
-        TenderFactory(perimeters=[chamrousse_perimeter])
-        TenderFactory(perimeters=[grenoble_perimeter, chamrousse_perimeter])
+        TenderFactory(perimeters=[self.grenoble_perimeter])
+        TenderFactory(perimeters=[self.chamrousse_perimeter])
+        TenderFactory(perimeters=[self.grenoble_perimeter, self.chamrousse_perimeter])
         # self.assertEqual(Tender.objects.in_perimeters().count(), 5)
         self.assertEqual(
             Tender.objects.in_perimeters(post_code="38000", department="38", region="Auvergne-Rhône-Alpes").count(), 4

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -593,6 +593,15 @@ class SiaeSearchOrderTest(TestCase):
         SiaeFactory(name="Ma boite")
         SiaeFactory(name="Une autre structure")
         SiaeFactory(name="ABC Insertion")
+        cls.grenoble_perimeter = PerimeterFactory(
+            name="Grenoble",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38185",
+            department_code="38",
+            region_code="84",
+            # post_codes=["38000", "38100", "38700"],
+            coords=Point(5.7301, 45.1825),
+        )
 
     def test_should_order_by_last_updated(self):
         url = reverse("siae:search_results", kwargs={})
@@ -633,14 +642,6 @@ class SiaeSearchOrderTest(TestCase):
         self.assertEqual(siaes[0].name, "ZZ ESI 3")
 
     def test_should_bring_the_siae_closer_to_the_city_to_the_top(self):
-        grenoble_perimeter = PerimeterFactory(
-            name="Grenoble",
-            kind=Perimeter.KIND_CITY,
-            insee_code="38185",
-            department_code="38",
-            region_code="84",
-            coords=Point(5.7301, 45.1825),
-        )
         SiaeFactory(
             name="ZZ GEO Pontcharra",
             department="38",
@@ -661,7 +662,7 @@ class SiaeSearchOrderTest(TestCase):
             geo_range_custom_distance=10,
             coords=Point(5.7301, 45.1825),
         )
-        url = reverse("siae:search_results") + f"?perimeters={grenoble_perimeter.slug}"
+        url = reverse("siae:search_results") + f"?perimeters={self.grenoble_perimeter.slug}"
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 3)

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -63,7 +63,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
             "TENDER_TITLE": tender.title,
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_SECTORS": tender.sectors_list_string(),
-            "TENDER_PERIMETERS": tender.location.name_display,
+            "TENDER_PERIMETERS": tender.location_display,
             "TENDER_URL": get_share_url_object(tender),
         }
 
@@ -140,7 +140,7 @@ def send_tender_email_to_siae(email_subject: str, tender: Tender, siae: Siae):
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
-            "TENDER_PERIMETERS": tender.location.name_display,
+            "TENDER_PERIMETERS": tender.location_display,
             "TENDER_URL": f"{get_share_url_object(tender)}?siae_id={siae.id}",
         }
 


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/betagouv/itou-marche/pull/567

Nouvelle propriété `location_display`

### Pourquoi ?

Pour simplifier/homogénéiser la logique d'affichage du champ `location`