### PR TITLE
Formulaire de modification d'un Siae : ajouter un encart pour s'inspirer des structures complètes

### DIFF
--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -285,6 +285,13 @@ class SiaeModelQuerysetTest(TestCase):
         siae_queryset_with_order_by_parameter = Siae.objects.annotate_with_brand_or_name(with_order_by=True)
         self.assertEqual(siae_queryset_with_order_by_parameter.first(), siae_1)
 
+    def test_with_content_filled_stats(self):
+        siae_empty = SiaeFactory(name="Empty")
+        siae_filled_basic = SiaeFactory(name="Filled basic", user_count=1, sector_count=2, description="desc")
+        siae_queryset = Siae.objects.with_content_filled_stats()
+        self.assertEqual(siae_queryset.get(id=siae_empty.id).content_filled_basic, False)
+        self.assertEqual(siae_queryset.get(id=siae_filled_basic.id).content_filled_basic, True)
+
 
 class SiaeGroupModelTest(TestCase):
     @classmethod

--- a/lemarche/templates/dashboard/siae_edit_info.html
+++ b/lemarche/templates/dashboard/siae_edit_info.html
@@ -48,11 +48,12 @@
                         <i class="ri-information-line ri-lg"></i>
                         <strong>Conseil</strong>
                     </p>
-                    <p class="mb-0">
+                    <p class="mb-1">
                         Inspirez-vous des fiches commerciales des prestataires inclusifs
                         <a href="{% url 'siae:detail' last_3_siae_content_filled_full.0.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.0.name_display }}</a>
                         et <a href="{% url 'siae:detail' last_3_siae_content_filled_full.1.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.1.name_display }}</a>.
-                        <br />
+                    </p>
+                    <p class="mb-0">
                         Une fiche commerciale bien complétée c'est davantage de chances d'être sollicité par des clients.
                     </p>
                 </div>

--- a/lemarche/templates/dashboard/siae_edit_info.html
+++ b/lemarche/templates/dashboard/siae_edit_info.html
@@ -41,6 +41,23 @@
                 </fieldset>
             </div>
         </div>
+        {% if last_3_siae_content_filled_full %}
+            <div class="col-12 col-lg-4">
+                <div class="alert alert-info mt-3 mt-lg-0" role="alert">
+                    <p class="mb-1">
+                        <i class="ri-information-line ri-lg"></i>
+                        <strong>Conseil</strong>
+                    </p>
+                    <p class="mb-0">
+                        Inspirez-vous des fiches commerciales des prestataires inclusifs
+                        <a href="{% url 'siae:detail' last_3_siae_content_filled_full.0.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.0.name_display }}</a>
+                        et <a href="{% url 'siae:detail' last_3_siae_content_filled_full.1.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.1.name_display }}</a>.
+                        <br />
+                        Une fiche commerciale bien complétée c'est davantage de chances d'être sollicité par des clients.
+                    </p>
+                </div>
+            </div>
+        {% endif %}
     </div>
 
     <div class="row mb-3 mb-lg-5">

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -392,6 +392,12 @@ class SiaeEditInfoView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView)
             context["label_formset"] = SiaeLabelFormSet(self.request.POST, instance=self.object)
         else:
             context["label_formset"] = SiaeLabelFormSet(instance=self.object)
+        context["last_3_siae_content_filled_full"] = (
+            Siae.objects.with_content_filled_stats()
+            .filter(content_filled_full=True)
+            .exclude(id=self.object.id)
+            .order_by("-updated_at")[:3]
+        )
         return context
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

- Nouveau queryset `Siae.objects.with_content_filled_stats()` : qui calcule 2 nouveaux champs `content_filled_basic` & `content_filled_full`
- Dans SiaeEditInfoView, récupérer 3 structures "complètes" qui ont été récemment modifiées + les afficher dans un encart

### Pourquoi ?

Donner des exemples de structures complètes aux structures

### Captures d'écran (optionnel)

![Screenshot from 2023-02-21 14-56-44](https://user-images.githubusercontent.com/7147385/220367493-ac9d8543-3650-472b-ad10-cc1479f69032.png)
