### PR TITLE
Mise à jour de l'url communauté

### DIFF
--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -81,7 +81,7 @@
                         </p>
                         <ul>
                             <li><a href="https://emplois.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Les emplois (lien externe)">Les emplois</a></li>
-                            <li><a href="https://communaute.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="La communauté (lien externe)">La communauté</a></li>
+                            <li><a href="https://communaute-experimentation.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="La communauté (lien externe)">La communauté</a></li>
                             <li><a href="https://pilotage.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Le pilotage (lien externe)">Le pilotage</a></li>
                             <li><a href="https://lemarche.inclusion.beta.gouv.fr" target="_blank" rel="noopener" title="Le marché (lien externe)">Le marché</a></li>
                         </ul>

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -23,7 +23,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://communaute.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
+                        <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
                             <span>La communauté</span>
                             <i class="ri-arrow-right-up-line ri-lg"></i>
                         </a>
@@ -256,7 +256,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://communaute.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
+                            <a href="https://communaute-experimentation.inclusion.beta.gouv.fr" class="is-communaute" rel="noopener" target="_blank" title="La communauté de l'inclusion (lien externe)">
                                 <span>La communauté</span>
                                 <i class="ri-arrow-right-up-line ri-lg"></i>
                             </a>


### PR DESCRIPTION
### Quoi ?

Mise à jour des liens communauté 
De communaute.inclusion.beta.gouv.fr vers communaute-experimentation.inclusion.beta.gouv.fr

### Pourquoi ?

Préparation de la redirection/fermeture du site WP
Carte notion > https://www.notion.so/Rediriger-tous-les-sites-de-la-PDI-vers-la-nouvelle-interface-C3-f1ccd9f264814ff7bfc029af3aaa7192