### PR TITLE
Dépôt de besoin : cleanup de l'affichage d'un besoin

### DIFF
--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -31,25 +31,31 @@
                 <div class="row">
                     <div class="col-md-4">
                         <i class="ri-time-line"></i>
-                        Publié le {{ tender.updated_at|date }}
+                        Créé le {{ tender.created_at|date }}
                     </div>
-                    <div class="col-md-4">
-                        <i class="ri-mail-check-line"></i>
-                        <strong>{{ tender.siae_email_send_count|default:0 }} structures contactées</strong>
-                    </div>
+                    {% if tender.status == tender.STATUS_VALIDATED %}
+                        <div class="col-md-4">
+                            <i class="ri-time-line"></i>
+                            Publié le {{ tender.validated_at|date }}
+                        </div>
+                        <div class="col-md-4">
+                            <i class="ri-mail-check-line"></i>
+                            <strong>{{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} contacté{{ tender.siae_email_send_count|pluralize }}</strong>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             <div class="col-md-4 text-center my-auto">
                 {% if tender.status == tender.STATUS_VALIDATED %}
                     {% if tender.siae_detail_contact_click_since_last_seen_date_count %}
                         <span class="badge badge-base badge-pill badge-pilotage">
-                            <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveaux prestataires
+                            <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveau{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize:"x" }} prestataire{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }}
                         </span>
                     {% endif %}
                     <div class="row">
                         <div class="col-6">
                             <h4 class="mt-2">
-                                <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} prestataires intéressés
+                                <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} prestataire{{ tender.siae_detail_contact_click_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_count|pluralize }}
                             </h4>
                             {% if tender.siae_detail_contact_click_count %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
@@ -59,7 +65,7 @@
                         </div>
                     </div>
                 {% else %}
-                    <i>Le besoin n'est pas encore envoyé.</i>
+                    <i>Le besoin n'a pas encore été envoyé.</i>
                 {% endif %}
             </div>
         </div>

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -37,25 +37,29 @@
                         <i class="ri-mail-check-line"></i>
                         <strong>{{ tender.siae_email_send_count|default:0 }} structures contactées</strong>
                     </div>
-                    <div class="col-md-4">
-                        <i class="ri-eye-line"></i>
-                        <strong>{{ tender.siae_detail_display_count|default:0 }} vues</strong>
-                    </div>
                 </div>
             </div>
             <div class="col-md-4 text-center my-auto">
-                {% if tender.siae_detail_contact_click_since_last_seen_date_count %}
-                    <span class="badge badge-base badge-pill badge-pilotage">
-                        <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouvelles structures
-                    </span>
-                {% endif %}
-                <h4 class="mt-2">
-                    <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} structures intéressées
-                </h4>
-                {% if tender.siae_detail_contact_click_count %}
-                    <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
-                        Voir la liste
-                    </a>
+                {% if tender.status == tender.STATUS_VALIDATED %}
+                    {% if tender.siae_detail_contact_click_since_last_seen_date_count %}
+                        <span class="badge badge-base badge-pill badge-pilotage">
+                            <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveaux prestataires
+                        </span>
+                    {% endif %}
+                    <div class="row">
+                        <div class="col-6">
+                            <h4 class="mt-2">
+                                <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} prestataires intéressés
+                            </h4>
+                            {% if tender.siae_detail_contact_click_count %}
+                                <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
+                                    Voir la liste
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% else %}
+                    <i>Le besoin n'est pas encore envoyé.</i>
                 {% endif %}
             </div>
         </div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -90,13 +90,13 @@
                                 <i class="ri-checkbox-circle ri-xl text-info"></i>
                             </div>
                             <div class="col">
-                                <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est validé et publié !</p>
+                                <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est validé et envoyé !</p>
                             </div>
                         </div>
                     </div>
                     <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
                         <i class="ri-thumb-up-line"></i>
-                        {{ siae_detail_contact_click_date_count }} prestataires intéressés
+                        {{ siae_detail_contact_click_date_count }} prestataire{{ siae_detail_contact_click_date_count|pluralize }} intéressé{{ siae_detail_contact_click_date_count|pluralize }}
                     </a>
                 {% endif %}
             {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -26,79 +26,25 @@
 
 {% block content %}
 <section class="container">
-    {% if tender.author == request.user or user_siae_has_detail_contact_click_date %}
+    {# Afficher les contacts en haut + conseil #}
+    {% if user_siae_has_detail_contact_click_date and not tender.deadline_date_outdated %}
         <div class="row">
             <div class="col-12 col-lg-8">
-                {% if tender.author == request.user %}
-                    {% if is_draft %}
-                        <div class="alert alert-warning fade show" role="status">
-                            <div class="row">
-                                <div class="col-auto pr-0">
-                                    <i class="ri-information-line ri-xl text-warning"></i>
-                                </div>
-                                <div class="col">
-                                    <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est encore en brouillon. Modifiez-le pour le publier.</p>
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if is_pending_validation %}
-                        <div class="alert alert-info fade show" role="status">
-                            <div class="row">
-                                <div class="col-auto pr-0">
-                                    <i class="ri-information-line ri-xl text-info"></i>
-                                </div>
-                                <div class="col">
-                                    <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est en cours de validation.</p>
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if is_validated %}
-                        <div class="alert alert-success fade show" role="status">
-                            <div class="row">
-                                <div class="col-auto pr-0">
-                                    <i class="ri-checkbox-circle ri-xl text-info"></i>
-                                </div>
-                                <div class="col">
-                                    <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est validé et publié !</p>
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
-                {% endif %}
-                {% if user_siae_has_detail_contact_click_date and not tender.deadline_date_outdated %}
-                    <div class="alert alert-info fade show" role="status">
-                        {% include "tenders/_detail_contact.html" with tender=tender %}
-                    </div>
-                {% endif %}
+                <div class="alert alert-info fade show" role="status">
+                    {% include "tenders/_detail_contact.html" with tender=tender %}
+                </div>
             </div>
-            <div class="col-12 col-lg-4 pb-3 pb-lg-0">
-                {% if tender.author == request.user %}
-                    {% if is_draft %}
-                        <a href="{% url 'tenders:update' tender.slug %}" class="btn btn-primary btn-ico">
-                            <i class="ri-pencil-fill ri-lg font-weight-normal" aria-hidden="true"></i>
-                            <span>Modifier</span>
-                        </a>
-                    {% endif %}
-                    {% if is_validated %}
-                        <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
-                            {{ siae_detail_contact_click_date_count }} structures intéressées
-                        </a>
-                    {% endif %}
-                {% endif %}
-                {% if user_siae_has_detail_contact_click_date and not tender.deadline_date_outdated %}
-                    <div class="alert alert-info mt-3 mt-lg-0" role="alert">
-                        <p class="mb-1">
-                            <i class="ri-information-line ri-lg"></i>
-                            <strong>Conseil</strong>
-                        </p>
-                        <p class="mb-0 fs-sm">
-                            N'attendez pas et contactez dès maintenant le client.
-                            En fonction, envoyez lui un devis, une plaquette commerciale ou répondez à son marché.
-                        </p>
-                    </div>
-                {% endif %}
+            <div class="col-12 col-lg-4">
+                <div class="alert alert-info mt-3 mt-lg-0" role="alert">
+                    <p class="mb-1">
+                        <i class="ri-information-line ri-lg"></i>
+                        <strong>Conseil</strong>
+                    </p>
+                    <p class="mb-0 fs-sm">
+                        N'attendez pas et contactez dès maintenant le client.
+                        En fonction, envoyez lui un devis, une plaquette commerciale ou répondez à son marché.
+                    </p>
+                </div>
             </div>
         </div>
     {% endif %}
@@ -106,8 +52,55 @@
         <div class="col-12 col-lg-8 order-2">
             {% include "tenders/detail_card.html" with tender=tender %}
         </div>
-        {% if tender.author != request.user and not tender.deadline_date_outdated %}
-            <div class="col-12 col-lg-4 order-1 order-lg-2">
+        {# Sidebar "actions" #}
+        <div class="col-12 col-lg-4 order-1 order-lg-2">
+            {% if tender.author == request.user %}
+                {% if is_draft %}
+                    <div class="alert alert-warning fade show" role="status">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-warning"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est encore en brouillon. Modifiez-le pour le publier.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="{% url 'tenders:update' tender.slug %}" class="btn btn-primary btn-ico">
+                        <i class="ri-pencil-fill ri-lg font-weight-normal" aria-hidden="true"></i>
+                        <span>Modifier</span>
+                    </a>
+                {% endif %}
+                {% if is_pending_validation %}
+                    <div class="alert alert-info fade show" role="status">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-info"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est en cours de validation.</p>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if is_validated %}
+                    <div class="alert alert-success fade show" role="status">
+                        <div class="row">
+                            <div class="col-auto pr-0">
+                                <i class="ri-checkbox-circle ri-xl text-info"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">Votre {{ tender_kind_display|default:tender.get_kind_display }} est validé et publié !</p>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
+                        <i class="ri-thumb-up-line"></i>
+                        {{ siae_detail_contact_click_date_count }} prestataires intéressés
+                    </a>
+                {% endif %}
+            {% endif %}
+            {% if tender.author != request.user and not tender.deadline_date_outdated %}
                 {% if siae_detail_display_date_count_all %}
                     <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
                         <p class="mb-0 fs-sm">
@@ -159,8 +152,8 @@
                         <span>Répondre à cette opportunité</span>
                     </a>
                 {% endif %}
-            </div>
-        {% endif %}
+            {% endif %}
+        </div>
     </div>
 </section>
 {% endblock %}

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -311,7 +311,7 @@ class TenderListViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tenders"]), 1)
-        self.assertNotContains(response, "1 structures intéressées")  # tender_3, but only visible to author
+        self.assertNotContains(response, "1 prestataire intéressé")  # tender_3, but only visible to author
 
     def test_buyer_user_should_only_see_his_tenders(self):
         self.client.force_login(self.user_buyer_1)
@@ -319,7 +319,7 @@ class TenderListViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tenders"]), 3)
-        self.assertContains(response, "1 structures intéressées")  # tender_3
+        self.assertContains(response, "1 prestataire intéressé")  # tender_3
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
         self.client.force_login(self.user_partner)
@@ -456,12 +456,12 @@ class TenderDetailViewTest(TestCase):
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertContains(response, "1 structures intéressées")
+        self.assertContains(response, "1 prestataire intéressé")
         # but hidden for non-author
         self.client.force_login(self.user_buyer_2)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertNotContains(response, "1 structures intéressées")
+        self.assertNotContains(response, "1 prestataire intéressé")
 
     def test_update_tendersiae_stats_on_tender_view(self):
         self.tender_1.siaes.add(self.siae_2)


### PR DESCRIPTION
Suite de #680

### Quoi ?

- utiliser "prestataires" au lieu de "structures"
- Tender detail : continuer de ré-organiser / simplifier en mettant toutes les actions dans la sidebar