### PR TITLE
Dépôt de besoin : renommer l'URL de la liste des structures intéressées

### DIFF
--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -53,7 +53,7 @@
                     <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} structures intéressées
                 </h4>
                 {% if tender.siae_detail_contact_click_count %}
-                    <a href="{% url 'tenders:detail-siae-interested' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
+                    <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
                         Voir la liste
                     </a>
                 {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -82,7 +82,7 @@
                         </a>
                     {% endif %}
                     {% if is_validated %}
-                        <a href="{% url 'tenders:detail-siae-interested' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
+                        <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
                             {{ siae_detail_contact_click_date_count }} structures intéressées
                         </a>
                     {% endif %}

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -737,7 +737,7 @@ class TenderDetailContactClickStatViewTest(TestCase):
 #         self.assertEqual(tender.logs[0]["action"], "email_feedback_30d_sent")
 
 
-class TenderSiaeInterestedListView(TestCase):
+class TenderSiaeListView(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.siae_1 = SiaeFactory(name="ZZ ESI")
@@ -762,7 +762,7 @@ class TenderSiaeInterestedListView(TestCase):
         )
 
     def test_anonymous_user_cannot_view_tender_siae_interested_list(self):
-        url = reverse("tenders:detail-siae-interested", kwargs={"slug": self.tender_1.slug})
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith("/accounts/login/"))
@@ -770,14 +770,14 @@ class TenderSiaeInterestedListView(TestCase):
     def test_only_tender_author_can_view_tender_1_siae_interested_list(self):
         # authorized
         self.client.force_login(self.user_buyer_1)
-        url = reverse("tenders:detail-siae-interested", kwargs={"slug": self.tender_1.slug})
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tendersiaes"]), 2)
         # forbidden
         for user in [self.user_buyer_2, self.user_partner, self.siae_user_1, self.siae_user_2]:
             self.client.force_login(user)
-            url = reverse("tenders:detail-siae-interested", kwargs={"slug": self.tender_1.slug})
+            url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
             response = self.client.get(url)
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response.url, "/besoins/")
@@ -785,7 +785,7 @@ class TenderSiaeInterestedListView(TestCase):
     def test_viewing_tender_siae_interested_list_should_update_stats(self):
         self.assertIsNone(self.tender_1.siae_interested_list_last_seen_date)
         self.client.force_login(self.user_buyer_1)
-        url = reverse("tenders:detail-siae-interested", kwargs={"slug": self.tender_1.slug})
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tendersiaes"]), 2)
@@ -794,8 +794,8 @@ class TenderSiaeInterestedListView(TestCase):
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default
         self.assertEqual(self.tender_1.tendersiae_set.first().id, self.tendersiae_1_3.id)
-        # but TenderSiaeInterestedListView are ordered by -detail_contact_click_date
+        # but TenderSiaeListView are ordered by -detail_contact_click_date
         self.client.force_login(self.user_buyer_1)
-        url = reverse("tenders:detail-siae-interested", kwargs={"slug": self.tender_1.slug})
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.context["tendersiaes"][0].id, self.tendersiae_1_1.id)

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         "<str:slug>/structures-interesses",
         RedirectView.as_view(pattern_name="tenders:detail-siae-list", permanent=True),
         name="detail-siae-list-old",
-    ),
+    ),  # TODO: delete in 2024
     path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/contact-click-stat", TenderDetailContactClickStat.as_view(), name="detail-contact-click-stat"),
 ]

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -6,7 +6,7 @@ from lemarche.www.tenders.views import (
     TenderDetailContactClickStat,
     TenderDetailView,
     TenderListView,
-    TenderSiaeInterestedListView,
+    TenderSiaeListView,
 )
 
 
@@ -21,6 +21,11 @@ urlpatterns = [
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),
     path("status/<status>", TenderListView.as_view(), name="list"),
     path("", TenderListView.as_view(), name="list"),
-    path("<str:slug>/structures-interessees", TenderSiaeInterestedListView.as_view(), name="detail-siae-interested"),
+    path(
+        "<str:slug>/structures-interesses",
+        RedirectView.as_view(pattern_name="tenders:detail-siae-list", permanent=True),
+        name="detail-siae-list-old",
+    ),
+    path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/contact-click-stat", TenderDetailContactClickStat.as_view(), name="detail-contact-click-stat"),
 ]

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -388,7 +388,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
         return "<strong>Répondre à cette opportunité</strong><br />Pour répondre à cette opportunité, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
 
 
-class TenderSiaeInterestedListView(TenderAuthorOrAdminRequiredMixin, ListView):
+class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):
     template_name = "tenders/siae_interested_list.html"
     queryset = TenderSiae.objects.select_related("tender", "siae").all()
     context_object_name = "tendersiaes"


### PR DESCRIPTION
### Quoi ?

Dans la page Dépôt de besoin > Structures intéressées, j'ai renommé l'URL à `/prestataires`
- pour préparer aux modifications qui vont suivre (élargissement de cette pages aux structures concernées aussi - dans une 2e onglet)
- pour homogénéiser l'utilisateur de "prestataires"
