### PR TITLE
Accessibilité : ajout des title sur les breadcrumbs

### DIFF
--- a/lemarche/templates/cms/article_list.html
+++ b/lemarche/templates/cms/article_list.html
@@ -16,7 +16,7 @@
                 <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ page.title }}">{{ page.title }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/cms/article_page.html
+++ b/lemarche/templates/cms/article_page.html
@@ -18,7 +18,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% slugurl 'ressources' %}">Ressources</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ page.title }}">{{ page.title }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/dashboard/profile_network_siae_tender_list.html
+++ b/lemarche/templates/dashboard/profile_network_siae_tender_list.html
@@ -14,7 +14,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_siae_list' network.slug %}">Mes adhérents</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display|truncatechars:25 }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name_display }}">{{ siae.name_display|truncatechars:25 }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/dashboard/profile_network_tender_detail.html
+++ b/lemarche/templates/dashboard/profile_network_tender_detail.html
@@ -14,7 +14,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_list' network.slug %}">Opportunités commerciales</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ tender.title|truncatechars:25 }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/dashboard/profile_network_tender_siae_list.html
+++ b/lemarche/templates/dashboard/profile_network_tender_siae_list.html
@@ -14,7 +14,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_list' network.slug %}">Opportunités commerciales</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_detail' network.slug tender.slug %}">{{ tender.title|truncatechars:25 }}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_detail' network.slug tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Adhérents notifiés</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/dashboard/siae_edit_base.html
+++ b/lemarche/templates/dashboard/siae_edit_base.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display }} : modifier</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name_display }} : modifier">{{ siae.name_display }} : modifier</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/dashboard/siae_users.html
+++ b/lemarche/templates/dashboard/siae_users.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name }} : collaborateurs</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name }} : collaborateurs">{{ siae.name }} : collaborateurs</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/favorites/dashboard_favorite_list_detail.html
+++ b/lemarche/templates/favorites/dashboard_favorite_list_detail.html
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard_favorites:list' %}">Liste d'achat favoris</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ favorite_list.name }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ favorite_list.name }}">{{ favorite_list.name }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/pages/flatpage_template.html
+++ b/lemarche/templates/pages/flatpage_template.html
@@ -13,7 +13,7 @@
                     <nav class="c-breadcrumb c-breadcrumb--marche" aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">{{ flatpage.title }}</li>
+                            <li class="breadcrumb-item active" aria-current="page"title="{{ flatpage.title }}">{{ flatpage.title }}</li>
                         </ol>
                     </nav>
                 </div>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -20,7 +20,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'siae:search_results' %}?{{ current_search_query }}" title="Revenir aux résultats de recherche">Recherche</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ siae.name_display }}</li>
+                        <li class="breadcrumb-item active" aria-current="page"title="{{ siae.name_display }}">{{ siae.name_display }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -15,7 +15,7 @@
                             <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                             <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">{{ parent_title }}</a></li>
                         {% endif %}
-                        <li class="breadcrumb-item active" aria-current="page">{{ tender.title|truncatechars:25 }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/list.html
+++ b/lemarche/templates/tenders/list.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">{{ page_title }}</li>
+                        <li class="breadcrumb-item active" aria-current="page" title="{{ page_title }}">{{ page_title }}</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -13,7 +13,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Mes besoins</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}">{{ tender.title|truncatechars:25 }}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Prestataires intéressés</li>
                     </ol>
                 </nav>


### PR DESCRIPTION
### Quoi ?

Lorsque les breadcrumbs sont trop longs, ils sont truncated (défini en dure, ou automatiquement).
Ajout de balises `title` pour éviter au maximum une perte d'information.

### Capture d'écran

![image](https://user-images.githubusercontent.com/7147385/232722993-da8c0658-cbf1-46d6-994a-ca69f0bb9ad8.png)
 