### PR TITLE
Admin : améliorer le rendu des CheckboxSelectMultiple

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib import admin
 from django.contrib.gis import admin as gis_admin
 from django.db.models import Count
@@ -18,7 +19,7 @@ from lemarche.siaes.models import (
 )
 from lemarche.users.models import User
 from lemarche.utils.admin.actions import export_as_xls
-from lemarche.utils.fields import pretty_print_readonly_jsonfield
+from lemarche.utils.fields import ChoiceArrayField, pretty_print_readonly_jsonfield
 
 
 class IsLiveFilter(admin.SimpleListFilter):
@@ -129,6 +130,9 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "created_at",
         "updated_at",
     ]
+    formfield_overrides = {
+        ChoiceArrayField: {"widget": forms.CheckboxSelectMultiple(attrs={"class": "custom-checkbox-select-multiple"})},
+    }
 
     # OSMGeoAdmin param for coords fields
     modifiable = False

--- a/lemarche/static/itou_marche/admin.css
+++ b/lemarche/static/itou_marche/admin.css
@@ -10,3 +10,10 @@
     margin-left: 1em;
     margin-bottom: 1.5em;
 }
+
+.custom-checkbox-select-multiple {
+    display: table-cell;
+}
+div.custom-checkbox-select-multiple > div > label {
+    width: 500px;  /* 160px default ; to avoid line breaks */
+}

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from ckeditor.widgets import CKEditorWidget
+from django import forms
 from django.contrib import admin
 from django.db import models
 from django.http import HttpResponseRedirect
@@ -14,7 +15,7 @@ from lemarche.perimeters.admin import PerimeterRegionFilter
 from lemarche.tenders import constants
 from lemarche.tenders.forms import TenderAdminForm
 from lemarche.tenders.models import PartnerShareTender, Tender
-from lemarche.utils.fields import pretty_print_readonly_jsonfield
+from lemarche.utils.fields import ChoiceArrayField, pretty_print_readonly_jsonfield
 from lemarche.www.tenders.tasks import (
     send_confirmation_published_email_to_author,
     send_tender_emails_to_partners,
@@ -128,7 +129,10 @@ class TenderAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
-    formfield_overrides = {models.TextField: {"widget": CKEditorWidget}}
+    formfield_overrides = {
+        models.TextField: {"widget": CKEditorWidget},
+        ChoiceArrayField: {"widget": forms.CheckboxSelectMultiple(attrs={"class": "custom-checkbox-select-multiple"})},
+    }
 
     fieldsets = (
         (


### PR DESCRIPTION
### Quoi ?

On a certains champs des modèles `Siae` et `Tender` qui utilisent `CheckboxSelectMultiple`.
Or coté admin le widget par défaut est `SelectMultiple`.
Utilisation de `CheckboxSelectMultiple` pour améliorer le rendu.

### Pourquoi ?

Améliorer l'UI des champs à choix multiples.

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://user-images.githubusercontent.com/7147385/234875521-55d7ebe8-a28a-432a-a9e0-f58c7874a5c3.png)|![image](https://user-images.githubusercontent.com/7147385/234875047-d9d3d3ae-53f2-4943-8fdb-f95975e4bdd0.png)|