### PR TITLE
Dépôt de besoin : filtre sur les prestataires concernés & intéressés

### DIFF
--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -2,43 +2,43 @@
     <div class="card-body">
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid">
-                <div class="row">
+                {# <div class="row">
                     <div class="col-12">
-                        <span title="{{ tendersiae.created_at }}">{{ tendersiae.created_at|date }}</span>
+                        <span title="{{ siae.tendersiae_set.first.created_at }}">{{ siae.tendersiae_set.first.created_at|date }}</span>
                     </div>
-                </div>
+                </div> #}
                 <div class="row">
                     <div class="col-12">
-                        <h2 class="py-2">{{ tendersiae.siae.name_display }}</h2>
+                        <h2 class="py-2">{{ siae.name_display }}</h2>
                     </div>
                 </div>
                 <div class="row mb-2">
                     <div class="col-md-4">
                         <i class="ri-user-line"></i>
-                        <span>{{ tendersiae.siae.contact_short_name }}</span>
+                        <span>{{ siae.contact_short_name }}</span>
                     </div>
                     <div class="col-md-4">
                         <i class="ri-phone-line"></i>
-                        <a href="tel:{{ tendersiae.siae.contact_phone }}" id="tender_siae_company_phone" style="text-overflow:ellipsis">{{ tendersiae.siae.contact_phone }}</a>
+                        <a href="tel:{{ siae.contact_phone }}" id="tender_siae_company_phone" style="text-overflow:ellipsis">{{ siae.contact_phone }}</a>
                     </div>
                     <div class="col-md-4 has-ellipsis">
                         <i class="ri-at-line"></i>
-                        <a href="mailto:{{ tendersiae.siae.contact_email }}" id="tender_siae_company_email">{{ tendersiae.siae.contact_email }}</a>
+                        <a href="mailto:{{ siae.contact_email }}" id="tender_siae_company_email">{{ siae.contact_email }}</a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-md-6 has-ellipsis">
                         <i class="ri-window-2-line"></i>
-                        <a href="{{ tendersiae.siae.contact_website }}" id="tender_siae_company_website" target="_blank" rel="noopener">{{ tendersiae.siae.contact_website }}</a>
+                        <a href="{{ siae.contact_website }}" id="tender_siae_company_website" target="_blank" rel="noopener">{{ siae.contact_website }}</a>
                     </div>
                     <div class="col-md-6 has-ellipsis">
                         <i class="ri-earth-line"></i>
-                        <a href="{{ tendersiae.siae.contact_social_website }}" id="tender_siae_company_social_website" target="_blank" rel="noopener">{{ tendersiae.siae.contact_social_website }}</a>
+                        <a href="{{ siae.contact_social_website }}" id="tender_siae_company_social_website" target="_blank" rel="noopener">{{ siae.contact_social_website }}</a>
                     </div>
                 </div>
             </div>
             <div class="col-md-4 text-center my-auto">
-                <a href="{% url 'siae:detail' tendersiae.siae.slug %}" class="btn btn-primary" target="_blank" rel="noopener">
+                <a href="{% url 'siae:detail' siae.slug %}" class="btn btn-primary" target="_blank" rel="noopener">
                     <span>Accéder à la fiche commerciale</span>
                 </a>
             </div>

--- a/lemarche/templates/siaes/_card_tender.html
+++ b/lemarche/templates/siaes/_card_tender.html
@@ -2,11 +2,11 @@
     <div class="card-body">
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid">
-                {# <div class="row">
+                <!-- <div class="row">
                     <div class="col-12">
                         <span title="{{ siae.tendersiae_set.first.created_at }}">{{ siae.tendersiae_set.first.created_at|date }}</span>
                     </div>
-                </div> #}
+                </div> -->
                 <div class="row">
                     <div class="col-12">
                         <h2 class="py-2">{{ siae.name_display }}</h2>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -33,13 +33,13 @@
                         <form method="GET" role="search" id="filter-search-form">
                             {% bootstrap_form_errors form type="all" %}
                             <div class="row align-items-start">
-                                <div class="col-12 col-md-6 col-lg-3">
+                                <!-- <div class="col-12 col-md-6 col-lg-3">
                                     <div class="form-group">
                                         <label for="id_perimeters">{{ form.perimeters.label }}</label>
                                         <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
                                         <div id="perimeters-selected" class="mt-2"></div>
                                     </div>
-                                </div>
+                                </div> -->
                                 <div class="col-12 col-md-6 col-lg-3">
                                     {% bootstrap_field form.kind %}
                                 </div>
@@ -67,14 +67,14 @@
                 {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
 
                 <li class="nav-item">
-                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}"
+                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}?{{ current_search_query }}"
                         class="nav-link{% if TENDER_SIAE_LIST_URL in request.get_full_path %} active{% endif %}"
                         hx-target="#tenderSiaeList" hx-swap="outerHTML">
                         Prestataires ciblés
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}"
+                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}?{{ current_search_query }}"
                         class="nav-link{% if TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL in request.get_full_path %} active{% endif %}"
                         hx-target="#tenderSiaeList" hx-swap="outerHTML">
                         Prestataires intéressés
@@ -92,10 +92,10 @@
                         <i class="ri-download-line ri-lg"></i>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right">
-                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&{{ current_search_query }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
                             Télécharger la liste (.xls)
                         </a>
-                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&{{ current_search_query }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
                             Télécharger la liste (.csv)
                         </a>
                     </div>
@@ -114,9 +114,4 @@
         {% endblock %}
     </div>
 </section>
-{% endblock %}
-
-{% block extra_js %}
-{{ current_perimeters|json_script:"current-perimeters" }}
-<script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 {% endblock %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -33,13 +33,6 @@
                         <form method="GET" role="search" id="filter-search-form">
                             {% bootstrap_form_errors form type="all" %}
                             <div class="row align-items-start">
-                                <!-- <div class="col-12 col-md-6 col-lg-3">
-                                    <div class="form-group">
-                                        <label for="id_perimeters">{{ form.perimeters.label }}</label>
-                                        <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
-                                        <div id="perimeters-selected" class="mt-2"></div>
-                                    </div>
-                                </div> -->
                                 <div class="col-12 col-md-6 col-lg-3">
                                     {% bootstrap_field form.kind %}
                                 </div>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -25,57 +25,98 @@
 
 {% block content %}
 <section class="pt-4 pb-6">
-    {% block htmx %}
-    <div class="container" id="tenderSiaeList">
-        <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
-            {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
-            {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
-
-            <li class="nav-item">
-                <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}"
-                    class="nav-link{% if request.get_full_path == TENDER_SIAE_LIST_URL %} active{% endif %}"
-                    hx-target="#tenderSiaeList" hx-swap="outerHTML">
-                    Prestataires ciblés
-                </a>
-            </li>
-            <li class="nav-item">
-                <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}"
-                    class="nav-link{% if request.get_full_path == TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %} active{% endif %}"
-                    hx-target="#tenderSiaeList" hx-swap="outerHTML">
-                    Prestataires intéressés
-                </a>
-            </li>
-        </ul>
-
+    <div class="container">
         <div class="row">
-            <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">{{ siaes.count }} prestataire{{ siaes.count|pluralize }}</h1>
-            </div>
-            <div class="col-12 col-lg-4">
-                <button type="button" class="btn btn-ico white-space-nowrap text-decoration-none btn-link text-important px-0 float-right {% if tendersiaes.count == 0 %}disabled{% endif %}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="text-decoration-none ml-0">Télécharger la liste</span>
-                    <i class="ri-download-line ri-lg"></i>
-                </button>
-                <div class="dropdown-menu dropdown-menu-right">
-                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
-                        Télécharger la liste (.xls)
-                    </a>
-                    <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
-                        Télécharger la liste (.csv)
-                    </a>
+            <div class="col-12">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <form method="GET" role="search" id="filter-search-form">
+                            {% bootstrap_form_errors form type="all" %}
+                            <div class="row align-items-start">
+                                <div class="col-12 col-md-6 col-lg-3">
+                                    <div class="form-group">
+                                        <label for="id_perimeters">{{ form.perimeters.label }}</label>
+                                        <div id="dir_form_perimeters" data-input-name="{{ form.perimeters.name }}"></div>
+                                        <div id="perimeters-selected" class="mt-2"></div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-lg-3">
+                                    {% bootstrap_field form.kind %}
+                                </div>
+                                <div class="col-12 col-md-6 col-lg-3">
+                                    {% bootstrap_field form.territory %}
+                                </div>
+                                <div class="col-12 col-md-6 col-lg-3">
+                                    <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
+                                    <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
+                                        <span>Filtrer</span>
+                                        <i class="ri-search-line ri-lg"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-12">
-                {% for siae in siaes %}
-                    {% include "siaes/_card_tender.html" with siae=siae %}
-                {% endfor %}
-                {% include "includes/_pagination.html" %}
+        {% block htmx %}
+        <div id="tenderSiaeList">
+            <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
+                {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
+                {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
+
+                <li class="nav-item">
+                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}"
+                        class="nav-link{% if TENDER_SIAE_LIST_URL in request.get_full_path %} active{% endif %}"
+                        hx-target="#tenderSiaeList" hx-swap="outerHTML">
+                        Prestataires ciblés
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}"
+                        class="nav-link{% if TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL in request.get_full_path %} active{% endif %}"
+                        hx-target="#tenderSiaeList" hx-swap="outerHTML">
+                        Prestataires intéressés
+                    </a>
+                </li>
+            </ul>
+
+            <div class="row">
+                <div class="col-12 col-lg-8">
+                    <h1 class="mb-3 mb-lg-5">{{ siaes.count }} prestataire{{ siaes.count|pluralize }}</h1>
+                </div>
+                <div class="col-12 col-lg-4">
+                    <button type="button" class="btn btn-ico white-space-nowrap text-decoration-none btn-link text-important px-0 float-right {% if tendersiaes.count == 0 %}disabled{% endif %}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="text-decoration-none ml-0">Télécharger la liste</span>
+                        <i class="ri-download-line ri-lg"></i>
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right">
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=xls" id="tender-siae-interested-export-xls" class="dropdown-item">
+                            Télécharger la liste (.xls)
+                        </a>
+                        <a href="{% url 'siae:search_results_download' %}?tender={{ tender.slug }}&tender_status={{ status|default:"" }}&format=csv" id="tender-siae-interested-export-csv" class="dropdown-item">
+                            Télécharger la liste (.csv)
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-12">
+                    {% for siae in siaes %}
+                        {% include "siaes/_card_tender.html" with siae=siae %}
+                    {% endfor %}
+                    {% include "includes/_pagination.html" %}
+                </div>
             </div>
         </div>
+        {% endblock %}
     </div>
-    {% endblock %}
 </section>
+{% endblock %}
+
+{% block extra_js %}
+{{ current_perimeters|json_script:"current-perimeters" }}
+<script type="text/javascript" src="{% static 'js/perimeters_autocomplete_fields.js' %}"></script>
 {% endblock %}

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -49,7 +49,7 @@
 
         <div class="row">
             <div class="col-12 col-lg-8">
-                <h1 class="mb-3 mb-lg-5">{{ tendersiaes.count }} prestataire{{ tendersiaes.count|pluralize }}</h1>
+                <h1 class="mb-3 mb-lg-5">{{ siaes.count }} prestataire{{ siaes.count|pluralize }}</h1>
             </div>
             <div class="col-12 col-lg-4">
                 <button type="button" class="btn btn-ico white-space-nowrap text-decoration-none btn-link text-important px-0 float-right {% if tendersiaes.count == 0 %}disabled{% endif %}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -69,8 +69,8 @@
 
         <div class="row">
             <div class="col-12">
-                {% for tendersiae in tendersiaes %}
-                    {% include "siaes/_card_tender.html" with siae=tendersiae.siae %}
+                {% for siae in siaes %}
+                    {% include "siaes/_card_tender.html" with siae=siae %}
                 {% endfor %}
                 {% include "includes/_pagination.html" %}
             </div>

--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -53,7 +53,7 @@ DEFAULT_PAYLOAD = {
 # @task()
 def track(page: str = "", action: str = "load", meta: dict = {}):  # noqa B006
     # Don't log in dev
-    if settings.BITOUBI_ENV not in ("test"):
+    if settings.BITOUBI_ENV not in ("dev", "test"):
         date_created = timezone.now()
         user_id = int(meta.get("user_id")) if meta.get("user_id", None) else None
         user_kind = meta.get("user_type") if meta.get("user_type", "") else ""

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -131,8 +131,10 @@ class ProfileNetworkSiaeListView(NetworkMemberRequiredMixin, FormMixin, ListView
 
     def get_queryset(self):
         qs = super().get_queryset()
+        # first get the network's siaes
         self.network = Network.objects.get(slug=self.kwargs.get("slug"))
         qs = qs.filter(networks__in=[self.network]).with_tender_stats().annotate_with_brand_or_name(with_order_by=True)
+        # then filter with the form
         self.filter_form = NetworkSiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         return qs

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -330,7 +330,7 @@ class TenderSiaeFilterForm(forms.Form):
         required=False,
     )
 
-    def filter_queryset(self, qs=None):
+    def filter_queryset(self, qs=None):  # noqa C901
         if not qs:
             qs = Siae.objects.search_query_set()
 

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -311,14 +311,14 @@ class NetworkSiaeFilterForm(forms.Form):
 
 
 class TenderSiaeFilterForm(forms.Form):
-    # The hidden `perimeters` field is populated by the JS autocomplete library, see `perimeters_autocomplete_field.js`
-    perimeters = forms.ModelMultipleChoiceField(
-        label=Perimeter._meta.verbose_name_plural,
-        queryset=Perimeter.objects.all(),
-        to_field_name="slug",
-        required=False,
-        # widget=forms.HiddenInput()
-    )
+    # # The hidden `perimeters` field is populated by the JS autocomplete library, see `perimeters_autocomplete_field.js`  # noqa
+    # perimeters = forms.ModelMultipleChoiceField(
+    #     label="Localisation",
+    #     queryset=Perimeter.objects.all(),
+    #     to_field_name="slug",
+    #     required=False,
+    #     # widget=forms.HiddenInput()
+    # )
     kind = forms.MultipleChoiceField(
         label=Siae._meta.get_field("kind").verbose_name,
         choices=FORM_KIND_CHOICES_GROUPED,
@@ -337,9 +337,9 @@ class TenderSiaeFilterForm(forms.Form):
         if not hasattr(self, "cleaned_data"):
             self.full_clean()
 
-        perimeters = self.cleaned_data.get("perimeters", None)
-        if perimeters:
-            qs = qs.in_perimeters_area(perimeters)
+        # perimeters = self.cleaned_data.get("perimeters", None)
+        # if perimeters:
+        #     qs = qs.address_in_perimeter_list(perimeters)
 
         kinds = self.cleaned_data.get("kind", None)
         if kinds:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -311,14 +311,6 @@ class NetworkSiaeFilterForm(forms.Form):
 
 
 class TenderSiaeFilterForm(forms.Form):
-    # # The hidden `perimeters` field is populated by the JS autocomplete library, see `perimeters_autocomplete_field.js`  # noqa
-    # perimeters = forms.ModelMultipleChoiceField(
-    #     label="Localisation",
-    #     queryset=Perimeter.objects.all(),
-    #     to_field_name="slug",
-    #     required=False,
-    #     # widget=forms.HiddenInput()
-    # )
     kind = forms.MultipleChoiceField(
         label=Siae._meta.get_field("kind").verbose_name,
         choices=FORM_KIND_CHOICES_GROUPED,
@@ -336,10 +328,6 @@ class TenderSiaeFilterForm(forms.Form):
 
         if not hasattr(self, "cleaned_data"):
             self.full_clean()
-
-        # perimeters = self.cleaned_data.get("perimeters", None)
-        # if perimeters:
-        #     qs = qs.address_in_perimeter_list(perimeters)
 
         kinds = self.cleaned_data.get("kind", None)
         if kinds:

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -874,7 +874,7 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["tendersiaes"]), 3)  # email_send_date
+        self.assertEqual(len(response.context["siaes"]), 3)  # email_send_date
         # forbidden
         for user in [self.user_buyer_2, self.user_partner, self.siae_user_1, self.siae_user_2]:
             self.client.force_login(user)
@@ -889,7 +889,7 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["tendersiaes"]), 3)  # email_send_date
+        self.assertEqual(len(response.context["siaes"]), 3)  # email_send_date
         self.assertIsNotNone(Tender.objects.get(id=self.tender_1.id).siae_list_last_seen_date)
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
@@ -900,5 +900,5 @@ class TenderSiaeListView(TestCase):
         url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug, "status": "INTERESTED"})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context["tendersiaes"]), 3)  # detail_contact_click_date
-        self.assertEqual(response.context["tendersiaes"][0].id, self.tendersiae_1_1.id)
+        self.assertEqual(len(response.context["siaes"]), 3)  # detail_contact_click_date
+        self.assertEqual(response.context["siaes"][0].id, self.tendersiae_1_1.id)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -928,4 +928,4 @@ class TenderSiaeListView(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["siaes"]), 3)  # detail_contact_click_date
-        self.assertEqual(response.context["siaes"][0].id, self.tendersiae_1_1.id)
+        self.assertEqual(response.context["siaes"][0].id, self.tendersiae_1_1.siae.id)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -368,14 +368,15 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
 
     def get_queryset(self):
         qs = super().get_queryset()
+        # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
-        # qs = qs.filter(tendersiae__tender=self.tender)
         if self.status:  # status == "INTERESTED"
             qs = qs.filter(Q(tendersiae__tender=self.tender) & Q(tendersiae__detail_contact_click_date__isnull=False))
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
         else:  # default
             qs = qs.filter(Q(tendersiae__tender=self.tender) & Q(tendersiae__email_send_date__isnull=False))
             qs = qs.order_by("-tendersiae__email_send_date")
+        # then filter with the form
         self.filter_form = TenderSiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         return qs
@@ -395,10 +396,5 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         context["status"] = self.status
         siae_search_form = self.filter_form if self.filter_form else TenderSiaeFilterForm(data=self.request.GET)
         context["form"] = siae_search_form
-        # if len(self.request.GET.keys()):
-        #     if siae_search_form.is_valid():
-        #         current_perimeters = siae_search_form.cleaned_data.get("perimeters")
-        #         if current_perimeters:
-        #             context["current_perimeters"] = list(current_perimeters.values("id", "slug", "name"))
         context["current_search_query"] = self.request.GET.urlencode()
         return context

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -395,9 +395,10 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         context["status"] = self.status
         siae_search_form = self.filter_form if self.filter_form else TenderSiaeFilterForm(data=self.request.GET)
         context["form"] = siae_search_form
-        if len(self.request.GET.keys()):
-            if siae_search_form.is_valid():
-                current_perimeters = siae_search_form.cleaned_data.get("perimeters")
-                if current_perimeters:
-                    context["current_perimeters"] = list(current_perimeters.values("id", "slug", "name"))
+        # if len(self.request.GET.keys()):
+        #     if siae_search_form.is_valid():
+        #         current_perimeters = siae_search_form.cleaned_data.get("perimeters")
+        #         if current_perimeters:
+        #             context["current_perimeters"] = list(current_perimeters.values("id", "slug", "name"))
+        context["current_search_query"] = self.request.GET.urlencode()
         return context


### PR DESCRIPTION
### Quoi ?

L'auteur d'un besoin peut déjà accéder à la liste des prestataires concernés & intéressés.
On ajoute ici une barre de filtre pour lui permettre de réduire sa cible.

Pour l'instant : filtre par "type de structure" & "territoire spécifique".

### Captures d'écran

![image](https://github.com/betagouv/itou-marche/assets/7147385/b80f53b7-c7a4-480f-9c2c-d9f2964951a9)

