### PR TITLE
Fiche : nouveau bouton vers Annuaire Entreprises

### DIFF
--- a/lemarche/templates/siaes/_annuaire_entreprises_button.html
+++ b/lemarche/templates/siaes/_annuaire_entreprises_button.html
@@ -1,0 +1,9 @@
+{% if siret %}
+    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ siret }}" target="_blank" id="siae-detail-annuaire-entreprises-btn" class="btn btn-sm btn-outline-primary btn-ico ">
+        <i class="ri-newspaper-fill" aria-hidden="true"></i>
+        <span>
+            Voir plus d'informations légales&nbsp;
+            <i class="ri-external-link-line" aria-hidden="true"></i>
+        </span>
+    </a>
+{% endif %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -121,6 +121,11 @@
                                         <span>{{ siae.ca_display }}</span>
                                     </div>
                                 </div>
+                                <div class="row">
+                                    <div class="col-12 mt-2 mb-2">
+                                        {% include "siaes/_annuaire_entreprises_button.html" with siret=siae.siret %}
+                                    </div>
+                                </div>
                             </div>
                             <div class="col-12 col-md-6">
                                 <div class="row">


### PR DESCRIPTION
### Quoi ?

- sur chaque fiche structure, ajout d'un bouton vers [L'annuaire des entreprises](https://annuaire-entreprises.data.gouv.fr/)
- nouveau template dédié au bouton, avec le `siret` comme paramètre

### Pourquoi ?

Pour fournir d'avantage d'informations légales aux utilisateurs

### Capture d'écran

![Screenshot from 2023-03-28 10-37-03](https://user-images.githubusercontent.com/7147385/228180396-00f45cbb-ce43-4008-982f-bfd58ee61ea8.png)
