### PR TITLE
Dépôt de besoin : envoyer le mail aux utilisateurs des structures

### DIFF
--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -18,13 +18,16 @@ def send_tender_emails_to_siaes(tender: Tender):
     """
     email_subject = "Une opportunité commerciale pour vous sur le Marché de l'inclusion"
     siaes = tender.siaes.all()
+    siae_users_count = 0
     siae_users_send_count = 0
 
     for siae in siaes:
         send_tender_email_to_siae(email_subject, tender, siae)
         for user in siae.users.all():
-            send_tender_email_to_siae(email_subject, tender, siae, email_to_override=user.email)
-            siae_users_send_count += 1
+            siae_users_count += 1
+            if user.email != siae.contact_email:
+                send_tender_email_to_siae(email_subject, tender, siae, email_to_override=user.email)
+                siae_users_send_count += 1
 
     tender.tendersiae_set.update(email_send_date=timezone.now(), updated_at=timezone.now())
 
@@ -41,6 +44,7 @@ def send_tender_emails_to_siaes(tender: Tender):
         "email_subject": email_subject,
         "email_count": siae_users_send_count,
         "email_timestamp": timezone.now().isoformat(),
+        "siae_users_count": siae_users_count,
     }
     tender.logs.append(siae_users_log_item)
     tender.save()

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -13,6 +13,8 @@ from lemarche.utils.urls import get_admin_url_object, get_share_url_object
 def send_tender_emails_to_siaes(tender: Tender):
     """
     All corresponding Siae will be contacted
+    - we send emails to both the Siae's 'contact_email' & the Siae's users 'email'
+    - but we avoid sending duplicate emails
 
     previous email_subject: f"{tender.get_kind_display()} : {tender.title} ({tender.author.company_name})"
     """
@@ -22,7 +24,9 @@ def send_tender_emails_to_siaes(tender: Tender):
     siae_users_send_count = 0
 
     for siae in siaes:
+        # send to siae 'contact_email'
         send_tender_email_to_siae(email_subject, tender, siae)
+        # also send to the siae's user(s) 'email' (if its value is different)
         for user in siae.users.all():
             siae_users_count += 1
             if user.email != siae.contact_email:

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -18,22 +18,31 @@ def send_tender_emails_to_siaes(tender: Tender):
     """
     email_subject = "Une opportunité commerciale pour vous sur le Marché de l'inclusion"
     siaes = tender.siaes.all()
+    siae_users_send_count = 0
 
     for siae in siaes:
         send_tender_email_to_siae(email_subject, tender, siae)
         for user in siae.users.all():
             send_tender_email_to_siae(email_subject, tender, siae, email_to_override=user.email)
+            siae_users_send_count += 1
 
     tender.tendersiae_set.update(email_send_date=timezone.now(), updated_at=timezone.now())
 
     # log email batch
-    log_item = {
+    siaes_log_item = {
         "action": "email_siaes_matched",
         "email_subject": email_subject,
         "email_count": siaes.count(),
         "email_timestamp": timezone.now().isoformat(),
     }
-    tender.logs.append(log_item)
+    tender.logs.append(siaes_log_item)
+    siae_users_log_item = {
+        "action": "email_siae_users_matched",
+        "email_subject": email_subject,
+        "email_count": siae_users_send_count,
+        "email_timestamp": timezone.now().isoformat(),
+    }
+    tender.logs.append(siae_users_log_item)
     tender.save()
 
 


### PR DESCRIPTION
### Quoi ?

Envoyer aussi le mail de matching aux utilisateurs des structures concernés
Une majorité de structures ont le même `contact_email` que le champ `email` de leur utilisateur, donc on n'envoie que aux utilisateurs dont l'e-mail est différent