### PR TITLE
Dépôt de besoin : changer le CTA en fonction du type de besoin

### DIFF
--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -11,7 +11,7 @@
                 {% csrf_token %}
                 <div class="modal-body home-content-body">
                     <p>
-                        Pour {{ tender_cta_text | lower }}, vous devez signaler votre intérêt à l'acheteur.
+                        Pour {{ tender.cta_text | lower }}, vous devez signaler votre intérêt à l'acheteur.
                     </p>
                 </div>
                 <div class="modal-footer">

--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -11,7 +11,7 @@
                 {% csrf_token %}
                 <div class="modal-body home-content-body">
                     <p>
-                        Pour répondre à cette opportunité, vous devez signaler votre intérêt à l'acheteur.
+                        Pour {{ tender_cta_text | lower }}, vous devez signaler votre intérêt à l'acheteur.
                     </p>
                 </div>
                 <div class="modal-footer">

--- a/lemarche/templates/tenders/create_step_description.html
+++ b/lemarche/templates/tenders/create_step_description.html
@@ -89,7 +89,6 @@
 <script type="text/javascript" src="{% static 'vendor/alpinejs@3.11.1.min.js'%}" defer></script>
 
 <script>
-
 function toggleRadioSelectElement(divToToggle, value) {
     if(value){
         divToToggle.classList.add("d-none");

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -143,8 +143,8 @@
                                 </p>
                             </div>
                         {% elif not user_siae_has_detail_contact_click_date %}
-                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="Répondre à cette opportunité">
-                                Répondre à cette opportunité
+                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="{{ tender_cta_text }}">
+                                {{ tender_cta_text }}
                             </button>
                             <div id="show-tender-contact-content" style="display:none">
                                 {% include "tenders/_detail_contact.html" with tender=tender %}
@@ -153,7 +153,7 @@
                     {% endif %}
                 {% else %}
                     <a href="#" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
-                        <span>Répondre à cette opportunité</span>
+                        <span>{{ tender_cta_text }}</span>
                     </a>
                 {% endif %}
             {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -143,8 +143,8 @@
                                 </p>
                             </div>
                         {% elif not user_siae_has_detail_contact_click_date %}
-                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="{{ tender_cta_text }}">
-                                {{ tender_cta_text }}
+                            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="{{ tender.cta_text }}">
+                                {{ tender.cta_text }}
                             </button>
                             <div id="show-tender-contact-content" style="display:none">
                                 {% include "tenders/_detail_contact.html" with tender=tender %}
@@ -153,7 +153,7 @@
                     {% endif %}
                 {% else %}
                     <a href="#" id="show-tender-contact-modal-btn" class="btn btn-success float-right mb-4" data-toggle="modal" data-target="#login_or_signup_siae_tender_modal" data-next-params="{% url 'tenders:detail' tender.slug %}">
-                        <span>{{ tender_cta_text }}</span>
+                        <span>{{ tender.cta_text }}</span>
                     </a>
                 {% endif %}
             {% endif %}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -400,8 +400,14 @@ class Tender(models.Model):
     @cached_property
     def external_link_title(self):
         if self.kind == tender_constants.KIND_TENDER:
-            return "Voir l'appel d'offres"
+            return "Lien vers appel d'offres"
         return "Lien partagé"
+
+    @property
+    def cta_text(self):
+        if self.kind == tender_constants.KIND_TENDER:
+            return "Voir cet appel d'offres"
+        return "Répondre à cette opportunité"
 
     @cached_property
     def can_display_contact_email(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -400,7 +400,7 @@ class Tender(models.Model):
     @cached_property
     def external_link_title(self):
         if self.kind == tender_constants.KIND_TENDER:
-            return "Lien vers appel d'offres"
+            return "Voir l'appel d'offres"
         return "Lien partagé"
 
     @property

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -380,7 +380,7 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Répondre à cette opportunité")
+        self.assertContains(response, "Voir cet appel d'offre")
         # users
         for user in User.objects.all():
             self.client.force_login(user)
@@ -542,33 +542,37 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertNotContains(response, "Clôturé")
-        self.assertContains(response, "Répondre à cette opportunité")
+        self.assertContains(response, "Voir cet appel d'offre")
         # siae user interested
         self.client.force_login(self.siae_user_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Répondre à cette opportunité")
+        self.assertNotContains(response, "Voir cet appel d'offre")
         # siae user not concerned
         self.client.force_login(self.siae_user_2)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertContains(response, "Répondre à cette opportunité")
+        self.assertContains(response, "Voir cet appel d'offre")
         # siae user without siae
         self.client.force_login(self.siae_user_3)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "veuillez d'abord vous")
-        self.assertNotContains(response, "Répondre à cette opportunité")
+        self.assertNotContains(response, "Voir cet appel d'offre")
         # author
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "Coordonnées")
-        self.assertNotContains(response, "Répondre à cette opportunité")
+        self.assertNotContains(response, "Voir cet appel d'offre")
 
     def test_tender_outdated_contact_display(self):
-        tender_2 = TenderFactory(author=self.user_buyer_1, deadline_date=timezone.now() - timedelta(days=1))
+        tender_2 = TenderFactory(
+            kind=tender_constants.KIND_QUOTE,
+            author=self.user_buyer_1,
+            deadline_date=timezone.now() - timedelta(days=1),
+        )
         TenderSiae.objects.create(tender=tender_2, siae=self.siae_1, detail_contact_click_date=timezone.now())
         # anonymous
         url = reverse("tenders:detail", kwargs={"slug": tender_2.slug})
@@ -611,7 +615,7 @@ class TenderDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "pour être mis en relation avec le client.")
         self.assertNotContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Répondre à cette opportunité")
+        self.assertNotContains(response, "Voir cet appel d'offre")
         # this one can!
         user_partner_2 = UserFactory(kind=User.KIND_PARTNER, can_display_tender_contact_details=True)
         self.client.force_login(user_partner_2)
@@ -619,7 +623,7 @@ class TenderDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertNotContains(response, "pour être mis en relation avec le client.")
         self.assertContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Répondre à cette opportunité")
+        self.assertNotContains(response, "Voir cet appel d'offre")
 
     def test_tender_contact_details_display(self):
         self.client.force_login(self.user_buyer_1)  # author

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -682,7 +682,7 @@ class TenderDetailContactClickStatViewTest(TestCase):
         cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
         cls.user_partner = UserFactory(kind=User.KIND_PARTNER)
-        cls.tender = TenderFactory(author=cls.user_buyer_1, siaes=[cls.siae])
+        cls.tender = TenderFactory(kind=tender_constants.KIND_TENDER, author=cls.user_buyer_1, siaes=[cls.siae])
 
     def test_anonymous_user_cannot_call_tender_contact_click(self):
         url = reverse("tenders:detail-contact-click-stat", kwargs={"slug": self.tender.slug})

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -380,7 +380,6 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        print(response.content)
         self.assertContains(response, "Voir cet appel d")  # 'offre
         # users
         for user in User.objects.all():

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -380,7 +380,8 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Voir cet appel d'offre")
+        print(response.content)
+        self.assertContains(response, "Voir cet appel d")  # 'offre
         # users
         for user in User.objects.all():
             self.client.force_login(user)
@@ -542,30 +543,30 @@ class TenderDetailViewTest(TestCase):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertNotContains(response, "Clôturé")
-        self.assertContains(response, "Voir cet appel d'offre")
+        self.assertContains(response, "Voir cet appel d")  # 'offre
         # siae user interested
         self.client.force_login(self.siae_user_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Voir cet appel d'offre")
+        self.assertNotContains(response, "Voir cet appel d")  # 'offre
         # siae user not concerned
         self.client.force_login(self.siae_user_2)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
-        self.assertContains(response, "Voir cet appel d'offre")
+        self.assertContains(response, "Voir cet appel d")  # 'offre
         # siae user without siae
         self.client.force_login(self.siae_user_3)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "veuillez d'abord vous")
-        self.assertNotContains(response, "Voir cet appel d'offre")
+        self.assertNotContains(response, "Voir cet appel d")  # 'offre
         # author
         self.client.force_login(self.user_buyer_1)
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertContains(response, "Coordonnées")
-        self.assertNotContains(response, "Voir cet appel d'offre")
+        self.assertNotContains(response, "Voir cet appel d")  # 'offre
 
     def test_tender_outdated_contact_display(self):
         tender_2 = TenderFactory(
@@ -615,7 +616,7 @@ class TenderDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "pour être mis en relation avec le client.")
         self.assertNotContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Voir cet appel d'offre")
+        self.assertNotContains(response, "Voir cet appel d")  # 'offre
         # this one can!
         user_partner_2 = UserFactory(kind=User.KIND_PARTNER, can_display_tender_contact_details=True)
         self.client.force_login(user_partner_2)
@@ -623,7 +624,7 @@ class TenderDetailViewTest(TestCase):
         response = self.client.get(url)
         self.assertNotContains(response, "pour être mis en relation avec le client.")
         self.assertContains(response, "Contactez le client dès maintenant")
-        self.assertNotContains(response, "Voir cet appel d'offre")
+        self.assertNotContains(response, "Voir cet appel d")  # 'offre
 
     def test_tender_contact_details_display(self):
         self.client.force_login(self.user_buyer_1)  # author

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -293,24 +293,26 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
         - update 'email_link_click_date' (if ?siae_id in the URL)
         - update 'detail_display_date' (if the User has any Siae linked to this Tender)
         """
-        tender: Tender = self.get_object()
+        self.object = self.get_object()
         user = self.request.user
         siae_id = request.GET.get("siae_id", None)
         # update 'email_link_click_date'
         if siae_id:
-            TenderSiae.objects.filter(tender=tender, siae_id=siae_id, email_link_click_date=None).update(
+            TenderSiae.objects.filter(tender=self.object, siae_id=siae_id, email_link_click_date=None).update(
                 email_link_click_date=timezone.now(), updated_at=timezone.now()
             )
         # update 'detail_display_date'
         if user.is_authenticated:
             if user.kind == User.KIND_SIAE:
                 # user might not be concerned with this tender: we create TenderSiae stats
-                if not user.has_tender_siae(tender):
+                if not user.has_tender_siae(self.object):
                     for siae in user.siaes.all():
-                        TenderSiae.objects.create(tender=tender, siae=siae, source=TenderSiae.TENDER_SIAE_SOURCE_LINK)
+                        TenderSiae.objects.create(
+                            tender=self.object, siae=siae, source=TenderSiae.TENDER_SIAE_SOURCE_LINK
+                        )
                 # update stats
                 TenderSiae.objects.filter(
-                    tender=tender, siae__in=user.siaes.all(), detail_display_date__isnull=True
+                    tender=self.object, siae__in=user.siaes.all(), detail_display_date__isnull=True
                 ).update(detail_display_date=timezone.now(), updated_at=timezone.now())
         return super().get(request, *args, **kwargs)
 
@@ -318,7 +320,6 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
         """ """
         context = super().get_context_data(**kwargs)
         # init
-        tender: Tender = self.get_object()
         user = self.request.user
         user_kind = user.kind if user.is_authenticated else "anonymous"
         show_nps = self.request.GET.get("nps", None)
@@ -326,17 +327,17 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
         context["parent_title"] = TITLE_DETAIL_PAGE_SIAE if user_kind == User.KIND_SIAE else TITLE_DETAIL_PAGE_OTHERS
         context["tender_kind_display"] = (
             TITLE_KIND_SOURCING_SIAE
-            if user_kind == User.KIND_SIAE and tender.kind == tender_constants.KIND_PROJECT
-            else tender.get_kind_display()
+            if user_kind == User.KIND_SIAE and self.object.kind == tender_constants.KIND_PROJECT
+            else self.object.get_kind_display()
         )
         if user.is_authenticated:
-            if tender.author == user:
-                context["is_draft"] = tender.status == tender_constants.STATUS_DRAFT
-                context["is_pending_validation"] = tender.status == tender_constants.STATUS_PUBLISHED
-                context["is_validated"] = tender.status == tender_constants.STATUS_VALIDATED
+            if self.object.author == user:
+                context["is_draft"] = self.object.status == tender_constants.STATUS_DRAFT
+                context["is_pending_validation"] = self.object.status == tender_constants.STATUS_PUBLISHED
+                context["is_validated"] = self.object.status == tender_constants.STATUS_VALIDATED
             elif user.kind == User.KIND_SIAE:
                 context["user_siae_has_detail_contact_click_date"] = TenderSiae.objects.filter(
-                    tender=tender, siae__in=user.siaes.all(), detail_contact_click_date__isnull=False
+                    tender=self.object, siae__in=user.siaes.all(), detail_contact_click_date__isnull=False
                 ).exists()
                 if show_nps:
                     context["show_nps"] = True
@@ -360,17 +361,17 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
         return get_object_or_404(Tender, slug=self.kwargs.get("slug"))
 
     def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
         user = self.request.user
         detail_contact_click_confirm = self.request.POST.get("detail_contact_click_confirm", False) == "true"
         if user.kind == User.KIND_SIAE:
             if detail_contact_click_confirm:
                 # update detail_contact_click_date
-                tender = self.get_object()
                 TenderSiae.objects.filter(
-                    tender=tender, siae__in=user.siaes.all(), detail_contact_click_date__isnull=True
+                    tender=self.object, siae__in=user.siaes.all(), detail_contact_click_date__isnull=True
                 ).update(detail_contact_click_date=timezone.now(), updated_at=timezone.now())
                 # notify the tender author
-                send_siae_interested_email_to_author(tender)
+                send_siae_interested_email_to_author(self.object)
                 # redirect
                 messages.add_message(
                     self.request, messages.SUCCESS, self.get_success_message(detail_contact_click_confirm)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -329,9 +329,6 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
             if user_kind == User.KIND_SIAE and tender.kind == tender_constants.KIND_PROJECT
             else tender.get_kind_display()
         )
-        context["tender_cta_text"] = (
-            "Voir cet appel d'offre" if tender.kind == tender_constants.KIND_TENDER else "Répondre à cette opportunité"
-        )
         if user.is_authenticated:
             if tender.author == user:
                 context["is_draft"] = tender.status == tender_constants.STATUS_DRAFT
@@ -395,7 +392,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
     def get_success_message(self, detail_contact_click_confirm):
         if detail_contact_click_confirm:
             return "<strong>Bravo !</strong><br />Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur. Assurez-vous d'avoir une fiche commerciale bien renseignée."  # noqa
-        return "<strong>Répondre à cette opportunité</strong><br />Pour répondre à cette opportunité, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
+        return f"<strong>{self.object.cta_text}</strong><br />Pour {self.object.cta_text.lower()}, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
 
 
 class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, ListView):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -329,6 +329,9 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
             if user_kind == User.KIND_SIAE and tender.kind == tender_constants.KIND_PROJECT
             else tender.get_kind_display()
         )
+        context["tender_cta_text"] = (
+            "Voir cet appel d'offre" if tender.kind == tender_constants.KIND_TENDER else "Répondre à cette opportunité"
+        )
         if user.is_authenticated:
             if tender.author == user:
                 context["is_draft"] = tender.status == tender_constants.STATUS_DRAFT


### PR DESCRIPTION
### Quoi ?

Le CTA actuel est "Répondre à cette opportunité"

Modifications apportées : 
- si c'est un appel d'offre, alors changer le texte à "Voir cet appel d'offre"
- sinon garder le texte actuel