### PR TITLE
Dépôt de besoin : afficher un WYSIWYG pour les champs text

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
+from ckeditor.widgets import CKEditorWidget
 from django.contrib import admin
+from django.db import models
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
@@ -124,6 +126,7 @@ class TenderAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
+    formfield_overrides = {models.TextField: {"widget": CKEditorWidget}}
 
     fieldsets = (
         (


### PR DESCRIPTION
### Quoi ?

Dans l'admin des dépôts de besoins, utiliser CKEditorWidget pour les champs `TextField`
Ca s'applique à 2 champs : `description` & `constraints`