### PR TITLE
Réseau : page d'accueil via son tableau de bord

### DIFF
--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -107,16 +107,13 @@
                 {% else %}
                     <div class="card h-45 w-100 mb-3 mb-lg-5">
                         <div class="card-body">
-                            <p class="h4 lh-sm mb-lg-4">Mes adhérents</p>
-                            <p>
-                                <i>{{ user.partner_network }}</i>
-                            </p>
+                            <p class="h4 lh-sm mb-lg-4">Mon réseau : {{ user.partner_network }}</p>
                             <p>
                                 Suivez en temps réel les demandes de devis, appels d'offres et marchés reçus par vos adhérents et aidez-les à développer leur activité commerciale.
                             </p>
                         </div>
                         <div class="card-footer pt-0 bg-white text-right">
-                            <a href="{% url 'dashboard:profile_network_siae_list' user.partner_network.slug %}" id="dashboard_network_detail" class="btn btn-link btn-ico">
+                            <a href="{% url 'dashboard:profile_network_detail' user.partner_network.slug %}" id="dashboard_network_detail" class="btn btn-link btn-ico">
                                 <span>Animer mon réseau</span>
                                 <i class="ri-arrow-right-s-line ri-xl"></i>
                             </a>

--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -1,0 +1,78 @@
+{% extends "layouts/base.html" %}
+{% load bootstrap4 %}
+
+{% block title %}Mon réseau{{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+<section>
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Mon réseau</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="s-title-01">
+    <div class="s-title-01__container container">
+        <div class="s-title-01__row row">
+            <div class="s-title-01__col col-12">
+                <h1 class="s-title-01__title h1"><strong>Mon réseau : {{ network }}</strong></h1>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="s-section">
+    <div class="s-section__container container">
+        <div class="s-section__row row">
+            <div class="s-section__col col-12 col-lg-4">
+                <div class="card h-45 w-100 rounded-lg mb-3 mb-lg-5">
+                    <div class="card-body">
+                        <p class="h4 lh-sm mb-lg-4">Informations</p>
+                        <div class="d-flex">
+                            <div class="flex-fill text-center">
+                                <span class="h2 text-info d-block mb-1">{{ network.siaes.count }}</span>
+                                <span class="fs-sm lh-sm d-block">Adhérents</span>
+                            </div>
+                            {% if network.website %}
+                                <div class="flex-fill text-center">
+                                    <a href="{{ network.website }}" target="_blank" class="h2 text-info d-block mb-1">
+                                        Lien
+                                    </a>
+                                    <span class="fs-sm lh-sm d-block">vers le site internet <i class="ri-external-link-line" aria-hidden="true"></i></span>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="s-section__col col-12 col-lg-4">
+                <div class="card h-45 w-100 mb-3 mb-lg-5">
+                    <div class="card-body">
+                        <p class="h4 lh-sm mb-lg-4">Mes adhérents</p>
+                        <p>
+                            Consultez la liste complète de vos adhérents, ainsi que le nombre de besoins qu'ils ont chacuns reçus.
+                        </p>
+                    </div>
+                    <div class="card-footer pt-0 bg-white text-right">
+                        <a href="{% url 'dashboard:profile_network_siae_list' network.slug %}" class="btn btn-link btn-ico">
+                            <span>Voir la liste</span>
+                            <i class="ri-arrow-right-s-line ri-xl"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -26,7 +26,11 @@
     <div class="s-title-01__container container">
         <div class="s-title-01__row row">
             <div class="s-title-01__col col-12">
-                <h1 class="s-title-01__title h1"><strong>Mon réseau : {{ network }}</strong></h1>
+                <h1 class="s-title-01__title h1">
+                    <strong>Mon réseau : {{ network }}</strong>
+                    <br />
+                    <small>{{ network.siaes.count }} adhérent{{ network.siaes.count|pluralize }}</small>
+                </h1>
             </div>
         </div>
     </div>
@@ -35,27 +39,6 @@
 <section class="s-section">
     <div class="s-section__container container">
         <div class="s-section__row row">
-            <div class="s-section__col col-12 col-lg-4">
-                <div class="card h-45 w-100 rounded-lg mb-3 mb-lg-5">
-                    <div class="card-body">
-                        <p class="h4 lh-sm mb-lg-4">Informations</p>
-                        <div class="d-flex">
-                            <div class="flex-fill text-center">
-                                <span class="h2 text-info d-block mb-1">{{ network.siaes.count }}</span>
-                                <span class="fs-sm lh-sm d-block">Adhérents</span>
-                            </div>
-                            {% if network.website %}
-                                <div class="flex-fill text-center">
-                                    <a href="{{ network.website }}" target="_blank" class="h2 text-info d-block mb-1">
-                                        Lien
-                                    </a>
-                                    <span class="fs-sm lh-sm d-block">vers le site internet <i class="ri-external-link-line" aria-hidden="true"></i></span>
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-            </div>
             <div class="s-section__col col-12 col-lg-4">
                 <div class="card h-45 w-100 mb-3 mb-lg-5">
                     <div class="card-body">

--- a/lemarche/templates/dashboard/profile_network_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_list.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load bootstrap4 %}
 
-{% block title %}Mon réseau{{ block.super }}{% endblock %}
+{% block title %}Mes adhérents{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -12,7 +12,8 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Mon réseau</li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Mes adhérents</li>
                     </ol>
                 </nav>
             </div>
@@ -27,8 +28,9 @@
         <div class="row">
             <div class="col-12">
                 <h1 class="h1 mb-3 mb-lg-5">
-                    <strong>Mon réseau : {{ network }}</strong>
-                    <span class="badge badge-pill badge-marche-light fs-xs" style="vertical-align:middle;" title="{{ network.siaes.count }} adhérent{{ network.siaes.count|pluralize }}">{{ network.siaes.count }}</span>
+                    <strong>Mes adhérents</strong>
+                    <br />
+                    <small>Statistiques : toutes les demandes de devis, appel d'offres et sourcing</small>
                 </h1>
             </div>
         </div>
@@ -64,10 +66,8 @@
         <div class="row">
             <div class="col-12">
                 <h2>
-                    Statistiques : toutes les demandes de devis, appel d'offres et sourcing
-                    {% if siaes.count != network.siaes.count %}
-                        <span class="badge badge-pill fs-xs" style="vertical-align:middle;" title="{{ siaes.count }} structure{{ siaes.count|pluralize }} trouvée{{ siaes.count|pluralize }}">{{ siaes.count }}</span>
-                    {% endif %}
+                    {{ siaes.count }} structure{{ siaes.count|pluralize }}
+                    {% if siaes.count != network.siaes.count %}trouvée{{ siaes.count|pluralize }}{% endif %}
                 </h2>
                 <table class="table table-striped table-bordred">
                     <thead>

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -1,7 +1,7 @@
 {% extends BASE_TEMPLATE %}
 {% load bootstrap4 static %}
 
-{% block title %}{{ page_title }}{{ block.super }}{% endblock %}
+{% block title %}{{ siae.name_display }}{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -12,7 +12,8 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'pages:home' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_siae_list' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_siae_list' network.slug %}">Mes adhérents</a></li>
                         <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display|truncatechars:25 }}</li>
                     </ol>
                 </nav>
@@ -27,7 +28,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">Cette structure a reçu {{ tendersiaes.count }} demande{{ tendersiaes.count|pluralize }}</h1>
+                <h1 class="mb-3 mb-lg-5">Cet adhérent a reçu {{ tendersiaes.count }} demande{{ tendersiaes.count|pluralize }}</h1>
             </div>
         </div>
 
@@ -70,13 +71,13 @@
                         {% if not tendersiaes %}
                             <p class="text-muted my-5">
                                 {% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %}
-                                    Cette structure n'a reçue aucune demande.
+                                    Cet adhérent n'a reçu aucune demande.
                                 {% endif %}
                                 {% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
-                                    Cette structure n'a vu aucune des demandes reçues.
+                                    Cet adhérent n'a vu aucune des demandes reçues.
                                 {% endif %}
                                 {% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
-                                    Cette structure ne s'est jamais montré intéressé par une des demandes reçues.
+                                    Cet adhérent ne s'est jamais montré intéressé par une des demandes reçues.
                                 {% endif %}
                             </p>
                         {% endif %}

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -10,6 +10,7 @@ from lemarche.www.dashboard.views import (
     ProfileFavoriteListDetailView,
     ProfileFavoriteListEditView,
     ProfileFavoriteListView,
+    ProfileNetworkDetailView,
     ProfileNetworkSiaeListView,
     ProfileNetworkSiaeTenderListView,
     SiaeEditContactView,
@@ -50,7 +51,8 @@ urlpatterns = [
         name="profile_favorite_list_delete",
     ),
     # Network
-    path("reseaux/<str:slug>/", ProfileNetworkSiaeListView.as_view(), name="profile_network_siae_list"),
+    path("reseaux/<str:slug>/", ProfileNetworkDetailView.as_view(), name="profile_network_detail"),
+    path("reseaux/<str:slug>/prestataires/", ProfileNetworkSiaeListView.as_view(), name="profile_network_siae_list"),
     path(
         "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/<status>",
         ProfileNetworkSiaeTenderListView.as_view(),

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -221,6 +221,12 @@ class ProfileFavoriteItemDeleteView(LoginRequiredMixin, SuccessMessageMixin, Del
         )
 
 
+class ProfileNetworkDetailView(NetworkMemberRequiredMixin, DetailView):
+    template_name = "dashboard/profile_network_detail.html"
+    queryset = Network.objects.prefetch_related("siaes").all()
+    context_object_name = "network"
+
+
 class ProfileNetworkSiaeListView(NetworkMemberRequiredMixin, FormMixin, ListView):
     template_name = "dashboard/profile_network_siae_list.html"
     form_class = NetworkSiaeFilterForm


### PR DESCRIPTION
Suite de #629 

### Quoi ?

Réorganisé un peu le tableau de bord des partenaires rattachés à un réseau : 
- la page avec la liste des structures a maintenant l'url `reseaux/<str:slug>/prestataires/`
- l'url `reseaux/<str:slug>/` affiche maintenant un tableau de bord du réseau
- remplacé "structures" par "adhérents"

### Pourquoi ?

- pour clarifier le parcours utilisateur
- pour préparer l'arrivée d'une nouvelle page

### Capture d'écran

(la section "opportunités commerciales" arrive dans la foulée)

![Screenshot from 2023-03-28 13-35-28](https://user-images.githubusercontent.com/7147385/228228169-09ba24aa-d3fb-457f-a9c1-16cbbc9d84f7.png)
