### PR TITLE
Dépôt de besoin : fix d'erreur lors de la création via CSRF

### DIFF
--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -301,7 +301,7 @@ def csrf_failure(request, reason=""):  # noqa C901
             user = create_user_from_anonymous_content(tender_dict)
         else:
             user = request.user
-        tender_dict["user"] = user
+        tender_dict["author"] = user
         # create tender
         if is_adding:
             tender = create_tender_from_dict(tender_dict)


### PR DESCRIPTION
### Quoi ?

Suite à la PR #597

`author` et non `user`