### PR TITLE
Dépôt de besoin : logger lorsque le besoin est validé

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -46,9 +46,7 @@ class ResponseKindFilter(admin.SimpleListFilter):
 
 def update_and_send_tender_task(tender: Tender):
     # 1) validate the tender
-    tender.validated_at = datetime.now()
-    tender.status = constants.STATUS_VALIDATED
-    tender.save()
+    tender.set_validated(with_save=True)
     # 2) find the matching Siaes? done in Tender post_save signal
     send_confirmation_published_email_to_author(tender, nb_matched_siaes=tender.siaes.count())
     # 3) send the tender to all matching Siaes & Partners
@@ -62,7 +60,6 @@ def restart_send_tender_task(tender: Tender):
         "action": "restart_send",
         "date": str(datetime.now()),
     }
-
     tender.logs.append(log_item)
     tender.save()
     # 2) send the tender to all matching Siaes & Partners

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -111,6 +111,9 @@ class TenderAdmin(admin.ModelAdmin):
 
     autocomplete_fields = ["sectors", "location", "perimeters", "author"]
     readonly_fields = [field.name for field in Tender._meta.fields if field.name.endswith("_last_seen_date")] + [
+        # slug
+        # status
+        "validated_at",
         "siae_count_with_link",
         "siae_email_send_count_with_link",
         "siae_email_link_click_count_with_link",
@@ -221,10 +224,18 @@ class TenderAdmin(admin.ModelAdmin):
             },
         ),
         (
-            "Stats et autres",
+            "Status",
             {
                 "fields": (
                     "status",
+                    "validated_at",
+                )
+            },
+        ),
+        (
+            "Stats et autres",
+            {
+                "fields": (
                     "siae_interested_list_last_seen_date",
                     "source",
                     "logs_display",

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -424,11 +424,6 @@ class Tender(models.Model):
             return True
         return False
 
-    def set_hubspot_id(self, hubspot_deal_id, with_save=True):
-        self.extra_data.update({"hubspot_deal_id": hubspot_deal_id})
-        if with_save:
-            self.save()
-
     @property
     def hubspot_deal_id(self):
         return self.extra_data.get("hubspot_deal_id")
@@ -454,6 +449,22 @@ class Tender(models.Model):
 
     def get_absolute_url(self):
         return reverse("tenders:detail", kwargs={"slug": self.slug})
+
+    def set_hubspot_id(self, hubspot_deal_id, with_save=True):
+        self.extra_data.update({"hubspot_deal_id": hubspot_deal_id})
+        if with_save:
+            self.save()
+
+    def set_validated(self, with_save=True):
+        self.validated_at = datetime.now()
+        self.status = constants.STATUS_VALIDATED
+        log_item = {
+            "action": "validate",
+            "date": str(self.validated_at),
+        }
+        self.logs.append(log_item)
+        if with_save:
+            self.save()
 
 
 @receiver(post_save, sender=Tender)


### PR DESCRIPTION
### Quoi ?

- nouvelle méthode `Tender.set_validated()` pour centraliser l'action de "validation"
- ajouter un log au moment de la validation
- indiquer dans l'admin la date de validation (en plus de la section tout en bas)