### PR TITLE
Pouvoir anonymiser des emails

### DIFF
--- a/lemarche/templates/dashboard/siae_search_adopt_confirm.html
+++ b/lemarche/templates/dashboard/siae_search_adopt_confirm.html
@@ -75,7 +75,7 @@
                     <div class="alert alert-warning" role="alert">
                         <p class="mb-0">
                             <i>{{ siae.users.first.full_name }}</i> est déjà rattaché à cette structure sur le marché.<br />
-                            En cliquant sur <strong>Demander le rattachement</strong>, un e-mail sera envoyé à <i>{{ siae.users.first.full_name }}</i> afin qu'il ou elle valide votre rattachement.
+                            En cliquant sur <strong>Demander le rattachement</strong>, un e-mail sera envoyé à <i>{{ siae.users.first.full_name }}</i> ({{ siae.users.first.email_anonymized }}) afin qu'il ou elle valide votre rattachement.
                         </p>
                     </div>
                 {% endif %}

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from lemarche.stats.models import StatsUser
 from lemarche.utils import constants
+from lemarche.utils.emails import anonymize_email
 
 
 class UserQueryset(models.QuerySet):
@@ -309,6 +310,10 @@ class User(AbstractUser):
         if self.first_name and self.last_name:
             return f"{self.first_name.upper()[:1]}. {self.last_name.upper()}"
         return ""
+
+    @property
+    def email_anonymized(self):
+        return anonymize_email(self.email)
 
     @property
     def kind_detail_display(self):

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -1,9 +1,18 @@
+import re
+
 from django.conf import settings
 from django.core.mail import send_mail
 from huey.contrib.djhuey import task
 
 
 EMAIL_SUBJECT_PREFIX = f"[{settings.BITOUBI_ENV.upper()}] " if settings.BITOUBI_ENV != "prod" else ""
+
+
+def anonymize_email(email):
+    email_split = email.split("@")
+    email_username = email_split[0]
+    email_username_anonymized = email_username[0] + re.sub("[a-z]", "*", email_username[1:-1]) + email_username[-1]
+    return "@".join([email_username_anonymized, email_split[1]])
 
 
 # TODO: wrap this method on every send_mail. ex: use email base layout like C1

--- a/lemarche/utils/tests_emails.py
+++ b/lemarche/utils/tests_emails.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+from lemarche.utils.emails import anonymize_email
+
+
+class EmailTest(TestCase):
+    def test_anonymize_email(self):
+        email_1 = "bob@test.com"
+        self.assertEqual(anonymize_email(email_1), "b*b@test.com")
+        email_2 = "prenom.nom@test.com"
+        self.assertEqual(anonymize_email(email_2), "p*****.**m@test.com")

--- a/lemarche/utils/tests_emails.py
+++ b/lemarche/utils/tests_emails.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from lemarche.utils.emails import anonymize_email
+from lemarche.utils.emails import anonymize_email, whitelist_recipient_list
 
 
 class EmailTest(TestCase):
@@ -9,3 +9,9 @@ class EmailTest(TestCase):
         self.assertEqual(anonymize_email(email_1), "b*b@test.com")
         email_2 = "prenom.nom@test.com"
         self.assertEqual(anonymize_email(email_2), "p*****.**m@test.com")
+
+    def test_whitelist_recipient_list(self):
+        email_list_1 = ["bob@test.com"]
+        self.assertEqual(whitelist_recipient_list(email_list_1), [])
+        email_list_2 = ["bob@test.com", "prenom.nom@beta.gouv.fr"]
+        self.assertEqual(whitelist_recipient_list(email_list_2), ["prenom.nom@beta.gouv.fr"])


### PR DESCRIPTION
### Quoi ?

Nouvelle méthode `anonymize_email` qui permet d'anonymiser un email : 
- `prenom.nom@test.com` => `p*****.**m@test.com`
- utilisé dans le workflow de rattachement à une structure