### PR TITLE
Dépôt de besoin : cleanup du formulaire

### DIFF
--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -26,11 +26,8 @@ from lemarche.www.pages.forms import (
 )
 from lemarche.www.pages.tasks import send_contact_form_email, send_contact_form_receipt
 from lemarche.www.tenders.tasks import notify_admin_tender_created
-from lemarche.www.tenders.views import (
-    TenderCreateMultiStepView,
-    create_tender_from_dict,
-    get_or_create_user_from_anonymous_content,
-)
+from lemarche.www.tenders.utils import create_tender_from_dict, get_or_create_user_from_anonymous_content
+from lemarche.www.tenders.views import TenderCreateMultiStepView
 
 
 class HomeView(TemplateView):

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -3,13 +3,13 @@ from datetime import date
 from django import forms
 
 from lemarche.sectors.models import Sector
-from lemarche.tenders import constants, constants as tender_constants
+from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
 from lemarche.users.models import User
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
 
-class AddTenderStepGeneralForm(forms.ModelForm):
+class TenderCreateStepGeneralForm(forms.ModelForm):
     FORM_KIND_CHOICES = (
         (tender_constants.KIND_TENDER, "Appel d'offres"),
         (tender_constants.KIND_QUOTE, "Devis"),
@@ -66,7 +66,7 @@ class AddTenderStepGeneralForm(forms.ModelForm):
             self.add_error("sectors", msg_field_missing.format(Sector._meta.verbose_name_plural))
 
 
-class AddTenderStepDescriptionForm(forms.ModelForm):
+class TenderCreateStepDescriptionForm(forms.ModelForm):
     # fields from previous step
     kind = None
 
@@ -111,7 +111,7 @@ class AddTenderStepDescriptionForm(forms.ModelForm):
         self.fields["accept_cocontracting"].help_text = None
 
 
-class AddTenderStepContactForm(forms.ModelForm):
+class TenderCreateStepContactForm(forms.ModelForm):
     # fields from previous step
     max_deadline_date = None
     external_link = None
@@ -210,31 +210,31 @@ class AddTenderStepContactForm(forms.ModelForm):
             )
 
 
-class AddTenderStepSurveyForm(forms.ModelForm):
+class TenderCreateStepSurveyForm(forms.ModelForm):
     scale_marche_useless = forms.ChoiceField(
         label=Tender._meta.get_field("scale_marche_useless").help_text,
-        choices=constants.SURVEY_SCALE_QUESTION_CHOICES,
+        choices=tender_constants.SURVEY_SCALE_QUESTION_CHOICES,
         widget=forms.RadioSelect,
         required=True,
     )
 
     worked_with_inclusif_siae_this_kind_tender = forms.ChoiceField(
         label="Q°2. Avez-vous déjà travaillé avec des prestataires inclusifs sur ce type de prestation ?",
-        choices=constants.SURVEY_YES_NO_DONT_KNOW_CHOICES,
+        choices=tender_constants.SURVEY_YES_NO_DONT_KNOW_CHOICES,
         widget=forms.RadioSelect,
         required=True,
     )
     # hidden if worked_with_inclusif_siae_this_kind_tender is no or don't know
     is_encouraged_by_le_marche = forms.ChoiceField(
         label="Q°3. Est-ce la plateforme du Marché de l'inclusion qui vous a encouragé à consulter des prestataires inclusifs pour ce besoin ?",  # noqa
-        choices=constants.SURVEY_ENCOURAGED_BY_US_CHOICES,
+        choices=tender_constants.SURVEY_ENCOURAGED_BY_US_CHOICES,
         widget=forms.RadioSelect,
         required=False,
     )
 
     providers_out_of_insertion = forms.ChoiceField(
         label="Q°4. Comptez-vous consulter d'autres prestataires en dehors de l'Insertion et du Handicap ?",
-        choices=constants.SURVEY_SCALE_QUESTION_CHOICES,
+        choices=tender_constants.SURVEY_SCALE_QUESTION_CHOICES,
         widget=forms.RadioSelect,
         required=True,
     )
@@ -276,5 +276,5 @@ class AddTenderStepSurveyForm(forms.ModelForm):
                 return cleaned_data
 
 
-class AddTenderStepConfirmationForm(forms.Form):
+class TenderCreateStepConfirmationForm(forms.Form):
     pass

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -1,7 +1,22 @@
 from django.conf import settings
 
+from lemarche.tenders.models import Tender
 from lemarche.users.models import User
 from lemarche.www.auth.tasks import send_new_user_password_reset_link
+
+
+def create_tender_from_dict(tender_dict: dict) -> Tender:
+    tender_dict.pop("contact_company_name", None)
+    tender_dict.pop("id_location_name", None)
+    location = tender_dict.get("location")
+    sectors = tender_dict.pop("sectors", [])
+    tender = Tender(**tender_dict)
+    tender.save()
+    if location:
+        tender.perimeters.set([location])
+    if sectors:
+        tender.sectors.set(sectors)
+    return tender
 
 
 def get_or_create_user_from_anonymous_content(tender_dict: dict) -> User:
@@ -21,4 +36,22 @@ def get_or_create_user_from_anonymous_content(tender_dict: dict) -> User:
     )
     if created and settings.BITOUBI_ENV == "prod":
         send_new_user_password_reset_link(user)
+    return user
+
+
+def get_or_create_user(request_user, tender_dict: dict):
+    user: User = None
+    if not request_user.is_authenticated:
+        user = get_or_create_user_from_anonymous_content(tender_dict)
+    else:
+        user = request_user
+        need_to_be_saved = False
+        if not user.phone:
+            user.phone = tender_dict.get("contact_phone")
+            need_to_be_saved = True
+        if not user.company_name:
+            user.company_name = tender_dict.get("contact_company_name")
+            need_to_be_saved = True
+        if need_to_be_saved:
+            user.save()
     return user


### PR DESCRIPTION
Suite de #742

### Quoi ?

Léger cleanup / refactoring du formulaire de dépôt de besoin, avant l'ajout du nouveau champ "questions"
- bougé `create_tender_from_dict()` dans `tenders/utils.py`
- renommé `set_or_create_user` en `get_or_create_user` + bougé dans `tenders/utils.py`
- renommé `AddTenderStepGeneralForm` en `TenderCreateStepGeneralForm` (idem pour les autres steps)