### PR TITLE
Home : pouvoir modifier le bandeau "impact"

### DIFF
--- a/lemarche/pages/utils.py
+++ b/lemarche/pages/utils.py
@@ -1,0 +1,29 @@
+# flake8: noqa E203
+
+OPENING_P = "<p>"
+CLOSING_P = "</p>"
+OPENING_STRONG = "<strong>"
+CLOSING_STRONG = "</strong>"
+
+
+def strip_page_content_surroundings_p(content):
+    """
+    by default, ckeditor adds "<p>" at the beginning and "</p>" at the end
+    """
+    if content[: (len(OPENING_P))] == OPENING_P:
+        content = content[(len(OPENING_P)) :]
+
+    if content[(-len(CLOSING_P)) :] == CLOSING_P:
+        content = content[: (-len(CLOSING_P))]
+
+    return content
+
+
+def replace_page_content_strong(content):
+    """
+    on certain pages, we want to change the style of the <strong>text</strong>
+    """
+    content = content.replace(OPENING_STRONG, '<span class="text-important">')
+    content = content.replace(CLOSING_STRONG, "</span>")
+
+    return content

--- a/lemarche/pages/utils.py
+++ b/lemarche/pages/utils.py
@@ -19,11 +19,11 @@ def strip_page_content_surroundings_p(content):
     return content
 
 
-def replace_page_content_strong(content):
+def add_class_to_element(content, element="<strong>", class_to_add="", style_to_add=""):
     """
-    on certain pages, we want to change the style of the <strong>text</strong>
+    on certain pages, we want to change the style of some elements
     """
-    content = content.replace(OPENING_STRONG, '<span class="text-important">')
-    content = content.replace(CLOSING_STRONG, "</span>")
+    element_with_class_and_style = f'{element[:-1]} class="{class_to_add}" style="{style_to_add}">'
+    content = content.replace(element, element_with_class_and_style)
 
     return content

--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -61,15 +61,20 @@
     </div>
 </section>
 
-<section class="s-section m-0 bg-nuance-09">
-    <div class="s-section__container container">
-        <div class="s-section__row row">
-            <div class="s-section__col col-12 py-5">
-                <h2 class="h1 font-weight-bolder m-0">Le marché c'est <span class="text-important">{{ user_buyer_count }}&nbsp;acheteurs</span> inscrits, <span class="text-important">{{ siae_count }}&nbsp;prestataires</span> référencés, <span class="text-important">{{ tender_count }}&nbsp;besoins</span> publiés.</h1>
+{% if impact_custom_message %}
+    <section class="s-section m-0 bg-nuance-09">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 py-5">
+                    {# <h2 class="h1 font-weight-bolder m-0">Le marché c'est <span class="text-important">{{ user_buyer_count }}&nbsp;acheteurs</span> inscrits, <span class="text-important">{{ siae_count }}&nbsp;prestataires</span> référencés, <span class="text-important">{{ tender_count }}&nbsp;besoins</span> publiés.</h1> #}
+                    <h2 class="h1 font-weight-bolder m-0">
+                        <i class="ri-shield-star-fill mr-2"></i>{{ impact_custom_message|safe }}
+                    </h2>
+                </div>
             </div>
         </div>
-    </div>
-</section>
+    </section>
+{% endif %}
 
 {% include "pages/home_sections/_tenders_users_companies.html" %}
 {% include "pages/home_sections/_tenders_studies_case.html" %}

--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -66,7 +66,6 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12 py-5">
-                    {# <h2 class="h1 font-weight-bolder m-0">Le marché c'est <span class="text-important">{{ user_buyer_count }}&nbsp;acheteurs</span> inscrits, <span class="text-important">{{ siae_count }}&nbsp;prestataires</span> référencés, <span class="text-important">{{ tender_count }}&nbsp;besoins</span> publiés.</h1> #}
                     <h2 class="h1 font-weight-bolder m-0">
                         <i class="ri-shield-star-fill mr-2"></i>{{ impact_custom_message|safe }}
                     </h2>

--- a/lemarche/templates/pages/home.html
+++ b/lemarche/templates/pages/home.html
@@ -66,7 +66,7 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12 py-5">
-                    <h2 class="h1 font-weight-bolder m-0">
+                    <h2 class="h2 m-0">
                         <i class="ri-shield-star-fill mr-2"></i>{{ impact_custom_message|safe }}
                     </h2>
                 </div>

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -10,7 +10,7 @@ from django.views.generic import DetailView, FormView, ListView, TemplateView, V
 from django.views.generic.edit import FormMixin
 
 from lemarche.pages.models import Page, PageFragment
-from lemarche.pages.utils import replace_page_content_strong, strip_page_content_surroundings_p
+from lemarche.pages.utils import add_class_to_element, strip_page_content_surroundings_p
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.models import Sector
 from lemarche.siaes.models import Siae, SiaeGroup
@@ -59,13 +59,14 @@ class HomeView(TemplateView):
         try:
             context["impact_custom_message"] = PageFragment.objects.get(title="Impact", is_live=True).content
             context["impact_custom_message"] = strip_page_content_surroundings_p(context["impact_custom_message"])
-            context["impact_custom_message"] = replace_page_content_strong(context["impact_custom_message"])
+            context["impact_custom_message"] = add_class_to_element(
+                context["impact_custom_message"], element="<strong>", class_to_add="text-important"
+            )
         except PageFragment.DoesNotExist:
             pass
         context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
         context["siae_count"] = Siae.objects.is_live().count()
         context["tender_count"] = Tender.objects.validated().count() + 30  # historic number (before form)
-        print(PageFragment.objects.get(title="Impact", is_live=True))
         return context
 
 

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -55,9 +55,17 @@ class HomeView(TemplateView):
             context["sub_header_custom_message"] = PageFragment.objects.get(title="Bandeau", is_live=True).content
         except PageFragment.DoesNotExist:
             pass
+        try:
+            context["impact_custom_message"] = PageFragment.objects.get(title="Impact", is_live=True).content
+            context["impact_custom_message"] = (
+                context["impact_custom_message"].replace("<p>", "<span>").replace("</p>", "</span>")
+            )
+        except PageFragment.DoesNotExist:
+            pass
         context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
         context["siae_count"] = Siae.objects.is_live().count()
         context["tender_count"] = Tender.objects.validated().count() + 30  # historic number (before form)
+        print(PageFragment.objects.get(title="Impact", is_live=True))
         return context
 
 

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -16,7 +16,6 @@ from lemarche.sectors.models import Sector
 from lemarche.siaes.models import Siae, SiaeGroup
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
-from lemarche.users.models import User
 from lemarche.utils.apis import api_hubspot
 from lemarche.utils.tracker import track
 from lemarche.www.pages.forms import (
@@ -64,9 +63,6 @@ class HomeView(TemplateView):
             )
         except PageFragment.DoesNotExist:
             pass
-        context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
-        context["siae_count"] = Siae.objects.is_live().count()
-        context["tender_count"] = Tender.objects.validated().count() + 30  # historic number (before form)
         return context
 
 

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -10,6 +10,7 @@ from django.views.generic import DetailView, FormView, ListView, TemplateView, V
 from django.views.generic.edit import FormMixin
 
 from lemarche.pages.models import Page, PageFragment
+from lemarche.pages.utils import replace_page_content_strong, strip_page_content_surroundings_p
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.models import Sector
 from lemarche.siaes.models import Siae, SiaeGroup
@@ -57,9 +58,8 @@ class HomeView(TemplateView):
             pass
         try:
             context["impact_custom_message"] = PageFragment.objects.get(title="Impact", is_live=True).content
-            context["impact_custom_message"] = (
-                context["impact_custom_message"].replace("<p>", "<span>").replace("</p>", "</span>")
-            )
+            context["impact_custom_message"] = strip_page_content_surroundings_p(context["impact_custom_message"])
+            context["impact_custom_message"] = replace_page_content_strong(context["impact_custom_message"])
         except PageFragment.DoesNotExist:
             pass
         context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()


### PR DESCRIPTION
### Quoi ?

Similaire à https://github.com/betagouv/itou-marche/pull/621

Pouvoir modifier le contenu du bandeau "impact" sur la home page.
Nécessite de post-processer le contenu de PageFragment, car ici on ne souhaite pas les balises `<p>` par défaut
- https://github.com/ckeditor/ckeditor5/issues/1537

### Captures d'écran (optionnel)

|Page|Image|
|---|---|
|Home|![Screenshot from 2023-03-13 17-27-37](https://user-images.githubusercontent.com/7147385/224767575-0fbca9c0-fbd4-4d90-9fdd-90e8fe1bf3d8.png)|
|Admin|![Screenshot from 2023-03-13 17-28-32](https://user-images.githubusercontent.com/7147385/224767604-28798eac-7d76-4b87-afe9-3e66326df66f.png)|
