### PR TITLE
Email : léger refactoring de EMAIL_SUBJECT_PREFIX

### DIFF
--- a/lemarche/utils/apis/api_mailjet.py
+++ b/lemarche/utils/apis/api_mailjet.py
@@ -4,6 +4,8 @@ import requests
 from django.conf import settings
 from huey.contrib.djhuey import task
 
+from lemarche.utils.emails import EMAIL_SUBJECT_PREFIX
+
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +84,7 @@ def send_transactional_email_with_template(
                 "To": [{"Email": recipient_email, "Name": recipient_name}],
                 "TemplateID": template_id,
                 "TemplateLanguage": True,
-                "Subject": subject,
+                "Subject": EMAIL_SUBJECT_PREFIX + subject,
                 "Variables": variables,
                 # "Variables": {}
             }
@@ -115,7 +117,7 @@ def send_transactional_email_many_recipient_with_template(
                 "To": [{"Email": recipient_email} for recipient_email in recipient_email_list],
                 "TemplateID": template_id,
                 "TemplateLanguage": True,
-                "Subject": subject,
+                "Subject": EMAIL_SUBJECT_PREFIX + subject,
                 "Variables": variables,
                 # "Variables": {}
             }

--- a/lemarche/www/auth/tasks.py
+++ b/lemarche/www/auth/tasks.py
@@ -7,7 +7,7 @@ from django.utils.http import urlsafe_base64_encode
 
 from lemarche.users.models import User
 from lemarche.utils.apis import api_hubspot, api_mailjet
-from lemarche.utils.emails import EMAIL_SUBJECT_PREFIX, send_mail_async, whitelist_recipient_list
+from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
 from lemarche.utils.urls import get_domain_url
 
 
@@ -42,7 +42,7 @@ def send_signup_notification_email(user):
 
 
 def send_new_user_password_reset_link(user: User):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Finalisez votre inscription sur le marché de l'inclusion"
+    email_subject = "Finalisez votre inscription sur le marché de l'inclusion"
     recipient_list = whitelist_recipient_list([user.email])
     if recipient_list:
         recipient_email = recipient_list[0] if recipient_list else ""

--- a/lemarche/www/dashboard/tasks.py
+++ b/lemarche/www/dashboard/tasks.py
@@ -3,7 +3,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 
 from lemarche.utils.apis import api_mailjet
-from lemarche.utils.emails import EMAIL_SUBJECT_PREFIX, whitelist_recipient_list
+from lemarche.utils.emails import whitelist_recipient_list
 from lemarche.utils.urls import get_domain_url
 
 
@@ -11,78 +11,79 @@ def send_siae_user_request_email_to_assignee(siae_user_request):
     """
     Send request to the assignee
     """
-    email_subject = EMAIL_SUBJECT_PREFIX + "Nouveau collaborateur"
+    email_subject = "Nouveau collaborateur"
     recipient_list = whitelist_recipient_list([siae_user_request.assignee.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.assignee.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.assignee.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-        "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+            "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=settings.MAILJET_SIAEUSERREQUEST_ASSIGNEE_TEMPLATE_ID,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=settings.MAILJET_SIAEUSERREQUEST_ASSIGNEE_TEMPLATE_ID,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()
 
 
 def send_siae_user_request_response_email_to_initiator(siae_user_request, response=None):
     """
     Send request response (True or False) to the initial user
     """
-    email_subject_text = "Accéder à votre structure" if response else "Rattachement refusé"
-    email_subject = EMAIL_SUBJECT_PREFIX + email_subject_text
+    email_subject = "Accéder à votre structure" if response else "Rattachement refusé"
     email_template_id = (
         settings.MAILJET_SIAEUSERREQUEST_INITIATOR_RESPONSE_POSITIVE_TEMPLATE_ID
         if response
         else settings.MAILJET_SIAEUSERREQUEST_INITIATOR_RESPONSE_NEGATIVE_TEMPLATE_ID
     )
     recipient_list = whitelist_recipient_list([siae_user_request.initiator.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.initiator.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.initiator.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-        "DASHBOARD_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:home')}",
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+            "DASHBOARD_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:home')}",
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=email_template_id,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=email_template_id,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()
 
 
 def send_siae_user_request_reminder_3_days_emails(siae_user_request):
@@ -96,68 +97,70 @@ def send_siae_user_request_reminder_3_days_emails(siae_user_request):
 
 
 def send_siae_user_request_reminder_3_days_email_to_assignee(siae_user_request):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Nouveau collaborateur"
+    email_subject = "Nouveau collaborateur"
     recipient_list = whitelist_recipient_list([siae_user_request.assignee.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.assignee.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.assignee.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-        "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+            "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_1_ASSIGNEE_TEMPLATE_ID,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_1_ASSIGNEE_TEMPLATE_ID,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()
 
 
 def send_siae_user_request_reminder_3_days_email_to_initiator(siae_user_request):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Rattachement sans réponse"
+    email_subject = "Rattachement sans réponse"
     recipient_list = whitelist_recipient_list([siae_user_request.initiator.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.initiator.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.initiator.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_1_INITIATOR_TEMPLATE_ID,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_1_INITIATOR_TEMPLATE_ID,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()
 
 
 def send_siae_user_request_reminder_8_days_emails(siae_user_request):
@@ -171,66 +174,68 @@ def send_siae_user_request_reminder_8_days_emails(siae_user_request):
 
 
 def send_siae_user_request_reminder_8_days_email_to_assignee(siae_user_request):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Nouveau collaborateur"
+    email_subject = "Nouveau collaborateur"
     recipient_list = whitelist_recipient_list([siae_user_request.assignee.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.assignee.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.assignee.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-        "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+            "SIAE_USERS_URL": f"https://{get_domain_url()}{reverse_lazy('dashboard:siae_users', args=[siae_user_request.siae.slug])}",  # noqa
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_2_ASSIGNEE_TEMPLATE_ID,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_2_ASSIGNEE_TEMPLATE_ID,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()
 
 
 def send_siae_user_request_reminder_8_days_email_to_initiator(siae_user_request):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Rattachement sans réponse"
+    email_subject = "Rattachement sans réponse"
     recipient_list = whitelist_recipient_list([siae_user_request.initiator.email])
-    recipient_email = recipient_list[0] if recipient_list else ""
-    recipient_name = siae_user_request.initiator.full_name
+    if recipient_list:
+        recipient_email = recipient_list[0] if recipient_list else ""
+        recipient_name = siae_user_request.initiator.full_name
 
-    variables = {
-        "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
-        "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
-        "SIAE_NAME": siae_user_request.siae.name_display,
-        "SUPPORT_URL": f"https://{get_domain_url()}{reverse_lazy('pages:contact')}?siret={siae_user_request.siae.siret}",  # noqa
-    }
+        variables = {
+            "ASSIGNEE_FULL_NAME": siae_user_request.assignee.full_name,
+            "INITIATOR_FULL_NAME": siae_user_request.initiator.full_name,
+            "SIAE_NAME": siae_user_request.siae.name_display,
+            "SUPPORT_URL": f"https://{get_domain_url()}{reverse_lazy('pages:contact')}?siret={siae_user_request.siae.siret}",  # noqa
+        }
 
-    api_mailjet.send_transactional_email_with_template(
-        template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_2_INITIATOR_TEMPLATE_ID,
-        subject=email_subject,
-        recipient_email=recipient_email,
-        recipient_name=recipient_name,
-        variables=variables,
-    )
+        api_mailjet.send_transactional_email_with_template(
+            template_id=settings.MAILJET_SIAEUSERREQUEST_REMINDER_2_INITIATOR_TEMPLATE_ID,
+            subject=email_subject,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            variables=variables,
+        )
 
-    # log email
-    log_item = {
-        "action": "email_sent",
-        "email_to": recipient_email,
-        "email_subject": email_subject,
-        # "email_body": email_body,
-        "email_timestamp": timezone.now().isoformat(),
-    }
-    siae_user_request.logs.append(log_item)
-    siae_user_request.save()
+        # log email
+        log_item = {
+            "action": "email_sent",
+            "email_to": recipient_email,
+            "email_subject": email_subject,
+            # "email_body": email_body,
+            "email_timestamp": timezone.now().isoformat(),
+        }
+        siae_user_request.logs.append(log_item)
+        siae_user_request.save()

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import PartnerShareTender, Tender, TenderSiae
 from lemarche.utils.apis import api_mailjet, api_slack
-from lemarche.utils.emails import EMAIL_SUBJECT_PREFIX, send_mail_async, whitelist_recipient_list
+from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
 from lemarche.utils.urls import get_admin_url_object, get_share_url_object
 
 
@@ -14,9 +14,7 @@ def send_tender_emails_to_siaes(tender: Tender):
     """
     All corresponding Siae will be contacted
     """
-    email_subject = (
-        f"{EMAIL_SUBJECT_PREFIX}{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
-    )
+    email_subject = f"{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
     siaes = tender.siaes.all()
     for siae in siaes:
         send_tender_email_to_siae(email_subject, tender, siae)
@@ -39,9 +37,7 @@ def send_tender_emails_to_partners(tender: Tender):
     All corresponding partners (PartnerShareTender) will be contacted
     """
     partners = PartnerShareTender.objects.filter_by_tender(tender)
-    email_subject = (
-        f"{EMAIL_SUBJECT_PREFIX}{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
-    )
+    email_subject = f"{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
     for partner in partners:
         send_tender_email_to_partner(email_subject, tender, partner)
 
@@ -92,7 +88,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
 
 
 def send_tenders_author_feedback_30_days(tender: Tender):
-    email_subject = EMAIL_SUBJECT_PREFIX + "Concernant votre dépôt de besoin sur le marché de l'inclusion"
+    email_subject = "Concernant votre dépôt de besoin sur le marché de l'inclusion"
     recipient_list = whitelist_recipient_list([tender.author.email])
     if recipient_list:
         recipient_email = recipient_list[0] if recipient_list else ""
@@ -160,7 +156,7 @@ def send_confirmation_published_email_to_author(tender: Tender, nb_matched_siaes
         tender (Tender): Tender published
         nb_matched (int): number of siaes match
     """
-    email_subject = f"{EMAIL_SUBJECT_PREFIX}Votre {tender.get_kind_display().lower()} a été publié !"
+    email_subject = f"Votre {tender.get_kind_display().lower()} a été publié !"
     recipient_list = whitelist_recipient_list([tender.author.email])
     if recipient_list:
         recipient_email = recipient_list[0] if recipient_list else ""
@@ -215,19 +211,19 @@ def send_siae_interested_email_to_author(tender: Tender):
 
         if tender_siae_detail_contact_click_count == 1:
             should_send_email = True
-            email_subject = EMAIL_SUBJECT_PREFIX + "Une première structure intéressée !"
+            email_subject = "Une première structure intéressée !"
             template_id = settings.MAILJET_TENDERS_SIAE_INTERESTED_1_TEMPLATE_ID
         elif tender_siae_detail_contact_click_count == 2:
             should_send_email = True
-            email_subject = EMAIL_SUBJECT_PREFIX + "Une deuxième structure intéressée !"
+            email_subject = "Une deuxième structure intéressée !"
             template_id = settings.MAILJET_TENDERS_SIAE_INTERESTED_2_TEMPLATE_ID
         elif tender_siae_detail_contact_click_count == 5:
             should_send_email = True
-            email_subject = EMAIL_SUBJECT_PREFIX + "Une cinquième structure intéressée !"
+            email_subject = "Une cinquième structure intéressée !"
             template_id = settings.MAILJET_TENDERS_SIAE_INTERESTED_5_TEMPLATE_ID
         elif tender_siae_detail_contact_click_count % 5 == 0:
             should_send_email = True
-            email_subject = EMAIL_SUBJECT_PREFIX + "5 nouvelles structures intéressées !"
+            email_subject = "5 nouvelles structures intéressées !"
             template_id = settings.MAILJET_TENDERS_SIAE_INTERESTED_5_MORE_TEMPLATE_ID
         else:
             pass


### PR DESCRIPTION
### Quoi ?

- éviter d'utiliser `EMAIL_SUBJECT_PREFIX` partout, et le rajoute à la source instead
- réparer quelques cas où `if recipient_list:` était manquant