### PR TITLE
Dépôt de besoin : séparer les prestataires ciblés & intéressés

### DIFF
--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -45,7 +45,7 @@
                 {% if tender.status == tender.STATUS_VALIDATED %}
                     {% if tender.siae_detail_contact_click_since_last_seen_date_count %}
                         <span class="badge badge-base badge-pill badge-pilotage">
-                            <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveau{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize:"x" }} prestataire{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }}
+                            <i class="ri-thumb-up-line ri-xl"></i> {{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveau{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize:"x" }} prestataire{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }}
                         </span>
                     {% endif %}
                     <div class="row">

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -38,10 +38,6 @@
                             <i class="ri-time-line"></i>
                             Publié le {{ tender.validated_at|date }}
                         </div>
-                        <div class="col-md-4">
-                            <i class="ri-mail-check-line"></i>
-                            <strong>{{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} contacté{{ tender.siae_email_send_count|pluralize }}</strong>
-                        </div>
                     {% endif %}
                 </div>
             </div>
@@ -53,6 +49,16 @@
                         </span>
                     {% endif %}
                     <div class="row">
+                        <div class="col-6">
+                            <h4 class="mt-2">
+                                <i class="ri-mail-check-line font-weight-light"></i> {{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} ciblé{{ tender.siae_email_send_count|pluralize }}
+                            </h4>
+                            {% if tender.siae_email_send_count %}
+                                <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
+                                    Voir la liste
+                                </a>
+                            {% endif %}
+                        </div>
                         <div class="col-6">
                             <h4 class="mt-2">
                                 <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} prestataire{{ tender.siae_detail_contact_click_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_count|pluralize }}

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -3,7 +3,7 @@
 <div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
         <div class="row">
-            <div class="col-md-8" style="border-right:1px solid">
+            <div class="col-md-8" style="border-right:1px solid;">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
                     {% if tender.deadline_date_is_outdated %}
@@ -49,13 +49,13 @@
                         </span>
                     {% endif %}
                     <div class="row">
-                        <div class="col-6">
+                        <div class="col-6" style="border-right:1px solid;">
                             <h4 class="mt-2">
                                 <i class="ri-mail-check-line font-weight-light"></i> {{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} ciblé{{ tender.siae_email_send_count|pluralize }}
                             </h4>
                             {% if tender.siae_email_send_count %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
-                                    Voir la liste
+                                    Voir
                                 </a>
                             {% endif %}
                         </div>
@@ -65,7 +65,7 @@
                             </h4>
                             {% if tender.siae_detail_contact_click_count %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
-                                    Voir la liste
+                                    Voir
                                 </a>
                             {% endif %}
                         </div>

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -51,7 +51,7 @@
                     <div class="row">
                         <div class="col-6" style="border-right:1px solid;">
                             <h4 class="mt-2">
-                                <i class="ri-mail-check-line font-weight-light"></i> {{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} ciblé{{ tender.siae_email_send_count|pluralize }}
+                                <i class="ri-focus-2-line font-weight-light"></i> {{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} ciblé{{ tender.siae_email_send_count|pluralize }}
                             </h4>
                             {% if tender.siae_email_send_count %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
@@ -64,7 +64,7 @@
                                 <i class="ri-thumb-up-line font-weight-light"></i> {{ tender.siae_detail_contact_click_count|default:0 }} prestataire{{ tender.siae_detail_contact_click_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_count|pluralize }}
                             </h4>
                             {% if tender.siae_detail_contact_click_count %}
-                                <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
+                                <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
                                     Voir
                                 </a>
                             {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -95,7 +95,7 @@
                         </div>
                     </div>
                     <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-2">
-                        <i class="ri-mail-check-line"></i>
+                        <i class="ri-focus-2-line"></i>
                         {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
                     </a>
                     <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -96,11 +96,11 @@
                     </div>
                     <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-2">
                         <i class="ri-mail-check-line"></i>
-                        {{ siae_detail_contact_click_date_count }} prestataire{{ siae_detail_contact_click_date_count|pluralize }} ciblé{{ siae_detail_contact_click_date_count|pluralize }}
+                        {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
                     </a>
-                    <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
+                    <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
                         <i class="ri-thumb-up-line"></i>
-                        {{ siae_detail_contact_click_date_count }} prestataire{{ siae_detail_contact_click_date_count|pluralize }} intéressé{{ siae_detail_contact_click_date_count|pluralize }}
+                        {{ tender.siae_detail_contact_click_date_count }} prestataire{{ tender.siae_detail_contact_click_date_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_date_count|pluralize }}
                     </a>
                 {% endif %}
             {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -94,6 +94,10 @@
                             </div>
                         </div>
                     </div>
+                    <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-2">
+                        <i class="ri-mail-check-line"></i>
+                        {{ siae_detail_contact_click_date_count }} prestataire{{ siae_detail_contact_click_date_count|pluralize }} ciblé{{ siae_detail_contact_click_date_count|pluralize }}
+                    </a>
                     <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary">
                         <i class="ri-thumb-up-line"></i>
                         {{ siae_detail_contact_click_date_count }} prestataire{{ siae_detail_contact_click_date_count|pluralize }} intéressé{{ siae_detail_contact_click_date_count|pluralize }}

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -41,7 +41,7 @@
                     {% if user.kind != user.KIND_SIAE %}
                     {% block htmx %}
                     <div id="tendersList">
-                        <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
+                        <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
                             {% url 'tenders:list' as TENDERS_LIST_URL %}
                             {% url 'tenders:list' status=tender_constants.STATUS_DRAFT as TENDERS_DRAFT_LIST_URL %}
                             {% url 'tenders:list' status=tender_constants.STATUS_PUBLISHED as TENDERS_PUBLISHED_LIST_URL %}
@@ -75,7 +75,6 @@
                                     Envoyé
                                 </a>
                             </li>
-
                         </ul>
                         {% for tender in tenders %}
                             {% include "tenders/_list_item_buyer.html" with tender=tender %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -1,4 +1,4 @@
-{% extends "layouts/base.html" %}
+{% extends BASE_TEMPLATE %}
 {% load bootstrap4 static %}
 
 {% block title %}Prestataires intéressés par mon besoin{{ block.super }}{% endblock %}
@@ -25,10 +25,31 @@
 
 {% block content %}
 <section class="pt-4 pb-6">
-    <div class="container">
+    {% block htmx %}
+    <div class="container" id="tenderSiaeList">
+        <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
+            {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
+            {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
+
+            <li class="nav-item">
+                <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}"
+                    class="nav-link{% if request.get_full_path == TENDER_SIAE_LIST_URL %} active{% endif %}"
+                    hx-target="#tenderSiaeList" hx-swap="outerHTML">
+                    Prestataires ciblés
+                </a>
+            </li>
+            <li class="nav-item">
+                <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}"
+                    class="nav-link{% if request.get_full_path == TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %} active{% endif %}"
+                    hx-target="#tenderSiaeList" hx-swap="outerHTML">
+                    Prestataires intéressés
+                </a>
+            </li>
+        </ul>
+
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} prestataire{{ tendersiaes.count|pluralize }} intéressé{{ tendersiaes.count|pluralize }}</h1>
+                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} prestataire{{ tendersiaes.count|pluralize }}</h1>
             </div>
             <div class="col-12 col-lg-4">
                 <button type="button" class="btn btn-ico white-space-nowrap text-decoration-none btn-link text-important px-0 float-right {% if tendersiaes.count == 0 %}disabled{% endif %}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -55,5 +76,6 @@
             </div>
         </div>
     </div>
+    {% endblock %}
 </section>
 {% endblock %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -57,10 +57,10 @@
                     <i class="ri-download-line ri-lg"></i>
                 </button>
                 <div class="dropdown-menu dropdown-menu-right">
-                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
+                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
                         Télécharger la liste (.xls)
                     </a>
-                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
+                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
                         Télécharger la liste (.csv)
                     </a>
                 </div>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load bootstrap4 static %}
 
-{% block title %}{{ page_title }}{{ block.super }}{% endblock %}
+{% block title %}Prestataires intéressés par mon besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -14,7 +14,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Mes besoins</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}">{{ tender.title|truncatechars:25 }}</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Structures intéressées</li>
+                        <li class="breadcrumb-item active" aria-current="page">Prestataires intéressés</li>
                     </ol>
                 </nav>
             </div>
@@ -28,7 +28,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} structures intéressées</h1>
+                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} prestataire{{ tendersiaes.count|pluralize }} intéressé{{ tendersiaes.count|pluralize }}</h1>
             </div>
             <div class="col-12 col-lg-4">
                 <button type="button" class="btn btn-ico white-space-nowrap text-decoration-none btn-link text-important px-0 float-right {% if tendersiaes.count == 0 %}disabled{% endif %}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -452,6 +452,10 @@ class Tender(models.Model):
         )
 
     @property
+    def siae_email_send_date_count(self):
+        return self.tendersiae_set.filter(email_send_date__isnull=False).count()
+
+    @property
     def siae_detail_contact_click_date_count(self):
         return self.tendersiae_set.filter(detail_contact_click_date__isnull=False).count()
 

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -68,6 +68,8 @@ class SiaeSearchForm(forms.Form):
     tender = forms.ModelChoiceField(
         queryset=Tender.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
+    tender_status = forms.CharField(required=False, widget=forms.HiddenInput())
+
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
@@ -126,10 +128,13 @@ class SiaeSearchForm(forms.Form):
         if networks:
             qs = qs.filter_networks(networks)
 
-        # un auteur d'un dépôt de besoin peut exporter la liste des structures intéressées
+        # un auteur d'un dépôt de besoin peut exporter la liste des prestataires (ciblés ou intéressés)
         tender = self.cleaned_data.get("tender", None)
         if tender:
-            qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_contact_click_date__isnull=False)
+            qs = qs.filter(tendersiae__tender=tender, tendersiae__email_send_date__isnull=False)
+            tender_status = self.cleaned_data.get("tender_status", None)
+            if tender_status:
+                qs = qs.filter(tendersiae__detail_contact_click_date__isnull=False)
 
         favorite_list = self.cleaned_data.get("favorite_list", None)
         if favorite_list:

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -272,7 +272,8 @@ class TenderListViewTest(TestCase):
     def setUpTestData(cls):
         perimeter = PerimeterFactory(post_codes=["43705"], insee_code="06", name="Auvergne-Rhône-Alpes")
         cls.siae_user_1 = UserFactory(kind=User.KIND_SIAE)
-        cls.siae_1 = SiaeFactory(post_code=perimeter.post_codes[0])
+        cls.siae_1 = SiaeFactory()
+        cls.siae_2 = SiaeFactory(post_code=perimeter.post_codes[0])
         cls.siae_user_2 = UserFactory(kind=User.KIND_SIAE, siaes=[cls.siae_1])
         cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
@@ -288,7 +289,13 @@ class TenderListViewTest(TestCase):
             perimeters=[perimeter],
         )
         cls.tendersiae_3_1 = TenderSiae.objects.create(
-            tender=cls.tender_3, siae=cls.siae_1, detail_contact_click_date=timezone.now()
+            tender=cls.tender_3, siae=cls.siae_1, email_send_date=timezone.now()
+        )
+        cls.tendersiae_3_2 = TenderSiae.objects.create(
+            tender=cls.tender_3,
+            siae=cls.siae_2,
+            email_send_date=timezone.now(),
+            detail_contact_click_date=timezone.now(),
         )
 
     def test_anonymous_user_cannot_list_tenders(self):
@@ -311,6 +318,7 @@ class TenderListViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tenders"]), 1)
+        self.assertNotContains(response, "2 prestataires ciblés")  # tender_3, but only visible to author
         self.assertNotContains(response, "1 prestataire intéressé")  # tender_3, but only visible to author
 
     def test_buyer_user_should_only_see_his_tenders(self):
@@ -319,6 +327,7 @@ class TenderListViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tenders"]), 3)
+        self.assertContains(response, "2 prestataires ciblés")  # tender_3
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
@@ -456,11 +465,13 @@ class TenderDetailViewTest(TestCase):
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
+        self.assertContains(response, "1 prestataire ciblé")
         self.assertContains(response, "1 prestataire intéressé")
         # but hidden for non-author
         self.client.force_login(self.user_buyer_2)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
+        self.assertNotContains(response, "1 prestataire ciblé")
         self.assertNotContains(response, "1 prestataire intéressé")
 
     def test_update_tendersiae_stats_on_tender_view(self):

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -19,13 +19,14 @@ urlpatterns = [
     path("ajouter/", TenderCreateMultiStepView.as_view(), name="create"),
     path("modifier/<str:slug>", TenderCreateMultiStepView.as_view(), name="update"),
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),
-    path("status/<status>", TenderListView.as_view(), name="list"),
+    path("statut/<status>", TenderListView.as_view(), name="list"),
     path("", TenderListView.as_view(), name="list"),
     path(
         "<str:slug>/structures-interesses",
         RedirectView.as_view(pattern_name="tenders:detail-siae-list", permanent=True),
         name="detail-siae-list-old",
     ),  # TODO: delete in 2024
+    path("<str:slug>/prestataires/statut/<status>", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/contact-click-stat", TenderDetailContactClickStat.as_view(), name="detail-contact-click-stat"),
 ]

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -397,9 +397,10 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):
     def get_queryset(self):
         qs = super().get_queryset()
         qs = qs.filter(tender__slug=self.kwargs.get("slug"), email_send_date__isnull=False)
-        qs = qs.order_by("-detail_contact_click_date")
+        qs = qs.order_by("-email_send_date")
         if self.status:
             qs = qs.filter(detail_contact_click_date__isnull=False)
+            qs = qs.order_by("-detail_contact_click_date")
         return qs
 
     def get(self, request, status=None, *args, **kwargs):
@@ -414,4 +415,5 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["tender"] = Tender.objects.get(slug=self.kwargs.get("slug"))
+        context["status"] = self.status
         return context

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -397,7 +397,6 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):
     def get_queryset(self):
         qs = super().get_queryset()
         qs = qs.filter(tender__slug=self.kwargs.get("slug"), email_send_date__isnull=False)
-        qs = qs.order_by("-email_send_date")
         if self.status:
             qs = qs.filter(detail_contact_click_date__isnull=False)
             qs = qs.order_by("-detail_contact_click_date")


### PR DESCRIPTION
### Quoi ?

Pour un auteur de besoin, lui afficher les stats des prestataires ciblés (en plus des prestataires intéressés)

### Captures d'écran

|Page|Image|
|---|---|
|Liste des besoins|![Screenshot from 2023-03-01 16-28-08](https://user-images.githubusercontent.com/7147385/222185217-757775b3-6d6c-431d-949d-f90251d63e2f.png)|
|Besoin > détail|![Screenshot from 2023-03-01 15-27-30](https://user-images.githubusercontent.com/7147385/222169005-1681bfd2-df59-42ec-a976-78885d934ccf.png)|
|Besoin > détail > liste des prestataires|![Screenshot from 2023-03-01 15-25-02](https://user-images.githubusercontent.com/7147385/222168528-1f229df5-f162-4d55-8b65-46f145e1f31e.png)|



