### PR TITLE
Dépôt de besoin : améliorer la notification aux admin

### DIFF
--- a/lemarche/templates/tenders/create_notification_email_admin_body.txt
+++ b/lemarche/templates/tenders/create_notification_email_admin_body.txt
@@ -1,10 +1,12 @@
-Le marché de l'inclusion (C4) : dépôt de besoin, ajout d'un nouveau {{ tender_kind|safe }}
+Dépôt de besoin : ajout d'un nouveau {{ tender_kind|safe }}
 
----
 titre : {{ tender_title|safe }}
 type : {{ tender_kind|safe }}
+lieu d'intervention : {{ tender_location|safe }}
+date de clôture des réponses : {{ tender_deadline_date|safe }}
 contact : {{ tender_author_full_name|safe }}
 entreprise : {{ tender_author_company|safe }}
----
+si le Marché n'existait pas, auriez-vous consulté des prestataires inclusifs ? : {{ tender_scale_marche_useless|safe }}
+status : {{ tender_status|safe }}
 
 Lien dans l'admin : {{ tender_admin_url }}

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -273,8 +273,12 @@ def notify_admin_tender_created(tender: Tender):
             "tender_id": tender.id,
             "tender_title": tender.title,
             "tender_kind": tender.get_kind_display(),
+            "tender_location": tender.location_display,
+            "tender_deadline_date": tender.deadline_date,
             "tender_author_full_name": tender.contact_full_name,
             "tender_author_company": tender.author.company_name,
+            "tender_scale_marche_useless": tender.get_scale_marche_useless_display(),
+            "tender_status": tender.get_status_display(),
             "tender_admin_url": tender_admin_url,
         },
     )


### PR DESCRIPTION
### Quoi ?

Ajout de nouveaux champs dans la notification de création d'un besoin : location, deadline_date, scale_marche_useless & status