### PR TITLE
Création d'un utilisateur dans l'appel d'api pour la création du dépôt de besoin 

### DIFF
--- a/lemarche/api/tenders/serializers.py
+++ b/lemarche/api/tenders/serializers.py
@@ -13,6 +13,7 @@ class TenderSerializer(serializers.ModelSerializer):
     location = serializers.SlugRelatedField(
         queryset=Perimeter.objects.all(), slug_field="slug", allow_null=True, required=False
     )
+    contact_company_name = serializers.CharField(required=False)
     extra_data = serializers.JSONField(required=False)
 
     class Meta:
@@ -40,6 +41,7 @@ class TenderSerializer(serializers.ModelSerializer):
             "contact_last_name",
             "contact_email",
             "contact_phone",
+            "contact_company_name",
             "response_kind",
             "deadline_date",
             # extra data

--- a/lemarche/api/tenders/tests.py
+++ b/lemarche/api/tenders/tests.py
@@ -7,6 +7,8 @@ from lemarche.tenders.models import Tender
 from lemarche.users.factories import UserFactory
 
 
+USER_CONTACT_EMAIL = "prenom.nom@example.com"
+
 TENDER_JSON = {
     "kind": "TENDER",
     "title": "Test",
@@ -24,8 +26,8 @@ TENDER_JSON = {
     "accept_cocontracting": True,
     "contact_first_name": "Prénom",
     "contact_last_name": "Nom",
-    "contact_email": "prenom.nom@example.com",
-    # "contact_phone": "string",
+    "contact_email": USER_CONTACT_EMAIL,
+    "contact_phone": "string",
     "response_kind": ["EMAIL"],
     "deadline_date": "2023-03-14",
 }
@@ -58,7 +60,7 @@ class TenderCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertIn("slug", response.data.keys())
         tender = Tender.objects.get(title="Test author")
-        self.assertEqual(tender.author, self.user_with_token)
+        self.assertEqual(tender.author.email, USER_CONTACT_EMAIL)
         self.assertEqual(tender.status, Tender.STATUS_PUBLISHED)
         self.assertEqual(tender.source, Tender.SOURCE_API)
         self.assertNotEqual(tender.import_raw_object, None)

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -5,7 +5,7 @@ from lemarche.api.tenders.serializers import TenderSerializer
 from lemarche.api.utils import BasicChoiceSerializer, check_user_token
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
-from lemarche.www.tenders.utils import create_user_from_anonymous_content
+from lemarche.www.tenders.utils import get_or_create_user_from_anonymous_content
 
 
 class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
@@ -24,7 +24,7 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         return super().create(request, args, kwargs)
 
     def perform_create(self, serializer: TenderSerializer):
-        user = create_user_from_anonymous_content(serializer.validated_data)
+        user = get_or_create_user_from_anonymous_content(serializer.validated_data)
         serializer.save(
             author=user,
             status=Tender.STATUS_PUBLISHED,

--- a/lemarche/api/tenders/views.py
+++ b/lemarche/api/tenders/views.py
@@ -5,6 +5,7 @@ from lemarche.api.tenders.serializers import TenderSerializer
 from lemarche.api.utils import BasicChoiceSerializer, check_user_token
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
+from lemarche.www.tenders.utils import create_user_from_anonymous_content
 
 
 class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
@@ -19,12 +20,13 @@ class TenderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     )
     def create(self, request, *args, **kwargs):
         token = request.GET.get("token", None)
-        self.user = check_user_token(token)
+        check_user_token(token)
         return super().create(request, args, kwargs)
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer: TenderSerializer):
+        user = create_user_from_anonymous_content(serializer.validated_data)
         serializer.save(
-            author=self.user,
+            author=user,
             status=Tender.STATUS_PUBLISHED,
             source=Tender.SOURCE_API,
             import_raw_object=self.request.data,

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -29,7 +29,7 @@ from lemarche.www.tenders.tasks import notify_admin_tender_created
 from lemarche.www.tenders.views import (
     TenderCreateMultiStepView,
     create_tender_from_dict,
-    create_user_from_anonymous_content,
+    get_or_create_user_from_anonymous_content,
 )
 
 
@@ -342,7 +342,7 @@ def csrf_failure(request, reason=""):  # noqa C901
                         tender_dict[key_cleaned] = list() if value[0] == "" else value
         # get user
         if not request.user.is_authenticated:
-            user = create_user_from_anonymous_content(tender_dict)
+            user = get_or_create_user_from_anonymous_content(tender_dict)
         else:
             user = request.user
         tender_dict["author"] = user

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -4,7 +4,7 @@ from lemarche.users.models import User
 from lemarche.www.auth.tasks import send_new_user_password_reset_link
 
 
-def create_user_from_anonymous_content(tender_dict: dict) -> User:
+def get_or_create_user_from_anonymous_content(tender_dict: dict) -> User:
     user, created = User.objects.get_or_create(
         email=tender_dict.get("contact_email"),
         defaults={

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+
+from lemarche.users.models import User
+from lemarche.www.auth.tasks import send_new_user_password_reset_link
+
+
+def create_user_from_anonymous_content(tender_dict: dict) -> User:
+    user, created = User.objects.get_or_create(
+        email=tender_dict.get("contact_email"),
+        defaults={
+            "first_name": tender_dict.get("contact_first_name"),
+            "last_name": tender_dict.get("contact_last_name"),
+            "phone": tender_dict.get("contact_phone"),
+            "company_name": tender_dict.pop("contact_company_name")
+            if tender_dict.get("contact_company_name")
+            else "Particulier",
+            "kind": User.KIND_BUYER,  # not necessarily true, could be a PARTNER
+            "source": User.SOURCE_TENDER_FORM,
+        },
+    )
+    if created and settings.BITOUBI_ENV == "prod":
+        send_new_user_password_reset_link(user)
+    return user

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -26,7 +26,7 @@ from lemarche.www.tenders.tasks import (  # , send_tender_emails_to_siaes
     notify_admin_tender_created,
     send_siae_interested_email_to_author,
 )
-from lemarche.www.tenders.utils import create_user_from_anonymous_content
+from lemarche.www.tenders.utils import get_or_create_user_from_anonymous_content
 
 
 TITLE_DETAIL_PAGE_SIAE = "Trouver de nouvelles opportunités"
@@ -166,7 +166,7 @@ class TenderCreateMultiStepView(SessionWizardView):
     def set_or_create_user(self, tender_dict: dict):
         user: User = None
         if not self.request.user.is_authenticated:
-            user = create_user_from_anonymous_content(tender_dict)
+            user = get_or_create_user_from_anonymous_content(tender_dict)
         else:
             user = self.request.user
             need_to_be_saved = False

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -15,6 +15,7 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.apis import api_hubspot
 from lemarche.utils.data import get_choice
+from lemarche.utils.mixins import TenderAuthorOrAdminRequiredIfNotValidatedMixin, TenderAuthorOrAdminRequiredMixin
 from lemarche.www.tenders.forms import (
     AddTenderStepConfirmationForm,
     AddTenderStepContactForm,

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -15,8 +15,6 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.apis import api_hubspot
 from lemarche.utils.data import get_choice
-from lemarche.utils.mixins import TenderAuthorOrAdminRequiredIfNotValidatedMixin, TenderAuthorOrAdminRequiredMixin
-from lemarche.www.auth.tasks import send_new_user_password_reset_link
 from lemarche.www.tenders.forms import (
     AddTenderStepConfirmationForm,
     AddTenderStepContactForm,
@@ -28,28 +26,12 @@ from lemarche.www.tenders.tasks import (  # , send_tender_emails_to_siaes
     notify_admin_tender_created,
     send_siae_interested_email_to_author,
 )
+from lemarche.www.tenders.utils import create_user_from_anonymous_content
 
 
 TITLE_DETAIL_PAGE_SIAE = "Trouver de nouvelles opportunités"
 TITLE_DETAIL_PAGE_OTHERS = "Mes besoins"
 TITLE_KIND_SOURCING_SIAE = "Consultation en vue d'un achat"
-
-
-def create_user_from_anonymous_content(tender_dict: dict) -> User:
-    user, created = User.objects.get_or_create(
-        email=tender_dict["contact_email"],
-        defaults={
-            "first_name": tender_dict["contact_first_name"],
-            "last_name": tender_dict["contact_last_name"],
-            "phone": tender_dict["contact_phone"],
-            "company_name": tender_dict["contact_company_name"],
-            "kind": User.KIND_BUYER,  # not necessarily true, could be a PARTNER
-            "source": User.SOURCE_TENDER_FORM,
-        },
-    )
-    if created and settings.BITOUBI_ENV == "prod":
-        send_new_user_password_reset_link(user)
-    return user
 
 
 def create_tender_from_dict(tender_dict: dict) -> Tender:


### PR DESCRIPTION
### Quoi ?

Création d'un utilisateur dans l'appel d'api pour la création du dépôt de besoin .

### Pourquoi ?

Pour être iso avec l'interface.
