### PR TITLE
Dépôt de besoin : élargir la liste des structures intéressées

### DIFF
--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -257,7 +257,8 @@ class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
 
     def get(self, request, status=None, *args, **kwargs):
         """
-        Check that the Siae belongs to the Network
+        - check that both the Siae & the Network exist
+        - check that the Siae belongs to the Network
         """
         self.status = status
         if "slug" in self.kwargs:
@@ -271,12 +272,14 @@ class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        qs = qs.filter(siae=self.siae).filter(email_send_date__isnull=False)
+        qs = qs.filter(siae=self.siae)
         if self.status:
             if self.status == "DISPLAY":
                 qs = qs.filter(detail_display_date__isnull=False)
             elif self.status == "CONTACT-CLICK":
                 qs = qs.filter(detail_contact_click_date__isnull=False)
+        else:  # default
+            qs = qs.filter(email_send_date__isnull=False)
         return qs
 
     def get_context_data(self, **kwargs):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -250,17 +250,18 @@ class TenderListView(LoginRequiredMixin, ListView):
         - show owned Tenders for other Users
         """
         user = self.request.user
-        queryset = Tender.objects.none()
+        qs = Tender.objects.none()
         if user.kind == User.KIND_SIAE and user.siaes:
             # TODO: manage many siaes
             siaes = user.siaes.all()
             if siaes:
-                queryset = Tender.objects.filter_with_siaes(siaes)
+                qs = Tender.objects.filter_with_siaes(siaes)
         else:
-            queryset = Tender.objects.by_user(user).with_siae_stats()
+            qs = Tender.objects.by_user(user).with_siae_stats()
             if self.status:
-                queryset = queryset.filter(status=self.status)
-        return queryset.order_by_deadline_date()
+                qs = qs.filter(status=self.status)
+        qs = qs.order_by_deadline_date()
+        return qs
 
     def get(self, request, status=None, *args, **kwargs):
         """
@@ -402,10 +403,13 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        qs = qs.filter(tender__slug=self.kwargs.get("slug"), email_send_date__isnull=False)
-        if self.status:
+        qs = qs.filter(tender__slug=self.kwargs.get("slug"))
+        if self.status:  # status == "INTERESTED"
             qs = qs.filter(detail_contact_click_date__isnull=False)
             qs = qs.order_by("-detail_contact_click_date")
+        else:  # default
+            qs = qs.filter(email_send_date__isnull=False)
+            qs = qs.order_by("-email_send_date")
         return qs
 
     def get(self, request, status=None, *args, **kwargs):


### PR DESCRIPTION
### Quoi ?

Dans l'affichage pour l'acheteur des structures intéressées par son besoin, on considère actuellement une structure intéressée comme ayant nécessairement été contactées.

Or il y a parfois des structures qui se montrent intéressées par un besoin dont elles n'ont pas été contactées.

Reste à faire : 
- rajouter une petite infobulle pour indiquer que la structure n'avait pas été ciblée ?
