### PR TITLE
Dépôt de besoin : restreindre l'accès aux besoins non validés

### DIFF
--- a/lemarche/tenders/factories.py
+++ b/lemarche/tenders/factories.py
@@ -6,6 +6,7 @@ import factory.fuzzy
 from django.utils import timezone
 from factory.django import DjangoModelFactory
 
+from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import PartnerShareTender, Tender
 from lemarche.users.factories import UserFactory
 
@@ -42,6 +43,7 @@ class TenderFactory(DjangoModelFactory):
     contact_phone = factory.fuzzy.FuzzyText(length=10, chars=string.digits)
     # amount = tender_constants.AMOUNT_RANGE_100_150
     # marche_benefits = factory.fuzzy.FuzzyChoice([key for (key, _) in constants.MARCHE_BENEFIT_CHOICES])
+    status = tender_constants.STATUS_VALIDATED
 
     @factory.post_generation
     def perimeters(self, create, extracted, **kwargs):

--- a/lemarche/www/dashboard/mixins.py
+++ b/lemarche/www/dashboard/mixins.py
@@ -138,7 +138,7 @@ class TenderAuthorOrAdminRequiredMixin(LoginRequiredUserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("tenders:list"))
 
 
-class TenderAuthorOrAdminRequiredIfNotValidatedMixin(LoginRequiredUserPassesTestMixin):
+class TenderAuthorOrAdminRequiredIfNotValidatedMixin(UserPassesTestMixin):
     """
     If the Tender's status is not "validated", restrict access to the Tender's author (or Admin)
     """
@@ -147,7 +147,7 @@ class TenderAuthorOrAdminRequiredIfNotValidatedMixin(LoginRequiredUserPassesTest
         # user = self.request.user
         tender_slug = self.kwargs.get("slug")
         tender = Tender.objects.get(slug=tender_slug)
-        if not tender.status == tender_constants.STATUS_VALIDATED:
+        if tender.status != tender_constants.STATUS_VALIDATED:
             return TenderAuthorOrAdminRequiredMixin.test_func(self)
         return True
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -348,6 +348,7 @@ class TenderDetailViewTest(TestCase):
         cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
         cls.user_partner = UserFactory(kind=User.KIND_PARTNER)
+        cls.user_admin = UserFactory(kind=User.KIND_ADMIN)
         cls.tender_1 = TenderFactory(
             kind=Tender.TENDER_KIND_TENDER,
             author=cls.user_buyer_1,
@@ -376,6 +377,29 @@ class TenderDetailViewTest(TestCase):
             url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
+
+    def test_only_author_or_admin_can_view_non_validated_tender(self):
+        tender_draft = TenderFactory(author=self.user_buyer_1, status=tender_constants.STATUS_DRAFT)
+        tender_published = TenderFactory(author=self.user_buyer_1, status=tender_constants.STATUS_PUBLISHED)
+        for tender in [tender_draft, tender_published]:
+            # anonymous
+            url = reverse("tenders:detail", kwargs={"slug": tender.slug})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)  # redirect
+            # self.assertContains(response.url, "/accounts/login/?next=/besoins/")
+            # author & admin
+            for user in [self.user_buyer_1, self.user_admin]:
+                self.client.force_login(user)
+                url = reverse("tenders:detail", kwargs={"slug": tender.slug})
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+            # other users
+            for user in [self.siae_user_1, self.user_buyer_2, self.user_partner]:
+                self.client.force_login(user)
+                url = reverse("tenders:detail", kwargs={"slug": tender.slug})
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 302)  # redirect
+                self.assertEqual(response.url, "/")
 
     def test_tender_constraints_display(self):
         # tender with constraints: section should be visible

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -365,7 +365,7 @@ class TenderDetailViewTest(TestCase):
             detail_contact_click_date=timezone.now(),
         )
 
-    def test_anyone_can_view_tenders(self):
+    def test_anyone_can_view_validated_tenders(self):
         # anonymous
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -15,7 +15,10 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
 from lemarche.www.auth.tasks import send_new_user_password_reset_link
-from lemarche.www.dashboard.mixins import TenderAuthorOrAdminRequiredMixin
+from lemarche.www.dashboard.mixins import (
+    TenderAuthorOrAdminRequiredIfNotValidatedMixin,
+    TenderAuthorOrAdminRequiredMixin,
+)
 from lemarche.www.tenders.forms import (
     AddTenderStepConfirmationForm,
     AddTenderStepContactForm,
@@ -274,7 +277,7 @@ class TenderListView(LoginRequiredMixin, ListView):
         return context
 
 
-class TenderDetailView(DetailView):
+class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailView):
     model = Tender
     template_name = "tenders/detail.html"
     context_object_name = "tender"

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -15,7 +15,7 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
 from lemarche.www.auth.tasks import send_new_user_password_reset_link
-from lemarche.www.dashboard.mixins import TenderOwnerRequiredMixin
+from lemarche.www.dashboard.mixins import TenderAuthorOrAdminRequiredMixin
 from lemarche.www.tenders.forms import (
     AddTenderStepConfirmationForm,
     AddTenderStepContactForm,
@@ -380,7 +380,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
         return "<strong>Répondre à cette opportunité</strong><br />Pour répondre à cette opportunité, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
 
 
-class TenderSiaeInterestedListView(TenderOwnerRequiredMixin, ListView):
+class TenderSiaeInterestedListView(TenderAuthorOrAdminRequiredMixin, ListView):
     queryset = TenderSiae.objects.select_related("tender", "siae").all()
     template_name = "tenders/siae_interested_list.html"
     context_object_name = "tendersiaes"


### PR DESCRIPTION
### Quoi ?

Actuellement, si on a le bon lien, tout le monde peut accéder aux besoins en brouillon ou publiés (mais pas encore validés).

Restreindre l'accès des besoins non validés à : 
- leur auteur
- les utilisateurs "Admin"

### Comment ?

Nouveau mixin `TenderAuthorOrAdminRequiredIfNotValidatedMixin`