### PR TITLE
Correction du poste qui n'était pas enregistré à l'inscription pour les acheteurs

### DIFF
--- a/lemarche/www/auth/forms.py
+++ b/lemarche/www/auth/forms.py
@@ -77,6 +77,7 @@ class SignupForm(UserCreationForm):
             "first_name",
             "last_name",
             "phone",
+            "position",
             "company_name",
             "partner_kind",
             "email",


### PR DESCRIPTION
### Quoi ?

Correction du poste qui n'était pas enregistré à l'inscription pour les acheteurs.
