### PR TITLE
Dépôt de besoin : fix des erreurs 500 sur l'URL d'ajout

### DIFF
--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from lemarche.www.tenders.views import (
     TenderCreateMultiStepView,
@@ -13,6 +14,8 @@ from lemarche.www.tenders.views import (
 app_name = "tenders"
 
 urlpatterns = [
+    # why redirect? avoid conflict with tenders:detail
+    path("ajouter", RedirectView.as_view(pattern_name="tenders:create", permanent=True), name="create_without_slash"),
     path("ajouter/", TenderCreateMultiStepView.as_view(), name="create"),
     path("modifier/<str:slug>", TenderCreateMultiStepView.as_view(), name="update"),
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),


### PR DESCRIPTION
### Quoi ?

L'URL de base pour accéder au formulaire de dépôt de besoin est `/besoins/ajouter/`
Mais si l'utilisateur essayait `/besoins/ajouter` il y avait une erreur 500, car c'était le controlleur `TenderDetail` qui était appelé (la vue `tenders:detail`)

Réparé en rajoutant un redirect
