### PR TITLE
Dépôt de besoin : affichage dynamique d'external_link

### DIFF
--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -11,7 +11,7 @@
     {% if tender.contact_full_name %}
         <div class="col-md-6">
             <i class="ri-account-circle-line"></i>
-            {{ tender.contact_full_name }}
+            {{ tender.contact_full_name|safe }}
         </div>
     {% endif %}
     {% if tender.author.company_name %}
@@ -37,11 +37,7 @@
     <div class="row">
         <div class="col-12">
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                {% if tender.kind == tender.TENDER_KIND_TENDER %}
-                    Voir l'appel d'offres
-                {% else %}
-                    Lien partagé
-                {% endif %}
+                {{ tender.external_link_title|safe }}
                 <i class="ri-external-link-line" aria-hidden="true"></i>
             </a>
         </div>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -37,7 +37,7 @@
     <div class="row">
         <div class="col-12">
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                {% if tender.kind == "TENDER" %}
+                {% if tender.kind == tender.TENDER_KIND_TENDER %}
                     Voir l'appel d'offres
                 {% else %}
                     Lien partagé

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -37,7 +37,12 @@
     <div class="row">
         <div class="col-12">
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                Voir l'appel d'offres <i class="ri-external-link-line" aria-hidden="true"></i>
+                {% if tender.kind == "TENDER" %}
+                    Voir l'appel d'offres
+                {% else %}
+                    Lien partagé
+                {% endif %}
+                <i class="ri-external-link-line" aria-hidden="true"></i>
             </a>
         </div>
     </div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -30,13 +30,13 @@
             <div class="col-md-4" title="Secteurs d'activité">
                 {% if tender.sectors.count %}
                     <i class="ri-award-line"></i>
-                    {{ tender.sectors_list_string }}
+                    {{ tender.sectors_list_string|safe }}
                 {% endif %}
             </div>
             <div class="col-md-4 text-center" title="Lieu d'intervention">
                 {% if tender.perimeters_list_string %}
                     <i class="ri-map-pin-2-line"></i>
-                    {{ tender.perimeters_list_string }}
+                    {{ tender.perimeters_list_string|safe }}
                 {% endif %}
             </div>
             <div class="col-md-4 text-center">

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -139,7 +139,7 @@
             <hr class="my-5">
 
             <h2>
-                {% if tender.author == request.user %}
+                {% if source_form or tender.author == request.user %}
                     Montant du marché
                 {% else %}
                     Budget du client

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -29,13 +29,13 @@
             </div>
         </div>
         <div class="row text-bold">
-            <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string }}">
+            <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
                 <i class="ri-award-line"></i>
                 {{ tender.sectors_list_string }}
             </div>
             <div class="col" title="Lieu d'éxécution">
                 <i class="ri-map-pin-2-line"></i>
-                {{ tender.location_display }}
+                {{ tender.location_display|safe }}
             </div>
             {% if tender.presta_type %}
                 <div class="col" title="Type de prestation">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -385,15 +385,15 @@ class Tender(models.Model):
 
     @cached_property
     def can_display_contact_email(self):
-        return self.RESPONSE_KIND_EMAIL in self.response_kind and self.contact_email
+        return (self.RESPONSE_KIND_EMAIL in self.response_kind) and self.contact_email
 
     @cached_property
     def can_display_contact_phone(self):
-        return self.RESPONSE_KIND_TEL in self.response_kind and self.contact_phone
+        return (self.RESPONSE_KIND_TEL in self.response_kind) and self.contact_phone
 
     @cached_property
     def can_display_contact_external_link(self):
-        return self.RESPONSE_KIND_EXTERNAL in self.response_kind and self.external_link
+        return (self.RESPONSE_KIND_EXTERNAL in self.response_kind) and self.external_link
 
     @cached_property
     def accept_share_amount_display(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -384,6 +384,12 @@ class Tender(models.Model):
             return self.perimeters_list_string
 
     @cached_property
+    def external_link_title(self):
+        if self.kind == self.TENDER_KIND_TENDER:
+            return "Voir l'appel d'offres"
+        return "Lien partagé"
+
+    @cached_property
     def can_display_contact_email(self):
         return (self.RESPONSE_KIND_EMAIL in self.response_kind) and self.contact_email
 

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -90,13 +90,16 @@ class AddTenderStepDescriptionForm(forms.ModelForm):
         self.kind = kind
 
         if self.instance.start_working_date:
-            self.initial["start_working_date"] = self.instance.start_working_date.isoformat()  # Here
+            self.initial["start_working_date"] = self.instance.start_working_date.isoformat()
 
         # required fields
         self.fields["description"].required = True
         if self.kind == Tender.TENDER_KIND_TENDER:
             self.fields["amount"].required = True
         # label, placeholder & help_text
+        if self.kind != Tender.TENDER_KIND_TENDER:
+            self.fields["external_link"].label = "Lien à partager"
+            self.fields["external_link"].help_text = None
         self.fields["amount"].label = "Montant € estimé de votre besoin"
         self.fields["accept_share_amount"].label = self.fields["accept_share_amount"].help_text
         self.fields["accept_cocontracting"].label = self.fields["accept_cocontracting"].help_text
@@ -143,7 +146,7 @@ class AddTenderStepContactForm(forms.ModelForm):
         user_is_anonymous = not user.is_authenticated
 
         if self.instance.deadline_date:
-            self.initial["deadline_date"] = self.instance.deadline_date.isoformat()  # Here
+            self.initial["deadline_date"] = self.instance.deadline_date.isoformat()
 
         # required fields
         self.fields["contact_first_name"].required = True

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -572,6 +572,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, self.tender_1.contact_email)  # RESPONSE_KIND_EMAIL
         self.assertNotContains(response, self.tender_1.contact_phone)
         self.assertNotContains(response, "Voir l'appel d'offres")
+        self.assertNotContains(response, "Lien partagé")
         # tender with same kind & different response_kind
         tender_2 = TenderFactory(
             kind=Tender.TENDER_KIND_TENDER,


### PR DESCRIPTION
### Quoi ?

Modifications sur l'affichage du champ `Tender.external_link`
- dans le formulaire de dépôt de besoin : modifier le label en "Lien à partager" si ce n'est pas un Appel d'offres
- dans la page détail, modifier le texte à "Lien partagé" si ce n'est pas un Appel d'offres
- ajout de tests
