### PR TITLE
API : pouvoir déposer un besoin d'achat via l'API

### DIFF
--- a/lemarche/api/tenders/serializers.py
+++ b/lemarche/api/tenders/serializers.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+
+from lemarche.perimeters.models import Perimeter
+from lemarche.sectors.models import Sector
+from lemarche.tenders.models import Tender
+
+
+class TenderSerializer(serializers.ModelSerializer):
+    sectors = serializers.SlugRelatedField(
+        queryset=Sector.objects.all(), slug_field="slug", many=True, allow_null=True, required=False
+    )
+    location = serializers.SlugRelatedField(
+        queryset=Perimeter.objects.all(), slug_field="slug", allow_null=True, required=False
+    )
+
+    class Meta:
+        model = Tender
+        fields = [
+            # general
+            "kind",
+            "title",
+            "sectors",
+            "presta_type",
+            "location",
+            "is_country_area",
+            # description
+            "description",
+            "start_working_date",
+            "external_link",
+            "constraints",
+            "amount",
+            "why_amount_is_blank",
+            "accept_share_amount",
+            "accept_cocontracting",
+            # contact
+            "contact_first_name",
+            "contact_last_name",
+            "contact_email",
+            "contact_phone",
+            "response_kind",
+            "deadline_date",
+        ]

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from lemarche.tenders.models import Tender
+from lemarche.users.factories import UserFactory
+
+
+TENDER_JSON = {
+    "kind": "TENDER",
+    "title": "string",
+    "sectors": [],
+    "presta_type": ["DISP"],
+    "location": "",
+    # "is_country_area": True,
+    "description": "string",
+    "start_working_date": "2023-03-14",
+    "external_link": "",
+    "constraints": "string",
+    "amount": "0-1K",
+    # "why_amount_is_blank": "DONT_KNOW",
+    "accept_share_amount": True,
+    "accept_cocontracting": True,
+    "contact_first_name": "Prénom",
+    "contact_last_name": "Nom",
+    "contact_email": "prenom.nom@example.com",
+    # "contact_phone": "string",
+    "response_kind": ["EMAIL"],
+    "deadline_date": "2023-03-14",
+}
+
+
+class TenderCreateApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        UserFactory()
+        cls.user_with_token = UserFactory(api_key="admin")
+
+    def test_anonymous_user_cannot_create_tender(self):
+        url = reverse("api:tenders-list")
+        response = self.client.post(url, data=TENDER_JSON)
+        self.assertEqual(response.status_code, 401)
+
+    def test_user_with_unknown_api_key_cannot_create_tender(self):
+        url = reverse("api:tenders-list") + "?token=test"
+        response = self.client.post(url, data=TENDER_JSON)
+        self.assertEqual(response.status_code, 401)
+
+    def test_user_with_valid_api_key_can_create_tender(self):
+        url = reverse("api:tenders-list") + "?token=admin"
+        response = self.client.post(url, data=TENDER_JSON)
+        self.assertEqual(response.status_code, 201)
+        tender = Tender.objects.first()
+        self.assertEqual(tender.author, self.user_with_token)

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -1,0 +1,13 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import mixins, viewsets
+
+from lemarche.api.tenders.serializers import TenderSerializer
+from lemarche.tenders.models import Tender
+
+
+class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
+    serializer_class = TenderSerializer
+
+    @extend_schema(summary="Déposer un besoin d'achat", tags=[Tender._meta.verbose_name_plural])
+    def create(self, request, *args, **kwargs):
+        return super().create(request, args, kwargs)

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -1,13 +1,25 @@
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, viewsets
 
 from lemarche.api.tenders.serializers import TenderSerializer
+from lemarche.api.utils import check_user_token
 from lemarche.tenders.models import Tender
 
 
 class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     serializer_class = TenderSerializer
 
-    @extend_schema(summary="Déposer un besoin d'achat", tags=[Tender._meta.verbose_name_plural])
+    @extend_schema(
+        summary="Déposer un besoin d'achat",
+        tags=[Tender._meta.verbose_name_plural],
+        parameters=[
+            OpenApiParameter(name="token", description="Token Utilisateur", required=True, type=str),
+        ],
+    )
     def create(self, request, *args, **kwargs):
+        token = request.GET.get("token", None)
+        self.user = check_user_token(token)
         return super().create(request, args, kwargs)
+
+    def perform_create(self, serializer):
+        serializer.save(author=self.user)

--- a/lemarche/api/urls.py
+++ b/lemarche/api/urls.py
@@ -7,6 +7,7 @@ from lemarche.api.networks.views import NetworkViewSet
 from lemarche.api.perimeters.views import PerimeterAutocompleteViewSet, PerimeterKindViewSet, PerimeterViewSet
 from lemarche.api.sectors.views import SectorViewSet
 from lemarche.api.siaes.views import SiaeKindViewSet, SiaePrestaTypeViewSet, SiaeViewSet
+from lemarche.api.tenders.views import TenderViewSet
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -21,6 +22,7 @@ router.register(r"networks", NetworkViewSet, basename="networks")
 router.register(r"perimeters/kinds", PerimeterKindViewSet, basename="perimeter-kinds")
 router.register(r"perimeters/autocomplete", PerimeterAutocompleteViewSet, basename="perimeters-autocomplete")
 router.register(r"perimeters", PerimeterViewSet, basename="perimeters")
+router.register(r"tenders", TenderViewSet, basename="tenders")
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="api/home.html"), name="home"),

--- a/lemarche/api/utils.py
+++ b/lemarche/api/utils.py
@@ -17,7 +17,7 @@ def check_user_token(token):
     auth protocol is implemented it will be replaced
     """
     try:
-        return User.objects.get(api_key=token)
+        return User.objects.has_api_key().get(api_key=token)
     except (User.DoesNotExist, AssertionError):
         raise Unauthorized
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -170,6 +170,12 @@ class Tender(models.Model):
     description = models.TextField(
         verbose_name="Description du besoin", help_text="Décrivez en quelques mots votre besoin", blank=True
     )
+    presta_type = ChoiceArrayField(
+        verbose_name="Type de prestation",
+        base_field=models.CharField(max_length=20, choices=siae_constants.PRESTA_CHOICES),
+        blank=True,
+        default=list,
+    )
     constraints = models.TextField(
         verbose_name="Contraintes techniques spécifiques",
         help_text="Renseignez les contraintes liées à votre besoin",
@@ -256,12 +262,6 @@ class Tender(models.Model):
         verbose_name="France entière",
         help_text="Retournera uniquement les structures qui ont comme périmètre d'intervention 'France entière'",
         default=False,
-    )
-    presta_type = ChoiceArrayField(
-        verbose_name="Type de prestation",
-        base_field=models.CharField(max_length=20, choices=siae_constants.PRESTA_CHOICES),
-        blank=True,
-        default=list,
     )
     siae_kind = ChoiceArrayField(
         verbose_name="Type de structure",


### PR DESCRIPTION
### Quoi ?

- permettre aux acheteurs de déposer un besoin via l'API
- authentification & authorization via le token API
- ajout de tests

### Captures d'écran (optionnel)

![Screenshot from 2023-03-14 16-29-18](https://user-images.githubusercontent.com/7147385/225052115-6c748ff3-022e-4b2a-8e92-fe8f73afcb86.png)
