### PR TITLE
Dépôt de besoin : renommer 'Sourcing' en 'Sourcing inversé'

### DIFF
--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -76,7 +76,7 @@
                                 </button>
                                 <div class="dropdown-menu" aria-labelledby="solutionsDropdownMenuButton">
                                     <a href="{% url 'tenders:create' %}" id="header-dropdown-tender-create-btn" class="dropdown-item">
-                                        Sourcing
+                                        Sourcing inversé
                                     </a>
                                     <a href="{% url 'pages:valoriser_achats' %}" id="header-valoriser" class="dropdown-item">
                                         Valoriser vos achats
@@ -178,7 +178,7 @@
                         <hr />
                         <li>
                             <a href="{% url 'tenders:create' %}" id="header-dropdown-tender-create-btn">
-                                Sourcing
+                                Sourcing inversé
                             </a>
                         </li>
                         <li>

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -7,20 +7,46 @@
 
 {% block content_form %}
 {% csrf_token %}
-<fieldset>
-    {% bootstrap_field form.kind form_group_class="form-group form-group-required" %}
-    {% bootstrap_field form.title form_group_class="form-group form-group-required" %}
-    {% bootstrap_field form.sectors form_group_class="form-group form-group-required use-multiselect" %}
-    {% bootstrap_field form.presta_type form_group_class="form-group form-group-required use-multiselect" %}
-    <div class="form-group form-group-required {% if form.location.errors %}is-invalid{% endif %}">
-        <label for="id_location">{{ form.location.label }}</label>
-        <input id="id_location" name="general-location" value="{{form.location.value}}" type="text" class="d-none">
-        <div id="dir_form_location_name" data-input-value="{{form.instance.location.name_display}}"></div>
-        <small class="form-text text-muted">{{ form.location.help_text }}</small>
-        <div class="invalid-feedback">Ce champ est obligatoire.</div>
+<div class="row">
+    <div class="col-12 col-lg-8">
+        {% bootstrap_field form.kind %}
     </div>
-    {% bootstrap_field form.is_country_area %}
-</fieldset>
+    <div class="col-12 col-lg-4">
+        <div class="alert alert-info" role="alert">
+            <p class="mb-0 fs-sm">
+                <i class="ri-information-line ri-lg"></i>
+                En <strong>sourcing inversé</strong>, ce n'est pas vous qui recherchez et contactez chaque prestataire un par un - c'est l'inverse, c'est eux qui viennent à vous.
+            </p>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-12 col-lg-8">
+        {% bootstrap_field form.title %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-12 col-lg-8">
+        {% bootstrap_field form.sectors form_group_class="form-group form-group-required use-multiselect" %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-12 col-lg-8">
+        {% bootstrap_field form.presta_type %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-12 col-lg-8">
+        <div class="form-group form-group-required {% if form.location.errors %}is-invalid{% endif %}">
+            <label for="id_location">{{ form.location.label }}</label>
+            <input id="id_location" name="general-location" value="{{form.location.value}}" type="text" class="d-none">
+            <div id="dir_form_location_name" data-input-value="{{form.instance.location.name_display}}"></div>
+            <small class="form-text text-muted">{{ form.location.help_text }}</small>
+            <div class="invalid-feedback">Ce champ est obligatoire.</div>
+        </div>
+        {% bootstrap_field form.is_country_area %}
+    </div>
+</div>
 {% endblock content_form %}
 
 {% block extra_js %}

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -10,6 +10,12 @@ from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
 
 class AddTenderStepGeneralForm(forms.ModelForm):
+    TENDER_KIND_CHOICES = (
+        (Tender.TENDER_KIND_TENDER, "Appel d'offres"),
+        (Tender.TENDER_KIND_QUOTE, "Devis"),
+        (Tender.TENDER_KIND_PROJECT, "Sourcing inversé"),  # modif par rapport à Tender.TENDER_KIND_CHOICES
+    )
+
     sectors = GroupedModelMultipleChoiceField(
         label=Sector._meta.verbose_name_plural,
         queryset=Sector.objects.form_filter_queryset(),
@@ -40,10 +46,9 @@ class AddTenderStepGeneralForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["kind"].choices = self.TENDER_KIND_CHOICES
         self.fields["location"].to_field_name = "slug"
         # required fields
-        self.fields["sectors"].required = True
-        # self.fields["location"].required = True
         # self.fields["perimeters"].required = True  # JS
         # label, placeholder & help_text
         self.fields["title"].widget.attrs["placeholder"] = "Ex : Devis rénovation façade"


### PR DESCRIPTION
### Quoi ?

- renomme 'Sourcing' en 'Sourcing inversé'
  - dans le header
  - dans le formulaire de dépôt de besoin + help bubble

### Captures d'écran (optionnel)

![Screenshot from 2023-01-04 11-24-15](https://user-images.githubusercontent.com/7147385/210534788-f0729212-767d-46ce-9e93-b812b1a335c3.png)
