### PR TITLE
Flatpages : expliciter les urls pour éviter les conflits avec Wagtail

### DIFF
--- a/lemarche/templates/api/home.html
+++ b/lemarche/templates/api/home.html
@@ -30,7 +30,7 @@
             <div class="col-12">
                 <h3 class="h1" id="doc">Conditions générales d'utilisation</h3>
                 <p>
-                    <a href="/cgu-api/" target="_blank" rel="noopener">Lire les conditions générales d'utilisation de l'API du marché de l'inclusion</a><i class="ri-external-link-line ml-1 font-weight-bold"></i>.
+                    <a href="{% url 'pages:cgu-api' %}" target="_blank" rel="noopener">Lire les conditions générales d'utilisation de l'API du marché de l'inclusion</a><i class="ri-external-link-line ml-1 font-weight-bold"></i>.
                 </p>
             </div>
         </div>

--- a/lemarche/templates/includes/_header_notice_migration.html
+++ b/lemarche/templates/includes/_header_notice_migration.html
@@ -1,6 +1,6 @@
 <div id="header-notice" class="alert alert-info p-2 text-center">
     <p class="mb-0">
-        Le marché de l'inclusion <a href="/2021-10-06-le-marche-fait-peau-neuve/">fait peau neuve</a> !
+        Le marché de l'inclusion <a href="{% url 'pages:2021-10-06-le-marche-fait-peau-neuve' %}">fait peau neuve</a> !
         N'hésitez pas à <a href="{% url 'pages:contact' %}">nous remonter</a> le moindre problème.
     </p>
 </div>

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -18,9 +18,9 @@
             </div>
             <div class="s-prefooter__col col-12 col-lg-6 d-flex align-items-center">
                 <ul class="s-prefooter__gridlist">
-                    <li><a href="/faq/">Comment ça marche&nbsp;?</a></li>
+                    <li><a href="{% url 'pages:faq' %}">Comment ça marche&nbsp;?</a></li>
                     <li><a href="{% url 'pages:decouvrir_inclusion' %}">C'est quoi l'inclusion&nbsp;?</a></li>
-                    <li><a href="/qui-sommes-nous/">Qui sommes-nous&nbsp;?</a></li>
+                    <li><a href="{% url 'pages:qui-sommes-nous' %}">Qui sommes-nous&nbsp;?</a></li>
                     <li><a href="{% url 'api:home' %}">API</a></li>
                     <li><a href="{% url 'pages:stats' %}">Statistiques</a></li>
                     <li><a href="https://github.com/betagouv/itou-marche/" target="_blank" rel="noopener" title="Github (lien externe)">Code source</a><i class="ri-external-link-line ml-1 font-weight-bold"></i></li>
@@ -97,9 +97,9 @@
                 <div class="s-footer-legal__col col-xs-12 col-lg-8">
                     <ul>
                         <li><a href="https://doc.inclusion.beta.gouv.fr/mentions" rel="noopener" target="_blank" title="Mentions légales (lien externe)">Mentions légales</a></li>
-                        <li><a href="/cgu/" title="Conditions générales">Conditions générales</a></li>
-                        <li><a href="/cgu-api/" title="Conditions générales de l'API">Conditions générales de l'API</a></li>
-                        <li><a href="/confidentialite/" title="Confidentialité">Confidentialité</a></li>
+                        <li><a href="{% url 'pages:cgu' %}" title="Conditions générales">Conditions générales</a></li>
+                        <li><a href="{% url 'pages:cgu-api' %}" title="Conditions générales de l'API">Conditions générales de l'API</a></li>
+                        <li><a href="{% url 'pages:confidentialite' %}" title="Confidentialité">Confidentialité</a></li>
                     </ul>
                     <ul>
                         <li><a href="{% url 'pages:accessibilite' %}">Accessibilité : non conforme</a></li>

--- a/lemarche/www/pages/urls.py
+++ b/lemarche/www/pages/urls.py
@@ -67,9 +67,21 @@ urlpatterns = [
     path("sentry-debug/", trigger_error, name="sentry_debug"),
     # Tracking endpoint for the frontend
     path("track/", TrackView.as_view(), name="track_frontend"),
-    # Flatpages (created in the admin: faq, qui-sommes-nous, cgu, confidentialité
+    # Flatpages (created in the admin: faq, qui-sommes-nous, cgu, confidentialité)
+    # TODO: move to wagtail?
     # path("", include("django.contrib.flatpages.urls")),
-    path("<path:url>", PageView.as_view(), name="flatpage"),
+    # path("<path:url>", PageView.as_view(), name="flatpage"),  # conflict with wagtail_urls
+    path("qui-sommes-nous/", PageView.as_view(), {"url": "/qui-sommes-nous/"}, name="qui-sommes-nous"),
+    path("faq/", PageView.as_view(), {"url": "/faq/"}, name="faq"),
+    path(
+        "2021-10-06-le-marche-fait-peau-neuve/",
+        PageView.as_view(),
+        {"url": "/2021-10-06-le-marche-fait-peau-neuve/"},
+        name="2021-10-06-le-marche-fait-peau-neuve",
+    ),
+    path("cgu/", PageView.as_view(), {"url": "/cgu/"}, name="cgu"),
+    path("cgu-api/", PageView.as_view(), {"url": "/cgu-api/"}, name="cgu-api"),
+    path("confidentialite/", PageView.as_view(), {"url": "/confidentialite/"}, name="confidentialite"),
     # Error pages
     path("403/", TemplateView.as_view(template_name="403.html"), name="403"),
     path("404/", TemplateView.as_view(template_name="404.html"), name="404"),


### PR DESCRIPTION
### Quoi ?

Suite à #706, il y avait des conflits entre Flatpages & Wagtail

C'est une solution temporaire, en attendant de basculer les pages sous Wagtail ?