### PR TITLE
Réseaux : page détaillée avec la liste des adhérents notifiés par une opportunité donnée

### DIFF
--- a/lemarche/templates/dashboard/profile_network_detail.html
+++ b/lemarche/templates/dashboard/profile_network_detail.html
@@ -48,7 +48,7 @@
                         </p>
                     </div>
                     <div class="card-footer pt-0 bg-white text-right">
-                        <a href="{% url 'dashboard:profile_network_siae_list' network.slug %}" class="btn btn-link btn-ico">
+                        <a href="{% url 'dashboard:profile_network_siae_list' network.slug %}" id="dashboard-network-siae-list-btn" class="btn btn-link btn-ico">
                             <span>Voir la liste</span>
                             <i class="ri-arrow-right-s-line ri-xl"></i>
                         </a>
@@ -64,7 +64,7 @@
                         </p>
                     </div>
                     <div class="card-footer pt-0 bg-white text-right">
-                        <a href="{% url 'dashboard:profile_network_tender_list' network.slug %}" class="btn btn-link btn-ico">
+                        <a href="{% url 'dashboard:profile_network_tender_list' network.slug %}" id="dashboard-network-tender-list-btn" class="btn btn-link btn-ico">
                             <span>Voir les opportunités</span>
                             <i class="ri-arrow-right-s-line ri-xl"></i>
                         </a>

--- a/lemarche/templates/dashboard/profile_network_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_list.html
@@ -86,21 +86,21 @@
                                 </td>
                                 <td>
                                     {% if siae.tender_email_send_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues">{{ siae.tender_email_send_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues" id="dashboard-network-siae-show-tender-email-send-list-btn">{{ siae.tender_email_send_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_display_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues">{{ siae.tender_detail_display_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues" id="dashboard-network-siae-show-tender-detail-display-list-btn">{{ siae.tender_detail_display_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_contact_click_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées">{{ siae.tender_detail_contact_click_count }}</a>
+                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées" id="dashboard-network-siae-show-tender-detail-contact-click-list-btn">{{ siae.tender_detail_contact_click_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -35,53 +35,53 @@
         <div class="row">
             <div class="col-12">
                 {% block htmx %}
-                    <div id="tendersList">
-                        <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
-                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug as NETWORK_SIAE_TENDER_LIST_URL %}
-                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" as NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
-                            {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" as NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
-                            <li class="nav-item">
-                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_LIST_URL }}"
-                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"
-                                    hx-target="#tendersList" hx-swap="outerHTML">
-                                    Demandes reçues
-                                    <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_email_send_count }}</span>
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_DISPLAY_LIST_URL }}"
-                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %} active{% endif %}"
-                                    hx-target="#tendersList" hx-swap="outerHTML">
-                                    Demandes vues
-                                    <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_display_count }}</span>
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL }}"
-                                    class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %} active{% endif %}"
-                                    hx-target="#tendersList" hx-swap="outerHTML">
-                                    Demandes intéressées
-                                    <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_contact_click_count }}</span>
-                                </a>
-                            </li>
-                        </ul>
-                        {% for tendersiae in tendersiaes %}
-                            {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
-                        {% endfor %}
-                        {% if not tendersiaes %}
-                            <p class="text-muted my-5">
-                                {% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %}
-                                    Cet adhérent n'a reçu aucune demande.
-                                {% endif %}
-                                {% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
-                                    Cet adhérent n'a vu aucune des demandes reçues.
-                                {% endif %}
-                                {% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
-                                    Cet adhérent ne s'est jamais montré intéressé par une des demandes reçues.
-                                {% endif %}
-                            </p>
-                        {% endif %}
-                    </div>
+                <div id="siaeTenderList">
+                    <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
+                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug as NETWORK_SIAE_TENDER_LIST_URL %}
+                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" as NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
+                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" as NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
+                        <li class="nav-item">
+                            <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_LIST_URL }}"
+                                class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"
+                                hx-target="#siaeTenderList" hx-swap="outerHTML">
+                                Demandes reçues
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_email_send_count }}</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_DISPLAY_LIST_URL }}"
+                                class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %} active{% endif %}"
+                                hx-target="#siaeTenderList" hx-swap="outerHTML">
+                                Demandes vues
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_display_count }}</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL }}"
+                                class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %} active{% endif %}"
+                                hx-target="#siaeTenderList" hx-swap="outerHTML">
+                                Demandes intéressées
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_contact_click_count }}</span>
+                            </a>
+                        </li>
+                    </ul>
+                    {% for tendersiae in tendersiaes %}
+                        {% include "tenders/_list_item_siae.html" with tender=tendersiae.tender %}
+                    {% endfor %}
+                    {% if not tendersiaes %}
+                        <p class="text-muted my-5">
+                            {% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %}
+                                Cet adhérent n'a reçu aucune demande.
+                            {% endif %}
+                            {% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
+                                Cet adhérent n'a vu aucune des demandes reçues.
+                            {% endif %}
+                            {% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
+                                Cet adhérent ne s'est jamais montré intéressé par une des demandes reçues.
+                            {% endif %}
+                        </p>
+                    {% endif %}
+                </div>
                 {% endblock %}
             </div>
         </div>

--- a/lemarche/templates/dashboard/profile_network_tender_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_siae_list.html
@@ -28,7 +28,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">Mes adhérents ciblés et intéressés par cette opportunité</h1>
+                <h1 class="mb-3 mb-lg-5">Mes adhérents notifiés et intéressés par cette opportunité</h1>
             </div>
         </div>
 
@@ -43,7 +43,7 @@
                             <a role="button" hx-push-url="true" hx-get="{{ NETWORK_TENDER_SIAE_LIST_URL }}"
                                 class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
-                                Adhérents ciblés
+                                Adhérents notifiés
                                 <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_email_send_count }}</span>
                             </a>
                         </li>
@@ -62,7 +62,7 @@
                     {% if not tendersiaes %}
                         <p class="text-muted my-5">
                             {% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %}
-                                Aucun de mes adhérents n'a été ciblé par cette opportunité.
+                                Aucun de mes adhérents n'a été notifié de cette opportunité.
                             {% endif %}
                             {% if request.get_full_path == NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %}
                                 Aucun de mes adhérents ne s'est montré intéressé par cette opportunité.

--- a/lemarche/templates/dashboard/profile_network_tender_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_siae_list.html
@@ -28,20 +28,49 @@
     <div class="container">
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">Mes adhérents ciblés par cette opportunité</h1>
+                <h1 class="mb-3 mb-lg-5">Mes adhérents ciblés et intéressés par cette opportunité</h1>
             </div>
         </div>
 
         <div class="row">
             <div class="col-12">
-                {% for tendersiae in tendersiaes %}
-                    {% include "siaes/_card_tender.html" with siae=tendersiae.siae %}
-                {% endfor %}
-                {% if not tendersiaes %}
-                    <p class="text-muted my-5">
-                        Aucun de mes adhérents n'a été ciblé par cette opportunité.
-                    </p>
-                {% endif %}
+                {% block htmx %}
+                <div id="siaeTenderList">
+                    <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
+                        {% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug as NETWORK_TENDER_SIAE_LIST_URL %}
+                        {% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug "CONTACT-CLICK" as NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %}
+                        <li class="nav-item">
+                            <a role="button" hx-push-url="true" hx-get="{{ NETWORK_TENDER_SIAE_LIST_URL }}"
+                                class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %} active{% endif %}"
+                                hx-target="#siaeTenderList" hx-swap="outerHTML">
+                                Adhérents ciblés
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_email_send_count }}</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a role="button" hx-push-url="true" hx-get="{{ NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL }}"
+                                class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %} active{% endif %}"
+                                hx-target="#siaeTenderList" hx-swap="outerHTML">
+                                Adhérents intéressés
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_detail_contact_click_count }}</span>
+                            </a>
+                        </li>
+                    </ul>
+                    {% for tendersiae in tendersiaes %}
+                        {% include "siaes/_card_tender.html" with siae=tendersiae.siae %}
+                    {% endfor %}
+                    {% if not tendersiaes %}
+                        <p class="text-muted my-5">
+                            {% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %}
+                                Aucun de mes adhérents n'a été ciblé par cette opportunité.
+                            {% endif %}
+                            {% if request.get_full_path == NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %}
+                                Aucun de mes adhérents ne s'est montré intéressé par cette opportunité.
+                            {% endif %}
+                        </p>
+                    {% endif %}
+                </div>
+                {% endblock %}
             </div>
         </div>
     </div>

--- a/lemarche/templates/dashboard/profile_network_tender_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_siae_list.html
@@ -1,0 +1,49 @@
+{% extends "layouts/base.html" %}
+{% load bootstrap4 static %}
+
+{% block title %}{{ tender.title }}{{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+<section>
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_list' network.slug %}">Opportunités commerciales</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ tender.title|truncatechars:25 }}</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<section class="pt-4 pb-6">
+    <div class="container">
+        <div class="row">
+            <div class="col-12 col-lg-8">
+                <h1 class="mb-3 mb-lg-5">Mes adhérents ciblés par cette opportunité</h1>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                {% for tendersiae in tendersiaes %}
+                    {% include "siaes/_card_tender.html" with siae=tendersiae.siae %}
+                {% endfor %}
+                {% if not tendersiaes %}
+                    <p class="text-muted my-5">
+                        Aucun de mes adhérents n'a été ciblé par cette opportunité.
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/lemarche/templates/dashboard/profile_network_tender_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_siae_list.html
@@ -1,4 +1,4 @@
-{% extends "layouts/base.html" %}
+{% extends BASE_TEMPLATE %}
 {% load bootstrap4 static %}
 
 {% block title %}{{ tender.title }}{{ block.super }}{% endblock %}

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -50,6 +50,11 @@
                         <p class="font-weight-bold">
                             <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} ciblé{{ tender.network_siae_email_send_count|pluralize }}
                         </p>
+                        {% if tender.network_siae_email_send_count %}
+                            <a href="{% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug %}" id="dashboard-network-tender-show-siae-list-btn" class="btn btn-sm btn-primary">
+                                Voir la liste
+                            </a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -48,7 +48,7 @@
                 <div class="row">
                     <div class="col-12">
                         <p class="font-weight-bold">
-                            <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} ciblé{{ tender.network_siae_email_send_count|pluralize }}
+                            <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} notifié{{ tender.network_siae_email_send_count|pluralize }}
                         </p>
                         {% if tender.network_siae_email_send_count %}
                             <a href="{% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug %}" id="dashboard-network-tender-show-siae-list-btn" class="btn btn-sm btn-primary">

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -1,6 +1,6 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche siae-card">
+<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid;">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -137,7 +137,17 @@ class TenderQuerySet(models.QuerySet):
                     default=0,
                     output_field=IntegerField(),
                 )
-            )
+            ),
+            network_siae_detail_contact_click_count=Sum(
+                Case(
+                    When(
+                        Q(tendersiae__detail_contact_click_date__isnull=False) & Q(tendersiae__siae__in=network_siaes),
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            ),
         )
 
 

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -321,6 +321,9 @@ class DashboardNetworkViewTest(TestCase):
         cls.tendersiae_1_1 = TenderSiae.objects.create(
             tender=cls.tender_1, siae=cls.siae_1, email_send_date=timezone.now()
         )
+        cls.tendersiae_1_2 = TenderSiae.objects.create(
+            tender=cls.tender_1, siae=cls.siae_2, email_send_date=timezone.now()
+        )
         cls.tender_2 = TenderFactory()
 
     def test_anonymous_user_cannot_view_network_pages(self):
@@ -358,6 +361,7 @@ class DashboardNetworkViewTest(TestCase):
         url = reverse("dashboard:profile_network_siae_tender_list", args=[self.network_1.slug, self.siae_1.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.tender_1.title)
         # siae_2 not linked to network
         self.client.force_login(self.user_network_1)
         url = reverse("dashboard:profile_network_siae_tender_list", args=[self.network_1.slug, self.siae_2.slug])
@@ -372,3 +376,11 @@ class DashboardNetworkViewTest(TestCase):
         self.assertContains(response, self.tender_1.title)
         self.assertContains(response, "1 adhérent ciblé")
         self.assertNotContains(response, self.tender_2.title)
+
+    def test_network_siae_list_in_network_tender_siae_list(self):
+        self.client.force_login(self.user_network_1)
+        url = reverse("dashboard:profile_network_tender_siae_list", args=[self.network_1.slug, self.tender_1.slug])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.siae_1.name_display)
+        self.assertNotContains(response, self.siae_2.name_display)

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -374,7 +374,7 @@ class DashboardNetworkViewTest(TestCase):
         url = reverse("dashboard:profile_network_tender_list", args=[self.network_1.slug])
         response = self.client.get(url)
         self.assertContains(response, self.tender_1.title)
-        self.assertContains(response, "1 adhérent ciblé")
+        self.assertContains(response, "1 adhérent notifié")
         self.assertNotContains(response, self.tender_2.title)
 
     def test_network_siae_list_in_network_tender_siae_list(self):

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -67,7 +67,12 @@ urlpatterns = [
     ),
     path("reseaux/<str:slug>/besoins/", ProfileNetworkTenderListView.as_view(), name="profile_network_tender_list"),
     path(
-        "reseaux/<str:slug>/besoins/<slug:tender_slug>/",
+        "reseaux/<str:slug>/besoins/<slug:tender_slug>/prestataires/<status>",
+        ProfileNetworkTenderSiaeListView.as_view(),
+        name="profile_network_tender_siae_list",
+    ),
+    path(
+        "reseaux/<str:slug>/besoins/<slug:tender_slug>/prestataires/",
         ProfileNetworkTenderSiaeListView.as_view(),
         name="profile_network_tender_siae_list",
     ),

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -14,6 +14,7 @@ from lemarche.www.dashboard.views import (
     ProfileNetworkSiaeListView,
     ProfileNetworkSiaeTenderListView,
     ProfileNetworkTenderListView,
+    ProfileNetworkTenderSiaeListView,
     SiaeEditContactView,
     SiaeEditInfoView,
     SiaeEditLinksView,
@@ -65,6 +66,11 @@ urlpatterns = [
         name="profile_network_siae_tender_list",
     ),
     path("reseaux/<str:slug>/besoins/", ProfileNetworkTenderListView.as_view(), name="profile_network_tender_list"),
+    path(
+        "reseaux/<str:slug>/besoins/<slug:tender_slug>/",
+        ProfileNetworkTenderSiaeListView.as_view(),
+        name="profile_network_tender_siae_list",
+    ),
     # Adopt Siae
     path("prestataires/rechercher/", SiaeSearchBySiretView.as_view(), name="siae_search_by_siret"),
     path("prestataires/<str:slug>/adopter/", SiaeSearchAdoptConfirmView.as_view(), name="siae_search_adopt_confirm"),


### PR DESCRIPTION
Suite de #709

### Quoi ?

Pour une opportunité donnée : 
- afficher la liste des adhérents ~~ciblés~~ notifiés
- afficher la liste des adhérents intéressés

### Capture d'écran

![image](https://user-images.githubusercontent.com/7147385/230620051-a1a46e73-e109-4209-a862-e6162f74ba1c.png)

