### PR TITLE
Siae : définir en SQL le nom à afficher

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -357,14 +357,17 @@ class SiaeQuerySet(models.QuerySet):
             ),
         )
 
-    def annotate_with_brand_or_name(self):
+    def annotate_with_brand_or_name(self, with_order_by=False):
         """
         We usually want to display the brand by default
         See Siae.name_display()
         """
-        return self.annotate(
+        qs = self.annotate(
             brand_or_name=Case(When(brand="", then=F("name")), default=F("brand"), output_field=CharField())
         )
+        if with_order_by:
+            qs = qs.order_by("brand_or_name")
+        return qs
 
 
 class Siae(models.Model):

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -7,7 +7,7 @@ from django.contrib.gis.measure import D
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.search import TrigramSimilarity  # SearchVector
 from django.db import IntegrityError, models, transaction
-from django.db.models import Case, Count, IntegerField, Q, Sum, When
+from django.db.models import Case, CharField, Count, F, IntegerField, Q, Sum, When
 from django.db.models.functions import Greatest
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
@@ -355,6 +355,15 @@ class SiaeQuerySet(models.QuerySet):
                     output_field=IntegerField(),
                 )
             ),
+        )
+
+    def annotate_with_brand_or_name(self):
+        """
+        We usually want to display the brand by default
+        See Siae.name_display()
+        """
+        return self.annotate(
+            brand_or_name=Case(When(brand="", then=F("name")), default=F("brand"), output_field=CharField())
         )
 
 

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -280,8 +280,10 @@ class SiaeModelQuerysetTest(TestCase):
         self.assertEqual(siae_queryset.get(id=siae_1.id).brand_or_name, siae_1.brand)
         self.assertEqual(siae_queryset.get(id=siae_2.id).brand_or_name, siae_2.name)
         self.assertEqual(siae_queryset.first(), siae_2)  # default order is by "name"
-        siae_queryset_with_new_order = Siae.objects.annotate_with_brand_or_name().order_by("brand_or_name")
-        self.assertEqual(siae_queryset_with_new_order.first(), siae_1)
+        siae_queryset_with_order_by = Siae.objects.annotate_with_brand_or_name().order_by("brand_or_name")
+        self.assertEqual(siae_queryset_with_order_by.first(), siae_1)
+        siae_queryset_with_order_by_parameter = Siae.objects.annotate_with_brand_or_name(with_order_by=True)
+        self.assertEqual(siae_queryset_with_order_by_parameter.first(), siae_1)
 
 
 class SiaeGroupModelTest(TestCase):

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -273,6 +273,16 @@ class SiaeModelQuerysetTest(TestCase):
     # def test_with_tender_stats(self):
     # see tenders > tests.py > TenderModelQuerysetStatsTest
 
+    def test_annotate_with_brand_or_name(self):
+        siae_1 = SiaeFactory(name="ZZZ", brand="ABC")
+        siae_2 = SiaeFactory(name="Test", brand="")
+        siae_queryset = Siae.objects.annotate_with_brand_or_name()
+        self.assertEqual(siae_queryset.get(id=siae_1.id).brand_or_name, siae_1.brand)
+        self.assertEqual(siae_queryset.get(id=siae_2.id).brand_or_name, siae_2.name)
+        self.assertEqual(siae_queryset.first(), siae_2)  # default order is by "name"
+        siae_queryset_with_new_order = Siae.objects.annotate_with_brand_or_name().order_by("brand_or_name")
+        self.assertEqual(siae_queryset_with_new_order.first(), siae_1)
+
 
 class SiaeGroupModelTest(TestCase):
     @classmethod

--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -49,7 +49,7 @@
                         {% for siae in network_siaes %}
                             <tr>
                                 <td>
-                                    <a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.name_display }}</a>
+                                    <a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.brand_or_name }}</a>
                                 </td>
                                 <td>
                                     {% if siae.tender_email_send_count > 0 %}

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -228,7 +228,7 @@ class ProfileNetworkDetailView(NetworkMemberRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         network = self.get_object()
-        context["network_siaes"] = network.siaes.with_tender_stats()
+        context["network_siaes"] = network.siaes.with_tender_stats().annotate_with_brand_or_name(with_order_by=True)
         return context
 
 


### PR DESCRIPTION
### Quoi ?

Suite de #633

Nouveau queryset `annotate_with_brand_or_name` pour définir en SQL le nom de la structure à afficher (et sur lequel ordonner) : `brand` ou `name` sinon

### Pourquoi ?

- on souhaite souvent afficher l'Enseigne (`brand`) par défaut avant la Raison sociale (`name`)
- viter d'avoir des structures qui apparaissent dans le "désordre"