### PR TITLE
Réseaux (3b/3) : voir la liste des besoins concernés par chaque structure du réseau

### DIFF
--- a/lemarche/fixtures/django/10_tenders.json
+++ b/lemarche/fixtures/django/10_tenders.json
@@ -9,10 +9,34 @@
             "presta_type": ["DISP", "PREST"],
             "description": "Une courte description",
             "external_link": "https://example.com/",
-            "amount": "<100K",
+            "amount": "50-100K",
             "deadline_date": "2023-12-31",
             "response_kind": [
                 "EMAIL"
+            ],
+            "author": 2,
+            "contact_first_name": "Acheteur",
+            "contact_last_name": "Dupont",
+            "contact_email": "acheteur@test.com",
+            "contact_phone": "01 02 03 04 05",
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-10-26T22:26:47.569Z"
+        }
+    },
+    {
+        "model": "tenders.tender",
+        "pk": 2,
+        "fields": {
+            "title": "Traiteur, cocktail, récéption et buffet à Grenoble",
+            "slug": "traiteur-cocktail-reception-buffet-grenoble",
+            "kind": "PROJ",
+            "presta_type": ["DISP", "PREST"],
+            "description": "Une description",
+            "external_link": "https://example.com/",
+            "amount": "5-10K",
+            "deadline_date": "2023-12-31",
+            "response_kind": [
+                "EMAIL", "TEL"
             ],
             "author": 2,
             "contact_first_name": "Acheteur",

--- a/lemarche/fixtures/django/10_tenders.json
+++ b/lemarche/fixtures/django/10_tenders.json
@@ -19,8 +19,10 @@
             "contact_last_name": "Dupont",
             "contact_email": "acheteur@test.com",
             "contact_phone": "01 02 03 04 05",
-            "created_at": "2021-07-01T12:44:39Z",
-            "updated_at": "2021-10-26T22:26:47.569Z"
+            "status": "VALIDATED",
+            "validated_at": "2021-01-02T22:26:47.569Z",
+            "created_at": "2021-01-01T12:44:39Z",
+            "updated_at": "2021-01-02T22:26:47.569Z"
         }
     },
     {
@@ -34,7 +36,7 @@
             "description": "Une description",
             "external_link": "https://example.com/",
             "amount": "5-10K",
-            "deadline_date": "2023-12-31",
+            "deadline_date": "2023-06-30",
             "response_kind": [
                 "EMAIL", "TEL"
             ],
@@ -43,8 +45,10 @@
             "contact_last_name": "Dupont",
             "contact_email": "acheteur@test.com",
             "contact_phone": "01 02 03 04 05",
-            "created_at": "2021-07-01T12:44:39Z",
-            "updated_at": "2021-10-26T22:26:47.569Z"
+            "status": "VALIDATED",
+            "validated_at": "2021-01-03T22:26:47.569Z",
+            "created_at": "2021-01-01T12:44:39Z",
+            "updated_at": "2021-01-03T22:26:47.569Z"
         }
     }
 ]

--- a/lemarche/fixtures/django/11_tender_siaes.json
+++ b/lemarche/fixtures/django/11_tender_siaes.json
@@ -28,7 +28,7 @@
     },
     {
         "model": "tenders.tendersiae",
-        "pk": 2,
+        "pk": 3,
         "fields": {
             "tender": 1,
             "siae": 3853,
@@ -40,12 +40,25 @@
     },
     {
         "model": "tenders.tendersiae",
-        "pk": 2,
+        "pk": 4,
         "fields": {
             "tender": 1,
             "siae": 3852,
             "source": "EMAIL",
             "email_send_date": "2021-07-02T12:44:39Z",
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    },
+    {
+        "model": "tenders.tendersiae",
+        "pk": 5,
+        "fields": {
+            "tender": 1,
+            "siae": 2653,
+            "source": "EMAIL",
+            "email_send_date": "2021-07-02T12:44:39Z",
+            "email_link_click_date": "2021-07-02T12:44:39Z",
             "created_at": "2021-07-01T12:44:39Z",
             "updated_at": "2021-07-01T12:44:39Z"
         }

--- a/lemarche/fixtures/django/11_tender_siaes.json
+++ b/lemarche/fixtures/django/11_tender_siaes.json
@@ -54,7 +54,7 @@
         "model": "tenders.tendersiae",
         "pk": 5,
         "fields": {
-            "tender": 1,
+            "tender": 2,
             "siae": 2653,
             "source": "EMAIL",
             "email_send_date": "2021-07-02T12:44:39Z",

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -36,14 +36,17 @@ class SiaeFactory(DjangoModelFactory):
     @factory.post_generation
     def users(self, create, extracted, **kwargs):
         if extracted:
-            # Add the iterable of groups using bulk addition
             self.users.add(*extracted)
 
     @factory.post_generation
     def sectors(self, create, extracted, **kwargs):
         if extracted:
-            # Add the iterable of groups using bulk addition
             self.sectors.add(*extracted)
+
+    @factory.post_generation
+    def networks(self, create, extracted, **kwargs):
+        if extracted:
+            self.networks.add(*extracted)
 
 
 class SiaeOfferFactory(DjangoModelFactory):

--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -48,16 +48,30 @@
                     <tbody>
                         {% for siae in network_siaes %}
                             <tr>
-                                <td><a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.name_display }}</a></td>
                                 <td>
-                                    {% if siae.tender_email_send_count %}
+                                    <a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.name_display }}</a>
+                                </td>
+                                <td>
+                                    {% if siae.tender_email_send_count > 0 %}
                                         <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les besoins concernés">{{ siae.tender_email_send_count }}</a>
                                     {% else %}
-                                        {{ siae.tender_email_send_count }}
+                                        0
                                     {% endif %}
                                 </td>
-                                <td>{{ siae.tender_detail_display_count }}</td>
-                                <td>{{ siae.tender_detail_contact_click_count }}</td>
+                                <td>
+                                    {% if siae.tender_detail_display_count > 0 %}
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les besoins concernés">{{ siae.tender_detail_display_count }}</a>
+                                    {% else %}
+                                        0
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if siae.tender_detail_contact_click_count > 0 %}
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les besoins concernés">{{ siae.tender_detail_contact_click_count }}</a>
+                                    {% else %}
+                                        0
+                                    {% endif %}
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -49,7 +49,13 @@
                         {% for siae in network_siaes %}
                             <tr>
                                 <td><a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.name_display }}</a></td>
-                                <td>{{ siae.tender_email_send_count }}</td>
+                                <td>
+                                    {% if siae.tender_email_send_count %}
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les besoins concernés">{{ siae.tender_email_send_count }}</a>
+                                    {% else %}
+                                        {{ siae.tender_email_send_count }}
+                                    {% endif %}
+                                </td>
                                 <td>{{ siae.tender_detail_display_count }}</td>
                                 <td>{{ siae.tender_detail_contact_click_count }}</td>
                             </tr>

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -1,4 +1,4 @@
-{% extends "layouts/base.html" %}
+{% extends BASE_TEMPLATE %}
 {% load bootstrap4 static %}
 
 {% block title %}{{ page_title }}{{ block.super }}{% endblock %}
@@ -27,15 +27,58 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} besoins concernés</h1>
+                <h1 class="mb-3 mb-lg-5">Cette structure a reçu {{ tendersiaes.count }} demande{{ tendersiaes.count|pluralize }}</h1>
             </div>
         </div>
 
         <div class="row">
             <div class="col-12">
-                {% for tendersiae in tendersiaes %}
-                    {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
-                {% endfor %}
+                {% block htmx %}
+                    <div id="tendersList">
+                        <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
+                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug as NETWORK_SIAE_TENDER_LIST_URL %}
+                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" as NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
+                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" as NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
+                            <li class="nav-item">
+                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_LIST_URL }}"
+                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"
+                                    hx-target="#tendersList" hx-swap="outerHTML">
+                                    Toutes les demandes
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_DISPLAY_LIST_URL }}"
+                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %} active{% endif %}"
+                                    hx-target="#tendersList" hx-swap="outerHTML">
+                                    Demandes vues
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL }}"
+                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %} active{% endif %}"
+                                    hx-target="#tendersList" hx-swap="outerHTML">
+                                    Demandes intéressées
+                                </a>
+                            </li>
+                        </ul>
+                        {% for tendersiae in tendersiaes %}
+                            {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
+                        {% endfor %}
+                        {% if not tenders %}
+                            <p class="text-muted my-5">
+                                {% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %}
+                                    Cette structure n'a reçue aucune demande.
+                                {% endif %}
+                                {% if request.get_full_path == TENDERS_DRAFT_LIST_URL %}
+                                    Cette structure n'a vu aucune des demandes reçues.
+                                {% endif %}
+                                {% if request.get_full_path == TENDERS_PUBLISHED_LIST_URL %}
+                                    Cette structure ne s'est jamais montré intéressé par une des demandes reçues.
+                                {% endif %}
+                            </p>
+                        {% endif %}
+                    </div>
+                {% endblock %}
             </div>
         </div>
     </div>

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">Cette structure a reçu {{ tendersiaes.count }} demande{{ tendersiaes.count|pluralize }}</h1>
+                <h1 class="mb-3 mb-lg-5">Cette structure a reçu {{ tenders.count }} demande{{ tenders.count|pluralize }}</h1>
             </div>
         </div>
 
@@ -43,7 +43,7 @@
                                 <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_LIST_URL }}"
                                     class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"
                                     hx-target="#tendersList" hx-swap="outerHTML">
-                                    Toutes les demandes
+                                    Demandes reçues
                                 </a>
                             </li>
                             <li class="nav-item">
@@ -61,18 +61,18 @@
                                 </a>
                             </li>
                         </ul>
-                        {% for tendersiae in tendersiaes %}
-                            {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
+                        {% for tender in tenders %}
+                            {% include "tenders/_list_item_siae.html" with tender=tender %}
                         {% endfor %}
                         {% if not tenders %}
                             <p class="text-muted my-5">
                                 {% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %}
                                     Cette structure n'a reçue aucune demande.
                                 {% endif %}
-                                {% if request.get_full_path == TENDERS_DRAFT_LIST_URL %}
+                                {% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
                                     Cette structure n'a vu aucune des demandes reçues.
                                 {% endif %}
-                                {% if request.get_full_path == TENDERS_PUBLISHED_LIST_URL %}
+                                {% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
                                     Cette structure ne s'est jamais montré intéressé par une des demandes reçues.
                                 {% endif %}
                             </p>

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -1,0 +1,43 @@
+{% extends "layouts/base.html" %}
+{% load bootstrap4 static %}
+
+{% block title %}{{ page_title }}{{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+<section>
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display|truncatechars:25 }}</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="pt-4 pb-6">
+    <div class="container">
+        <div class="row">
+            <div class="col-12 col-lg-8">
+                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} besoins concernés</h1>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                {% for tendersiae in tendersiaes %}
+                    {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -11,7 +11,7 @@
                     {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}
-                            {{ title_kind_sourcing_siae }}
+                            {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
                         {% else %}
                             {{ tender.get_kind_display }}
                         {% endif %}

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -11,6 +11,7 @@ from lemarche.www.dashboard.views import (
     ProfileFavoriteListEditView,
     ProfileFavoriteListView,
     ProfileNetworkDetailView,
+    ProfileNetworkSiaeTenderListView,
     SiaeEditContactView,
     SiaeEditInfoView,
     SiaeEditLinksView,
@@ -50,6 +51,11 @@ urlpatterns = [
     ),
     # Network
     path("reseaux/<str:slug>/", ProfileNetworkDetailView.as_view(), name="profile_network_detail"),
+    path(
+        "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/",
+        ProfileNetworkSiaeTenderListView.as_view(),
+        name="profile_network_siae_tender_list",
+    ),
     # Adopt Siae
     path("prestataires/rechercher/", SiaeSearchBySiretView.as_view(), name="siae_search_by_siret"),
     path("prestataires/<str:slug>/adopter/", SiaeSearchAdoptConfirmView.as_view(), name="siae_search_adopt_confirm"),

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -52,6 +52,11 @@ urlpatterns = [
     # Network
     path("reseaux/<str:slug>/", ProfileNetworkDetailView.as_view(), name="profile_network_detail"),
     path(
+        "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/<status>",
+        ProfileNetworkSiaeTenderListView.as_view(),
+        name="profile_network_siae_tender_list",
+    ),
+    path(
         "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/",
         ProfileNetworkSiaeTenderListView.as_view(),
         name="profile_network_siae_tender_list",

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -246,7 +246,7 @@ class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
             if "siae_slug" in self.kwargs:
                 siae = get_object_or_404(Siae, slug=self.kwargs.get("siae_slug"))
                 if siae not in network.siaes.all():
-                    return redirect("dashboard:profile_network_detail", slug=self.network.slug)
+                    return redirect("dashboard:profile_network_detail", slug=network.slug)
 
         return super().get(request, *args, **kwargs)
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -14,7 +14,7 @@ from lemarche.cms.snippets import ArticleCategory
 from lemarche.favorites.models import FavoriteItem, FavoriteList
 from lemarche.networks.models import Network
 from lemarche.siaes.models import Siae, SiaeUser, SiaeUserRequest
-from lemarche.tenders.models import Tender
+from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.s3 import S3Upload
 from lemarche.www.dashboard.forms import (
@@ -159,8 +159,8 @@ class ProfileFavoriteListCreateView(LoginRequiredMixin, SuccessMessageMixin, Cre
 
 class ProfileFavoriteListDetailView(FavoriteListOwnerRequiredMixin, DetailView):
     template_name = "dashboard/profile_favorite_list_detail.html"
-    context_object_name = "favorite_list"
     queryset = FavoriteList.objects.prefetch_related("siaes").all()
+    context_object_name = "favorite_list"
 
 
 class ProfileFavoriteListEditView(FavoriteListOwnerRequiredMixin, SuccessMessageMixin, UpdateView):
@@ -222,13 +222,44 @@ class ProfileFavoriteItemDeleteView(LoginRequiredMixin, SuccessMessageMixin, Del
 
 class ProfileNetworkDetailView(NetworkMemberRequiredMixin, DetailView):
     template_name = "dashboard/profile_network_detail.html"
-    context_object_name = "network"
     queryset = Network.objects.all()
+    context_object_name = "network"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         network = self.get_object()
         context["network_siaes"] = network.siaes.with_tender_stats()
+        return context
+
+
+class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
+    template_name = "dashboard/profile_network_siae_tender_list.html"
+    queryset = TenderSiae.objects.select_related("tender", "siae").all()
+    context_object_name = "tendersiaes"
+
+    def get(self, request, *args, **kwargs):
+        """
+        Check that the Siae belongs to the Network
+        """
+        if "slug" in self.kwargs:
+            network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
+            if "siae_slug" in self.kwargs:
+                siae = get_object_or_404(Siae, slug=self.kwargs.get("siae_slug"))
+                if siae not in network.siaes.all():
+                    return redirect("dashboard:profile_network_detail", slug=self.network.slug)
+
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = qs.filter(siae__slug=self.kwargs.get("siae_slug"), email_send_date__isnull=False)
+        qs = qs.order_by("-created_at")
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = Network.objects.get(slug=self.kwargs.get("slug"))
+        context["siae"] = Siae.objects.get(slug=self.kwargs.get("siae_slug"))
         return context
 
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -236,11 +236,13 @@ class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
     template_name = "dashboard/profile_network_siae_tender_list.html"
     queryset = TenderSiae.objects.select_related("tender", "siae").all()
     context_object_name = "tendersiaes"
+    status = None
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, status=None, *args, **kwargs):
         """
         Check that the Siae belongs to the Network
         """
+        self.status = status
         if "slug" in self.kwargs:
             network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
             if "siae_slug" in self.kwargs:
@@ -253,6 +255,12 @@ class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
     def get_queryset(self):
         qs = super().get_queryset()
         qs = qs.filter(siae__slug=self.kwargs.get("siae_slug"), email_send_date__isnull=False)
+        if self.status:
+            print("status", self.status)
+            if self.status == "DISPLAY":
+                qs = qs.filter(detail_display_date__isnull=False)
+            elif self.status == "CONTACT-CLICK":
+                qs = qs.filter(detail_contact_click_date__isnull=False)
         qs = qs.order_by("-created_at")
         return qs
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -389,8 +389,8 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
 
 
 class TenderSiaeInterestedListView(TenderAuthorOrAdminRequiredMixin, ListView):
-    queryset = TenderSiae.objects.select_related("tender", "siae").all()
     template_name = "tenders/siae_interested_list.html"
+    queryset = TenderSiae.objects.select_related("tender", "siae").all()
     context_object_name = "tendersiaes"
 
     def get_queryset(self):


### PR DESCRIPTION
### Quoi ?

Suite de #629

- rendre les stats clickable
- nouvelle page pour voir la liste des demandes reçues / vues / intéressées par la structure
- utiliser htmx pour naviguer entre les différents onglets

### Capture d'écran

![Screenshot from 2023-01-26 18-45-31](https://user-images.githubusercontent.com/7147385/214910226-61640d4b-55ce-4fd9-a4e0-486acbde86a9.png)
