### PR TITLE
Dépôt de besoin : afficher dans certains cas l'email de Sofiane dans les coordonnées de contact

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -300,8 +300,9 @@ EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 DEFAULT_FROM_NAME = "Marché de l'inclusion"
 CONTACT_EMAIL = env("CONTACT_EMAIL", default="contact@example.com")
+SOFIANE_CONTACT_EMAIL = env("SOFIANE_CONTACT_EMAIL", default="sofiane.contact@example.com")
 NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")
-GIP_CONTACT_EMAIL = "contact@inclusion.beta.gouv.fr"
+GIP_CONTACT_EMAIL = env("GIP_CONTACT_EMAIL", default="gip.contact@example.com")
 
 # Transactional email templates
 # -- new user password reset

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -300,7 +300,7 @@ EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 DEFAULT_FROM_EMAIL = "noreply@inclusion.beta.gouv.fr"
 DEFAULT_FROM_NAME = "Marché de l'inclusion"
 CONTACT_EMAIL = env("CONTACT_EMAIL", default="contact@example.com")
-SOFIANE_CONTACT_EMAIL = env("SOFIANE_CONTACT_EMAIL", default="sofiane.contact@example.com")
+TEAM_CONTACT_EMAIL = env("TEAM_CONTACT_EMAIL", default="team.contact@example.com")
 NOTIFY_EMAIL = env("NOTIFY_EMAIL", default="notif@example.com")
 GIP_CONTACT_EMAIL = env("GIP_CONTACT_EMAIL", default="gip.contact@example.com")
 

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -37,7 +37,7 @@
     <div class="row">
         <div class="col-md-6">
             <i class="ri-at-line"></i>
-            {{ SOFIANE_CONTACT_EMAIL }}
+            {{ TEAM_CONTACT_EMAIL }}
         </div>
     </div>
 {% endif %}

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -33,6 +33,14 @@
         </div>
     {% endif %}
 </div>
+{% if not tender.response_kind_is_only_external %}
+    <div class="row">
+        <div class="col-md-6">
+            <i class="ri-at-line"></i>
+            {{ SOFIANE_CONTACT_EMAIL }}
+        </div>
+    </div>
+{% endif %}
 {% if tender.can_display_contact_external_link %}
     <div class="row">
         <div class="col-12">

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -33,7 +33,7 @@
         </div>
     {% endif %}
 </div>
-{% if not tender.response_kind_is_only_external %}
+{% if source == "alert" and not tender.response_kind_is_only_external %}
     <div class="row">
         <div class="col-md-6">
             <i class="ri-at-line"></i>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -20,10 +20,17 @@
             {{ tender.author.company_name }}
         </div>
     {% endif %}
-    {% if tender.can_display_contact_email %}
+    {% if tender.can_display_contact_email or source == "alert" and not tender.response_kind_is_only_external %}
         <div class="col-md-6">
-            <i class="ri-at-line"></i>
-            {{ tender.contact_email }}
+            {% if tender.can_display_contact_email %}
+                <i class="ri-at-line"></i>
+                {{ tender.contact_email }}
+            {% endif %}
+            {% if source == "alert" and not tender.response_kind_is_only_external %}
+                {% if tender.can_display_contact_email %}<br />{% endif %}
+                <i class="ri-at-line"></i>
+                {{ TEAM_CONTACT_EMAIL }}
+            {% endif %}
         </div>
     {% endif %}
     {% if tender.can_display_contact_phone %}
@@ -33,14 +40,6 @@
         </div>
     {% endif %}
 </div>
-{% if source == "alert" and not tender.response_kind_is_only_external %}
-    <div class="row">
-        <div class="col-md-6">
-            <i class="ri-at-line"></i>
-            {{ TEAM_CONTACT_EMAIL }}
-        </div>
-    </div>
-{% endif %}
 {% if tender.can_display_contact_external_link %}
     <div class="row">
         <div class="col-12">

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -31,7 +31,7 @@
         <div class="row">
             <div class="col-12 col-lg-8">
                 <div class="alert alert-info fade show" role="status">
-                    {% include "tenders/_detail_contact.html" with tender=tender %}
+                    {% include "tenders/_detail_contact.html" with tender=tender source="alert" %}
                 </div>
             </div>
             <div class="col-12 col-lg-4">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -453,6 +453,10 @@ class Tender(models.Model):
         return (self.RESPONSE_KIND_EXTERNAL in self.response_kind) and self.external_link
 
     @cached_property
+    def response_kind_is_only_external(self):
+        return (len(self.response_kind) == 1) and self.can_display_contact_external_link
+
+    @cached_property
     def accept_share_amount_display(self):
         if self.accept_share_amount:
             return self.TENDER_ACCEPT_SHARE_AMOUNT_TRUE

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -19,7 +19,7 @@ def expose_settings(request):
         "CRISP_ID": settings.CRISP_ID,
         "API_GOUV_URL": settings.API_GOUV_URL,
         "CONTACT_EMAIL": settings.CONTACT_EMAIL,
-        "SOFIANE_CONTACT_EMAIL": settings.SOFIANE_CONTACT_EMAIL,
+        "TEAM_CONTACT_EMAIL": settings.TEAM_CONTACT_EMAIL,
         "GIP_CONTACT_EMAIL": settings.GIP_CONTACT_EMAIL,
         # forms & docs
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -19,6 +19,7 @@ def expose_settings(request):
         "CRISP_ID": settings.CRISP_ID,
         "API_GOUV_URL": settings.API_GOUV_URL,
         "CONTACT_EMAIL": settings.CONTACT_EMAIL,
+        "SOFIANE_CONTACT_EMAIL": settings.SOFIANE_CONTACT_EMAIL,
         "GIP_CONTACT_EMAIL": settings.GIP_CONTACT_EMAIL,
         # forms & docs
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.urls import reverse
@@ -633,7 +634,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Coordonnées")
         self.assertContains(response, self.tender_1.contact_email)  # RESPONSE_KIND_EMAIL
         self.assertNotContains(response, self.tender_1.contact_phone)
-        self.assertNotContains(response, "sofiane.contact@example.com")
+        self.assertNotContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertNotContains(response, "Voir l'appel d'offres")
         self.assertNotContains(response, "Lien partagé")
         # tender with same kind & different response_kind
@@ -650,7 +651,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Coordonnées")
         self.assertContains(response, tender_2.contact_email)  # RESPONSE_KIND_EMAIL
         self.assertNotContains(response, tender_2.contact_phone)
-        self.assertNotContains(response, "sofiane.contact@example.com")
+        self.assertNotContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertContains(response, "Voir l'appel d'offres")  # KIND_TENDER & RESPONSE_KIND_EXTERNAL
         self.assertNotContains(response, "Lien partagé")
         # tender with different kind & response_kind
@@ -668,7 +669,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Coordonnées")
         self.assertNotContains(response, tender_3.contact_email)
         self.assertContains(response, tender_3.contact_phone)  # RESPONSE_KIND_TEL
-        self.assertNotContains(response, "sofiane.contact@example.com")
+        self.assertNotContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertNotContains(response, "Voir l'appel d'offres")
         self.assertContains(response, "Lien partagé")  # !KIND_TENDER & RESPONSE_KIND_EXTERNAL
         # tender_3 siae user interested
@@ -678,7 +679,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, tender_3.contact_email)
         self.assertContains(response, tender_3.contact_phone)
-        self.assertContains(response, "sofiane.contact@example.com")
+        self.assertContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertNotContains(response, "Voir l'appel d'offres")
         self.assertContains(response, "Lien partagé")
         # tender with different response_kind
@@ -696,7 +697,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Coordonnées")
         self.assertNotContains(response, tender_4.contact_email)
         self.assertNotContains(response, tender_4.contact_phone)
-        self.assertNotContains(response, "sofiane.contact@example.com")
+        self.assertNotContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertNotContains(response, "Voir l'appel d'offres")
         self.assertContains(response, "Lien partagé")  # !KIND_TENDER & RESPONSE_KIND_EXTERNAL
         # tender_4 siae user interested
@@ -706,7 +707,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Contactez le client dès maintenant")
         self.assertNotContains(response, tender_4.contact_email)
         self.assertNotContains(response, tender_4.contact_phone)
-        self.assertNotContains(response, "sofiane.contact@example.com")
+        self.assertNotContains(response, settings.TEAM_CONTACT_EMAIL)
         self.assertNotContains(response, "Voir l'appel d'offres")
         self.assertContains(response, "Lien partagé")
 


### PR DESCRIPTION
### Quoi ?

Inciter les structures à contact Sofiane en mettant son e-mail dans les coordonnées de contact.
- afficher seulement si le moyen de réponse du besoin n'est pas exclusivement "lien externe"
- afficher seulement dans l'encart de contact en haut (pas dans le corps du besoin)
- ajout de tests

### Capture d'écran

![image](https://user-images.githubusercontent.com/7147385/231771806-308ab2fa-77de-45aa-9d53-e3c25ac6bfe6.png)
