### PR TITLE
Dépôt de besoin : élargir la stat du nombre de vues

### DIFF
--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -64,11 +64,11 @@
         </div>
         {% if tender.author != request.user and not tender.deadline_date_outdated %}
             <div class="col-12 col-lg-4">
-                {% if siae_detail_display_date_count %}
+                {% if siae_detail_display_date_count_all %}
                     <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
                         <p class="mb-0 fs-sm">
-                            Déjà {{ siae_detail_display_date_count }} prestataire{{ siae_detail_display_date_count|pluralize }} inclusif{{ siae_detail_display_date_count|pluralize }}
-                            {{ siae_detail_display_date_count|pluralize:"a,ont" }} vu le besoin de ce client.
+                            Déjà {{ siae_detail_display_date_count_all }} prestataire{{ siae_detail_display_date_count_all|pluralize }} inclusif{{ siae_detail_display_date_count_all|pluralize }}
+                            {{ siae_detail_display_date_count_all|pluralize:"a,ont" }} vu le besoin de ce client.
                         </p>
                     </div>
                 {% endif %}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -431,6 +431,17 @@ class Tender(models.Model):
         return self.tendersiae_set.filter(detail_display_date__isnull=False).count()
 
     @property
+    def siae_detail_display_date_count_all(self):
+        """
+        Return all siae that have seen the tender (via e-mail or link or both)
+        """
+        return (
+            self.tendersiae_set.filter(Q(email_link_click_date__isnull=False) | Q(detail_display_date__isnull=False))
+            .distinct()
+            .count()
+        )
+
+    @property
     def siae_detail_contact_click_date_count(self):
         return self.tendersiae_set.filter(detail_contact_click_date__isnull=False).count()
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -449,6 +449,11 @@ class TenderDetailViewTest(TestCase):
         self.assertIsNotNone(self.tender_1.tendersiae_set.last().email_link_click_date)  # siae_1
         self.assertIsNotNone(self.tender_1.tendersiae_set.last().detail_display_date)
         # first load anonymous
+        url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Déjà 1 prestataire inclusif")
+        # reload anonymous with ?siae_id=
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug}) + f"?siae_id={self.siae_2.id}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -456,7 +461,7 @@ class TenderDetailViewTest(TestCase):
         self.assertIsNotNone(siae_2_email_link_click_date)
         self.assertIsNone(self.tender_1.tendersiae_set.first().detail_display_date)
         self.assertIsNotNone(self.tender_1.tendersiae_set.last().detail_display_date)
-        self.assertContains(response, "Déjà 1 prestataire inclusif")
+        self.assertContains(response, "Déjà 2 prestataires inclusifs")
         self.assertNotContains(response, "contactez dès maintenant le client")
         # reload logged in (doesn't update email_link_click_date)
         self.client.force_login(self.siae_user_2)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -316,9 +316,9 @@ class TenderDetailView(DetailView):
             if user_kind == User.KIND_SIAE and tender.kind == Tender.TENDER_KIND_PROJECT
             else tender.get_kind_display()
         )
-        siae_detail_display_date_count = tender.siae_detail_display_date_count
-        if siae_detail_display_date_count > 0:
-            context["siae_detail_display_date_count"] = siae_detail_display_date_count
+        siae_detail_display_date_count_all = tender.siae_detail_display_date_count_all
+        if siae_detail_display_date_count_all > 0:
+            context["siae_detail_display_date_count_all"] = siae_detail_display_date_count_all
         if user.is_authenticated:
             if tender.author == user:
                 context["siae_detail_contact_click_date_count"] = tender.siae_detail_contact_click_date_count


### PR DESCRIPTION
### Quoi ?

Suite de la PR #598

Avant : on comptait seulement les `detail_display_date`
Après : on compte les `detail_display_date` ou `email_link_click_date`