### PR TITLE
Dépôt de besoin : afficher le nom de l'entreprise de l'acheteur

### DIFF
--- a/lemarche/fixtures/django/02_users.json
+++ b/lemarche/fixtures/django/02_users.json
@@ -14,6 +14,7 @@
             "date_joined": "2019-09-30T13:30:45.639Z",
             "email": "admin@test.com",
             "phone": "",
+            "company_name": "Admin",
             "groups": [],
             "user_permissions": [],
             "created_at": "2019-12-05T14:37:56.609Z",
@@ -35,6 +36,7 @@
             "date_joined": "2019-09-30T13:30:45.639Z",
             "email": "acheteur@test.com",
             "phone": "",
+            "company_name": "Ville de Grenoble",
             "groups": [],
             "user_permissions": [],
             "created_at": "2019-12-05T14:37:56.609Z",
@@ -69,6 +71,28 @@
             "password": "pbkdf2_sha256$260000$7SMYXy9OTGSwYOs5myl9bP$GVwB+ayk8qAxkWOmP62sO+qGm1qyzivafdADRDip2/w=",
             "last_login": "2021-07-13T09:46:55.391Z",
             "is_superuser": false,
+            "first_name": "Partenaire",
+            "last_name": "Bob",
+            "is_staff": false,
+            "is_active": true,
+            "kind": "PARTNER",
+            "date_joined": "2019-09-30T13:30:45.639Z",
+            "email": "partenaire_avec_reseau@test.com",
+            "phone": "",
+            "partner_network": 1,
+            "groups": [],
+            "user_permissions": [],
+            "created_at": "2019-12-05T14:37:56.609Z",
+            "updated_at": "2020-12-18T10:38:52.329Z"
+        }
+    },
+    {
+        "model": "users.user",
+        "pk": 5,
+        "fields": {
+            "password": "pbkdf2_sha256$260000$7SMYXy9OTGSwYOs5myl9bP$GVwB+ayk8qAxkWOmP62sO+qGm1qyzivafdADRDip2/w=",
+            "last_login": "2021-07-13T09:46:55.391Z",
+            "is_superuser": false,
             "first_name": "Structure",
             "last_name": "Simple",
             "is_staff": false,
@@ -85,7 +109,7 @@
     },
     {
         "model": "users.user",
-        "pk": 5,
+        "pk": 6,
         "fields": {
             "password": "pbkdf2_sha256$260000$7SMYXy9OTGSwYOs5myl9bP$GVwB+ayk8qAxkWOmP62sO+qGm1qyzivafdADRDip2/w=",
             "last_login": "2021-07-13T09:46:55.391Z",
@@ -106,7 +130,7 @@
     },
     {
         "model": "users.user",
-        "pk": 6,
+        "pk": 7,
         "fields": {
             "password": "pbkdf2_sha256$260000$Yu3SwSxxdxLBoYtqoepbC5$PwzIOEJH6xYe6Vg4HYiV+UBE6p0Oo43zyiictW28ZXM=",
             "last_login": "2021-05-12T10:19:41.262Z",
@@ -126,7 +150,7 @@
     },
     {
         "model": "users.user",
-        "pk": 7,
+        "pk": 8,
         "fields": {
             "password": "pbkdf2_sha256$180000$X2UhzsY9bMJG$qLSEggVtAjb7BSeg7U2tna2ctWYSTBLRZ5Lfn/iROV8=",
             "last_login": "2020-04-09T14:02:59.775Z",
@@ -146,7 +170,7 @@
     },
     {
         "model": "users.user",
-        "pk": 8,
+        "pk": 9,
         "fields": {
             "password": "pbkdf2_sha256$180000$CPDNpTjYqjR1$skD6ISRz3Q1/9PsgtJagpxfjWZzpWydnQwMvbXgT0yA=",
             "last_login": null,
@@ -166,7 +190,7 @@
     },
     {
         "model": "users.user",
-        "pk": 9,
+        "pk": 10,
         "fields": {
             "password": "pbkdf2_sha256$180000$7o6D9YJhaqer$6rfvJsJ4RSpfuDloSqiH90KDKFmZqWpTYhaBM5A2ynA=",
             "last_login": "2020-04-14T16:17:26.762Z",
@@ -186,127 +210,7 @@
     },
     {
         "model": "users.user",
-        "pk": 10,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$ifJF7xPdfv0R$gRKlWa25uPx++OnYMF6k7+jAsjeai1g0EcDjjYNlDYQ=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Isabelle",
-            "last_name": "Leclerc",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:33:45Z",
-            "email": "z.hadji01+milo@gmail.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
         "pk": 11,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$0N99LqyobuEu$7zmZMo2JaMjbaBHPgXs1VXW9ByDnHP/YUd1+IQHfRG4=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Anthony",
-            "last_name": "DUPONT",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:45:27Z",
-            "email": "z.hadji01+milo1@gmail.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 12,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$DsTSWicSwF9H$H0ozi37mW+ziTwyXSsbB2AlQS99u6z7BPT0snXxmJxI=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Hélène",
-            "last_name": "SUAREZ",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:46:24Z",
-            "email": "z.hadji01+milo2@gmail.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 13,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$j7FWQHXkqK0C$+eTASXEZvgn/j0ipE/Xg8F9qjPidyvchSRba95TNoPA=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Selim",
-            "last_name": "ERRADI",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:47:10Z",
-            "email": "z.hadji01+milo3@gmail.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 14,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$Wex0xNID5KGD$b48usgbJZwkJGgU+xt0nvCyvwNKd3EfsQvmurr4QMF4=",
-            "last_login": "2020-12-01T12:45:51.054Z",
-            "is_superuser": false,
-            "first_name": "Samantha",
-            "last_name": "BOYER",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:48:05Z",
-            "email": "z.hadji01+milo4@gmail.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 15,
-        "fields": {
-            "password": "pbkdf2_sha256$216000$N6NO0Ju0LQ53$gxedd3JFyQcY7FQXrH9dbxJ1VbmUdLopOfbtt3nZtqY=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Adrien",
-            "last_name": "MONK",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2020-12-01T10:48:55Z",
-            "email": "adrien.monk@faux123.com",
-            "phone": "0808080808",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 16,
         "fields": {
             "password": "pbkdf2_sha256$216000$gjjv3KvwjU6Z$1nqe1GanxWvTw6ioPjRy8q+N+YMWN1LHzwkoo2OE8m4=",
             "last_login": null,
@@ -326,107 +230,7 @@
     },
     {
         "model": "users.user",
-        "pk": 17,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$mI2e7IGesO22AiGL4dOiVc$spm6uOzTaFDWyruRqHIVdYSZomLhogmbWuud5gvqZjo=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Bob",
-            "last_name": "Le Bricoleur",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2021-05-11T15:58:10.924Z",
-            "email": "bob-le-bricoleur@tycrois.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 18,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$AQNPbQaiGhZnpCjJSmR3zh$d3sM38VXHqb9QLhDJ2GtwDr/t6eaphLIPryLB9/j7ag=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "John \"Hannibal\"",
-            "last_name": "Smith",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2021-05-12T09:10:11Z",
-            "email": "hannibal.smith@a-team.fake.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 19,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$144veFnFeHskmYeaA7Oq6l$3VH03K/USvl4GaS++bVWN4OammHM/zrdPg+2u2Doz6w=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Bosco \"BA\"",
-            "last_name": "Baracus",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2021-05-12T09:18:49Z",
-            "email": "bosco.ba.baracus@a-team.fake.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 20,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$CrYJG51hP67fWhSc8il7zj$N6V+TbAGrPm5boIRfIDFXAbUsruOiSfeaOz5/g2Hisc=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "Templeton \"Faceman\"",
-            "last_name": "Peck",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2021-05-12T09:23:28Z",
-            "email": "templeton.faceman.peck@a-team.fake.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 21,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$2n9NPKFZvk9zn1egx1GotI$OA/nscRAk37xtOPuT2sg7qcCjkOFZRc+/t/oBHvI6Es=",
-            "last_login": null,
-            "is_superuser": false,
-            "first_name": "\"Howling Mad\"",
-            "last_name": "Murdock",
-            "is_staff": false,
-            "is_active": true,
-            "date_joined": "2021-05-12T09:38:59Z",
-            "email": "howling.mad.murdock@a-team.fake.com",
-            "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 24,
+        "pk": 12,
         "fields": {
             "password": "pbkdf2_sha256$260000$6zGXZtrOltM7ZGRXR14Oic$I9pQl83eftdBRS11PB7f/w8Le7H5kgtst4tAXnGfSck=",
             "last_login": "2021-07-13T15:35:10.286Z",
@@ -438,28 +242,6 @@
             "date_joined": "2021-07-13T15:33:29Z",
             "email": "test+dreets@inclusion.beta.gouv.fr",
             "phone": "",
-            "groups": [],
-            "user_permissions": [],
-            "created_at": "2019-12-05T14:37:56.609Z",
-            "updated_at": "2020-12-18T10:38:52.329Z"
-        }
-    },
-    {
-        "model": "users.user",
-        "pk": 3,
-        "fields": {
-            "password": "pbkdf2_sha256$260000$7SMYXy9OTGSwYOs5myl9bP$GVwB+ayk8qAxkWOmP62sO+qGm1qyzivafdADRDip2/w=",
-            "last_login": "2021-07-13T09:46:55.391Z",
-            "is_superuser": false,
-            "first_name": "Partenaire",
-            "last_name": "Bob",
-            "is_staff": false,
-            "is_active": true,
-            "kind": "PARTNER",
-            "date_joined": "2019-09-30T13:30:45.639Z",
-            "email": "partenaire_avec_reseau@test.com",
-            "phone": "",
-            "partner_network": 1,
             "groups": [],
             "user_permissions": [],
             "created_at": "2019-12-05T14:37:56.609Z",

--- a/lemarche/fixtures/django/03_siae_users.json
+++ b/lemarche/fixtures/django/03_siae_users.json
@@ -3,7 +3,7 @@
         "model": "siaes.siaeuser",
         "pk": 1,
         "fields": {
-            "user": 4,
+            "user": 5,
             "siae": 2653,
             "created_at": "2020-12-01T10:08:03.596Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -13,7 +13,7 @@
         "model": "siaes.siaeuser",
         "pk": 2,
         "fields": {
-            "user": 5,
+            "user": 6,
             "siae": 2653,
             "created_at": "2020-12-01T10:08:03.596Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -23,7 +23,7 @@
         "model": "siaes.siaeuser",
         "pk": 3,
         "fields": {
-            "user": 5,
+            "user": 6,
             "siae": 3850,
             "created_at": "2020-12-01T10:08:03.599Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -33,7 +33,7 @@
         "model": "siaes.siaeuser",
         "pk": 4,
         "fields": {
-            "user": 5,
+            "user": 6,
             "siae": 3853,
             "created_at": "2020-12-18T13:08:08.053Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -43,7 +43,7 @@
         "model": "siaes.siaeuser",
         "pk": 5,
         "fields": {
-            "user": 5,
+            "user": 6,
             "siae": 3854,
             "created_at": "2020-12-18T13:12:02.928Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -53,7 +53,7 @@
         "model": "siaes.siaeuser",
         "pk": 6,
         "fields": {
-            "user": 6,
+            "user": 7,
             "siae": 3850,
             "created_at": "2020-12-01T10:08:03.598Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -63,7 +63,7 @@
         "model": "siaes.siaeuser",
         "pk": 7,
         "fields": {
-            "user": 9,
+            "user": 10,
             "siae": 3851,
             "created_at": "2020-12-01T10:08:03.600Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -73,7 +73,7 @@
         "model": "siaes.siaeuser",
         "pk": 8,
         "fields": {
-            "user": 6,
+            "user": 7,
             "siae": 3852,
             "created_at": "2020-12-01T10:30:23.026Z",
             "updated_at": "2020-12-01T10:31:37.930Z"
@@ -83,7 +83,7 @@
         "model": "siaes.siaeuser",
         "pk": 9,
         "fields": {
-            "user": 6,
+            "user": 7,
             "siae": 3853,
             "created_at": "2020-12-18T13:08:08.053Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -93,7 +93,7 @@
         "model": "siaes.siaeuser",
         "pk": 10,
         "fields": {
-            "user": 6,
+            "user": 7,
             "siae": 3854,
             "created_at": "2020-12-18T13:12:02.928Z",
             "updated_at": "2020-12-31T13:08:08.053Z"
@@ -103,7 +103,7 @@
         "model": "siaes.siaeuser",
         "pk": 11,
         "fields": {
-            "user": 16,
+            "user": 11,
             "siae": 3855,
             "created_at": "2021-02-22T15:06:22.049Z",
             "updated_at": "2020-12-31T13:08:08.053Z"

--- a/lemarche/templates/tenders/detail_card.html
+++ b/lemarche/templates/tenders/detail_card.html
@@ -26,10 +26,10 @@
                 <i class="ri-map-pin-2-line"></i>
                 {{ tender.location_display|safe }}
             </div>
-            {% if tender.presta_type %}
+            {% if tender.author.company_name %}
                 <div class="col" title="Type de prestation">
-                    <i class="ri-briefcase-4-line"></i>
-                    {% array_choices_display tender 'presta_type' %}
+                    <i class="ri-building-4-line"></i>
+                    {{ tender.author.company_name }}
                 </div>
             {% endif %}
         </div>

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -355,7 +355,7 @@ class TenderDetailViewTest(TestCase):
         cls.siae_user_1 = UserFactory(kind=User.KIND_SIAE, siaes=[cls.siae_1])
         cls.siae_user_2 = UserFactory(kind=User.KIND_SIAE, siaes=[cls.siae_2])
         cls.siae_user_3 = UserFactory(kind=User.KIND_SIAE)
-        cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER)
+        cls.user_buyer_1 = UserFactory(kind=User.KIND_BUYER, company_name="Entreprise Buyer")
         cls.user_buyer_2 = UserFactory(kind=User.KIND_BUYER)
         cls.user_partner = UserFactory(kind=User.KIND_PARTNER)
         cls.user_admin = UserFactory(kind=User.KIND_ADMIN)
@@ -411,6 +411,13 @@ class TenderDetailViewTest(TestCase):
                 response = self.client.get(url)
                 self.assertEqual(response.status_code, 302)  # redirect
                 self.assertEqual(response.url, "/")
+
+    def test_tender_basic_fields_display(self):
+        url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # tender.author.company_name
+        self.assertContains(response, "Entreprise Buyer")
 
     def test_tender_constraints_display(self):
         # tender with constraints: section should be visible


### PR DESCRIPTION
### Quoi ?

Sur la page "détail" d'un besoin, indiquer (si disponible) le nom de l'entreprise de l'acheteur.
Cela remplace la section "type de prestation" (qui n'était en fait pas rempli par les bizdev)

### Capture d'écran

|||
|---|---|
|Avant|![image](https://user-images.githubusercontent.com/7147385/234545375-15b312be-3d08-4624-9083-31cad8f6f890.png)|
|Après|![image](https://user-images.githubusercontent.com/7147385/234545249-1cd04355-36ef-48a8-997e-dfe041fb1585.png)|