### PR TITLE
Réseaux : page avec la liste des opportunités commerciales de ses adhérents

### DIFF
--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -55,6 +55,22 @@
                     </div>
                 </div>
             </div>
+            <div class="s-section__col col-12 col-lg-4">
+                <div class="card h-45 w-100 mb-3 mb-lg-5">
+                    <div class="card-body">
+                        <p class="h4 lh-sm mb-lg-4">Opportunités commerciales</p>
+                        <p>
+                            Consultez la liste de toutes les opportunités commerciales reçues par vos adhérents.
+                        </p>
+                    </div>
+                    <div class="card-footer pt-0 bg-white text-right">
+                        <a href="{% url 'dashboard:profile_network_tender_list' network.slug %}" class="btn btn-link btn-ico">
+                            <span>Voir les opportunités</span>
+                            <i class="ri-arrow-right-s-line ri-xl"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </section>

--- a/lemarche/templates/dashboard/profile_network_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_list.html
@@ -1,0 +1,56 @@
+{% extends "layouts/base.html" %}
+{% load bootstrap4 static %}
+
+{% block title %}Opportunités commerciales{{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+<section>
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">Opportunités commerciales</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section>
+    <div class="container py-4">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h1>Opportunités commerciales reçues par mes adhérents</h1>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12 my-5">
+                {% for tender in tenders %}
+                    {% include "tenders/_list_item_siae.html" with tender=tender %}
+                {% endfor %}
+                {% include "includes/_pagination.html" %}
+                {% if not tenders %}
+                    <p class="text-muted">
+                        Désolé, nous n'avons aucune opportunités à vous présenter pour le moment.
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript">
+    $(document).on("click", ".c-card--link", function(e) {
+        window.location.href = $(this).data("url");
+    });
+</script>
+{% endblock %}

--- a/lemarche/templates/dashboard/profile_network_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_list.html
@@ -33,7 +33,7 @@
         <div class="row">
             <div class="col-12 my-5">
                 {% for tender in tenders %}
-                    {% include "tenders/_list_item_siae.html" with tender=tender %}
+                    {% include "tenders/_list_item_network.html" with tender=tender %}
                 {% endfor %}
                 {% include "includes/_pagination.html" %}
                 {% if not tenders %}

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -1,0 +1,58 @@
+{% load static humanize %}
+
+<div class="card c-card c-card--marche siae-card">
+    <div class="card-body">
+        <div class="row">
+            <div class="col-md-8" style="border-right:1px solid;">
+                <p class="mb-1">
+                    Date de clôture : {{ tender.deadline_date|default:"" }}
+                    {% if tender.deadline_date_is_outdated %}
+                        <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
+                    {% endif %}
+                    <span class="float-right badge badge-base badge-pill badge-emploi">
+                        {% if tender.kind == "PROJ" %}
+                            {{ title_kind_sourcing_siae|default:tender.get_kind_display }}
+                        {% else %}
+                            {{ tender.get_kind_display }}
+                        {% endif %}
+                    </span>
+                </p>
+
+                <h2 class="py-2">{{ tender.title }}</h2>
+
+                <hr />
+
+                <div class="row">
+                    <div class="col-md-4" title="Secteurs d'activité">
+                        {% if tender.sectors.count %}
+                            <i class="ri-award-line"></i>
+                            {{ tender.sectors_list_string|safe }}
+                        {% endif %}
+                    </div>
+                    <div class="col-md-4 text-center" title="Lieu d'intervention">
+                        {% if tender.perimeters_list_string %}
+                            <i class="ri-map-pin-2-line"></i>
+                            {{ tender.location_display|safe }}
+                        {% endif %}
+                    </div>
+                    <div class="col-md-4 text-center">
+                        {% if tender.amount %}
+                            <i class="ri-money-euro-circle-line"></i>
+                            {{ tender.get_amount_display|default:"-" }}
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4 text-center my-auto">
+                <hr class="d-md-none" />
+                <div class="row">
+                    <div class="col-12">
+                        <p class="font-weight-bold">
+                            <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} ciblé{{ tender.network_siae_email_send_count|pluralize }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -36,7 +36,7 @@
             <div class="col-md-4 text-center" title="Lieu d'intervention">
                 {% if tender.perimeters_list_string %}
                     <i class="ri-map-pin-2-line"></i>
-                    {{ tender.perimeters_list_string|safe }}
+                    {{ tender.location_display|safe }}
                 {% endif %}
             </div>
             <div class="col-md-4 text-center">

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -20,7 +20,7 @@
         <div class="row text-bold">
             <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
                 <i class="ri-award-line"></i>
-                {{ tender.sectors_list_string }}
+                {{ tender.sectors_list_string|safe }}
             </div>
             <div class="col" title="Lieu d'éxécution">
                 <i class="ri-map-pin-2-line"></i>

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -35,10 +35,12 @@
                         <i class="ri-add-fill ri-lg mr-2"></i>Publier un besoin d'achat
                     </a>
                 </div>
-                {% endif %}
-                <div class="col-12 my-5">
-                    <!-- "buyer": display tenders which the user is the author -->
-                    {% if user.kind != user.KIND_SIAE %}
+            {% endif %}
+        </div>
+        <div class="row">
+            <div class="col-12 my-5">
+                <!-- "buyer": display tenders which the user is the author -->
+                {% if user.kind != user.KIND_SIAE %}
                     {% block htmx %}
                     <div id="tendersList">
                         <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
@@ -92,15 +94,15 @@
                                     Vous n'avez aucun besoin en cours de validation pour le moment.
                                 {% endif %}
                                 {% if request.get_full_path == TENDERS_VALIDATED_LIST_URL %}
-                                    Vous n'avez aucun besoin d'envoyé pour le moment.<br>
+                                    Vous n'avez aucun besoin d'envoyé pour le moment.
+                                    <br />
                                     Contacter notre équipe en cas de problème avec un de vos dépôts de besoins en cours de validation.
                                 {% endif %}
                             </p>
                         {% endif %}
                     </div>
+                    {% endblock %}
                 <!-- "siae": display opportunities -->
-                {% endblock %}
-
                 {% else %}
                     {% for tender in tenders %}
                         {% include "tenders/_list_item_siae.html" with tender=tender %}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -31,6 +31,12 @@ def get_perimeter_filter(siae):
 
 
 class TenderQuerySet(models.QuerySet):
+    def prefetch_many_to_many(self):
+        return self.prefetch_related("sectors")  # "perimeters", "siaes"
+
+    def select_foreign_keys(self):
+        return self.select_related("location")
+
     def by_user(self, user):
         return self.filter(author=user)
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -129,6 +129,17 @@ class TenderQuerySet(models.QuerySet):
             ),
         )
 
+    def with_network_siae_stats(self, network_siaes):
+        return self.annotate(
+            network_siae_email_send_count=Sum(
+                Case(
+                    When(Q(tendersiae__email_send_date__isnull=False) & Q(tendersiae__siae__in=network_siaes), then=1),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            )
+        )
+
 
 class Tender(models.Model):
     """Appel d'offres et devis"""

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -319,7 +319,7 @@ class DashboardNetworkViewTest(TestCase):
             deadline_date=timezone.now() - timedelta(days=5),
         )
         cls.tendersiae_1_1 = TenderSiae.objects.create(
-            tender=cls.tender_1, siae=cls.siae_1, detail_contact_click_date=timezone.now()
+            tender=cls.tender_1, siae=cls.siae_1, email_send_date=timezone.now()
         )
         cls.tender_2 = TenderFactory()
 
@@ -370,4 +370,5 @@ class DashboardNetworkViewTest(TestCase):
         url = reverse("dashboard:profile_network_tender_list", args=[self.network_1.slug])
         response = self.client.get(url)
         self.assertContains(response, self.tender_1.title)
+        self.assertContains(response, "1 adhérent ciblé")
         self.assertNotContains(response, self.tender_2.title)

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -302,6 +302,7 @@ class DashboardNetworkViewTest(TestCase):
         cls.DASHBOARD_NETWORK_URLS = [
             "dashboard:profile_network_detail",
             "dashboard:profile_network_siae_list",
+            "dashboard:profile_network_tender_list",
             # "dashboard:profile_network_siae_tender_list"
         ]
         cls.network_1 = NetworkFactory(name="Liste 1")
@@ -320,6 +321,7 @@ class DashboardNetworkViewTest(TestCase):
         cls.tendersiae_1_1 = TenderSiae.objects.create(
             tender=cls.tender_1, siae=cls.siae_1, detail_contact_click_date=timezone.now()
         )
+        cls.tender_2 = TenderFactory()
 
     def test_anonymous_user_cannot_view_network_pages(self):
         for dashboard_network_url in self.DASHBOARD_NETWORK_URLS:
@@ -362,3 +364,10 @@ class DashboardNetworkViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, f"/profil/reseaux/{self.network_1.slug}/prestataires/")
+
+    def test_tender_list_in_network_tender_list(self):
+        self.client.force_login(self.user_network_1)
+        url = reverse("dashboard:profile_network_tender_list", args=[self.network_1.slug])
+        response = self.client.get(url)
+        self.assertContains(response, self.tender_1.title)
+        self.assertNotContains(response, self.tender_2.title)

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -13,6 +13,7 @@ from lemarche.www.dashboard.views import (
     ProfileNetworkDetailView,
     ProfileNetworkSiaeListView,
     ProfileNetworkSiaeTenderListView,
+    ProfileNetworkTenderListView,
     SiaeEditContactView,
     SiaeEditInfoView,
     SiaeEditLinksView,
@@ -63,6 +64,7 @@ urlpatterns = [
         ProfileNetworkSiaeTenderListView.as_view(),
         name="profile_network_siae_tender_list",
     ),
+    path("reseaux/<str:slug>/besoins/", ProfileNetworkTenderListView.as_view(), name="profile_network_tender_list"),
     # Adopt Siae
     path("prestataires/rechercher/", SiaeSearchBySiretView.as_view(), name="siae_search_by_siret"),
     path("prestataires/<str:slug>/adopter/", SiaeSearchAdoptConfirmView.as_view(), name="siae_search_adopt_confirm"),

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -300,8 +300,10 @@ class ProfileNetworkTenderListView(NetworkMemberRequiredMixin, ListView):
     def get_queryset(self):
         qs = super().get_queryset()
         self.network = Network.objects.prefetch_related("siaes").get(slug=self.kwargs.get("slug"))
+        self.network_siaes = self.network.siaes.all()
         qs = qs.prefetch_many_to_many().select_foreign_keys()
-        qs = qs.filter_with_siaes(self.network.siaes.all())
+        qs = qs.filter_with_siaes(self.network_siaes)
+        qs = qs.with_network_siae_stats(self.network_siaes)
         qs = qs.order_by_deadline_date()
         return qs
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -252,7 +252,6 @@ class TenderListView(LoginRequiredMixin, ListView):
         user = self.request.user
         qs = Tender.objects.none()
         if user.kind == User.KIND_SIAE and user.siaes:
-            # TODO: manage many siaes
             siaes = user.siaes.all()
             if siaes:
                 qs = Tender.objects.filter_with_siaes(siaes)
@@ -260,6 +259,7 @@ class TenderListView(LoginRequiredMixin, ListView):
             qs = Tender.objects.by_user(user).with_siae_stats()
             if self.status:
                 qs = qs.filter(status=self.status)
+        qs = qs.prefetch_many_to_many().select_foreign_keys()
         qs = qs.order_by_deadline_date()
         return qs
 


### PR DESCRIPTION
### Quoi ?

Nouvelle page listant les besoins reçus par les adhérents
- à l'url `/reseaux/<réseau-slug>/besoins`
- nouveau template `_list_item_network.html` pour un affichage spécifique des besoins pour les réseaux
- nouveau queryset `Tender.objects.with_network_siae_stats()` pour calcuer le nombre de structures d'un réseau ciblées par un besoin donné

### Captures d'écran (optionnel)

![Screenshot from 2023-03-30 10-47-06](https://user-images.githubusercontent.com/7147385/228781669-bbfcc943-a310-42e2-a070-109343221336.png)
