### PR TITLE
Dépôt de besoin : formulaire : nouvelle étape pour poser des questions

### DIFF
--- a/lemarche/templates/tenders/create_step_questions.html
+++ b/lemarche/templates/tenders/create_step_questions.html
@@ -1,8 +1,8 @@
 {% extends "tenders/create_base.html" %}
 {% load bootstrap4 static %}
 
-{% block step_title %}Questions au client{% endblock %}
-{% block step_title_again %}Questions au client{% endblock %}
+{% block step_title %}Questions à poser aux prestataires ciblés{% endblock %}
+{% block step_title_again %}Questions à poser aux prestataires ciblés{% endblock %}
 {% block step_subtitle %}{% endblock %}
 
 {% block content_form %}
@@ -18,7 +18,7 @@
 
         <div id="tender-question-formset-empty-form" class="d-none">{% bootstrap_form form.empty_form %}</div>
         <button id="tender-question-formset-add-more" class="btn btn-outline-primary btn-sm btn-ico float-right" type="button">
-            <span>Ajouter une nouvelle question</span>
+            <span>Ajouter une autre question</span>
             <i class="ri-add-fill ri-lg"></i>
         </button>
     </div>

--- a/lemarche/templates/tenders/create_step_questions.html
+++ b/lemarche/templates/tenders/create_step_questions.html
@@ -1,0 +1,56 @@
+{% extends "tenders/create_base.html" %}
+{% load bootstrap4 static %}
+
+{% block step_title %}Questions au client{% endblock %}
+{% block step_title_again %}Questions au client{% endblock %}
+{% block step_subtitle %}{% endblock %}
+
+{% block content_form %}
+{% csrf_token %}
+<div class="row">
+    <div class="col-12 col-lg-7">
+        {% bootstrap_formset_errors form %}
+        <!-- {% if form.errors %}
+            <div class="alert alert-danger" role="alert">{{ form.errors }}</div>
+        {% endif %} -->
+
+        {% bootstrap_formset form %}
+
+        <div id="tender-question-formset-empty-form" class="d-none">{% bootstrap_form form.empty_form %}</div>
+        <button id="tender-question-formset-add-more" class="btn btn-outline-primary btn-sm btn-ico float-right" type="button">
+            <span>Ajouter une nouvelle question</span>
+            <i class="ri-add-fill ri-lg"></i>
+        </button>
+    </div>
+    <div class="col-12 col-lg-5">
+    </div>
+</div>
+
+<br />
+{% endblock content_form %}
+
+{% block extra_js %}
+<script type="text/javascript">
+/**
+ * Add formset items dynamically
+ */
+const prefixRegex = new RegExp('__prefix__', 'g');
+
+// questions formset
+const totalTenderQuestionFormset = document.getElementById('id_questions-TOTAL_FORMS');
+const tenderQuestionFormsetEmptyForm = document.getElementById('tender-question-formset-empty-form');
+const tenderQuestionFormsetAddMoreButton = document.getElementById('tender-question-formset-add-more');
+
+tenderQuestionFormsetAddMoreButton.addEventListener('click', function(e) {
+    if (e) { e.preventDefault(); }
+    // add new form
+    const copyTenderQuestionFormsetEmptyForm = tenderQuestionFormsetEmptyForm.cloneNode(true);
+    copyTenderQuestionFormsetEmptyForm.innerHTML = copyTenderQuestionFormsetEmptyForm.innerHTML.replace(prefixRegex, totalTenderQuestionFormset.value);
+    copyTenderQuestionFormsetEmptyForm.childNodes.forEach(node => {
+        tenderQuestionFormsetEmptyForm.parentNode.insertBefore(node, tenderQuestionFormsetEmptyForm);
+    });
+    // update total forms count
+    totalTenderQuestionFormset.setAttribute('value', parseInt(totalTenderQuestionFormset.getAttribute('value'), 10) + 1);
+});
+</script>
+{% endblock %}

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -1,10 +1,11 @@
 from datetime import date
 
 from django import forms
+from django.forms.models import inlineformset_factory
 
 from lemarche.sectors.models import Sector
 from lemarche.tenders import constants as tender_constants
-from lemarche.tenders.models import Tender
+from lemarche.tenders.models import Tender, TenderQuestion
 from lemarche.users.models import User
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
 
@@ -64,6 +65,21 @@ class TenderCreateStepGeneralForm(forms.ModelForm):
             self.add_error("location", msg_field_missing.format("Lieu d'intervention"))
         if "sectors" in self.errors:
             self.add_error("sectors", msg_field_missing.format(Sector._meta.verbose_name_plural))
+
+
+class TenderQuestionForm(forms.ModelForm):
+    class Meta:
+        model = TenderQuestion
+        fields = ["text"]  # TODO: make text mandatory
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["text"].widget.attrs.update({"rows": 2})
+
+
+TenderQuestionFormSet = inlineformset_factory(
+    Tender, TenderQuestion, form=TenderQuestionForm, extra=1, can_delete=True
+)
 
 
 class TenderCreateStepDescriptionForm(forms.ModelForm):

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -74,7 +74,7 @@ class TenderQuestionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["text"].widget.attrs.update({"rows": 2})
+        self.fields["text"].widget.attrs.update({"rows": 1})
 
 
 TenderQuestionFormSet = inlineformset_factory(

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -25,6 +25,7 @@ from lemarche.www.tenders.forms import (
     TenderCreateStepDescriptionForm,
     TenderCreateStepGeneralForm,
     TenderCreateStepSurveyForm,
+    TenderQuestionFormSet,
 )
 from lemarche.www.tenders.tasks import (  # , send_tender_emails_to_siaes
     notify_admin_tender_created,
@@ -59,6 +60,7 @@ class TenderCreateMultiStepView(SessionWizardView):
     """
     STEP_GENERAL = "general"
     STEP_DESCRIPTION = "description"
+    STEP_QUESTIONS = "questions"
     STEP_CONTACT = "contact"
     STEP_SURVEY = "survey"
     STEP_CONFIRMATION = "confirmation"
@@ -66,6 +68,7 @@ class TenderCreateMultiStepView(SessionWizardView):
     TEMPLATES = {
         STEP_GENERAL: "tenders/create_step_general.html",
         STEP_DESCRIPTION: "tenders/create_step_description.html",
+        STEP_QUESTIONS: "tenders/create_step_questions.html",
         STEP_CONTACT: "tenders/create_step_contact.html",
         STEP_SURVEY: "tenders/create_step_survey.html",
         STEP_CONFIRMATION: "tenders/create_step_confirmation.html",
@@ -74,6 +77,7 @@ class TenderCreateMultiStepView(SessionWizardView):
     form_list = [
         (STEP_GENERAL, TenderCreateStepGeneralForm),
         (STEP_DESCRIPTION, TenderCreateStepDescriptionForm),
+        (STEP_QUESTIONS, TenderQuestionFormSet),
         (STEP_CONTACT, TenderCreateStepContactForm),
         (STEP_SURVEY, TenderCreateStepSurveyForm),
         (STEP_CONFIRMATION, TenderCreateStepConfirmationForm),
@@ -125,6 +129,7 @@ class TenderCreateMultiStepView(SessionWizardView):
         if self.steps.current == self.STEP_CONFIRMATION:
             tender_dict = self.get_all_cleaned_data()
             tender_dict["sectors_list_string"] = ", ".join(tender_dict["sectors"].values_list("name", flat=True))
+            tender_dict["questions_list"] = [t["text"] for t in tender_dict["formset-questions"]]
             tender_dict["get_kind_display"] = get_choice(tender_constants.KIND_CHOICES, tender_dict["kind"])
             tender_dict["get_amount_display"] = get_choice(
                 tender_constants.AMOUNT_RANGE_CHOICES, tender_dict["amount"]

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -129,7 +129,7 @@ class TenderCreateMultiStepView(SessionWizardView):
         if self.steps.current == self.STEP_CONFIRMATION:
             tender_dict = self.get_all_cleaned_data()
             tender_dict["sectors_list_string"] = ", ".join(tender_dict["sectors"].values_list("name", flat=True))
-            tender_dict["questions_list"] = [t["text"] for t in tender_dict["formset-questions"]]
+            tender_dict["questions_list"] = [t.get("text", None) for t in tender_dict.get("formset-questions", [])]
             tender_dict["get_kind_display"] = get_choice(tender_constants.KIND_CHOICES, tender_dict["kind"])
             tender_dict["get_amount_display"] = get_choice(
                 tender_constants.AMOUNT_RANGE_CHOICES, tender_dict["amount"]


### PR DESCRIPTION
### Quoi ?

Suite de #742 & #749

On intègre `TenderQuestion` dans le formulaire de dépôt de besoin.
Pour l'instant dans une étape dédiée (step 3)