### PR TITLE
Dépôt de besoin : afficher les questions dans la page détail d'un besoin

### DIFF
--- a/lemarche/fixtures/django/11_tender_questions.json
+++ b/lemarche/fixtures/django/11_tender_questions.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "tenders.tenderquestion",
+        "fields": {
+            "id": 1,
+            "tender": 1,
+            "text": "Avez-vous le label Qualibat ?",
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    },
+    {
+        "model": "tenders.tenderquestion",
+        "fields": {
+            "id": 2,
+            "tender": 1,
+            "text": "Etes-vous basés en Isère ?",
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    },
+    {
+        "model": "tenders.tenderquestion",
+        "fields": {
+            "id": 3,
+            "tender": 2,
+            "text": "Pouvez-vous travailler le dimanche ?",
+            "created_at": "2021-07-01T12:44:39Z",
+            "updated_at": "2021-07-01T12:44:39Z"
+        }
+    }
+]

--- a/lemarche/fixtures/tests.py
+++ b/lemarche/fixtures/tests.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from lemarche.networks.models import Network
 from lemarche.sectors.models import Sector, SectorGroup
 from lemarche.siaes.models import Siae, SiaeClientReference, SiaeGroup, SiaeLabel, SiaeOffer, SiaeUser
-from lemarche.tenders.models import Tender, TenderSiae
+from lemarche.tenders.models import Tender, TenderQuestion, TenderSiae
 from lemarche.users.models import User
 
 
@@ -23,6 +23,7 @@ class FixturesTest(TestCase):
         "lemarche/fixtures/django/09_siaelabels.json",
         "lemarche/fixtures/django/09_siaeoffers.json",
         "lemarche/fixtures/django/10_tenders.json",
+        "lemarche/fixtures/django/11_tender_questions.json",
         "lemarche/fixtures/django/11_tender_sectors.json",
         "lemarche/fixtures/django/11_tender_siaes.json",
         "lemarche/fixtures/django/20_cms.json",
@@ -33,15 +34,16 @@ class FixturesTest(TestCase):
         # management.call_command("loaddata", "lemarche/fixtures/django/01_siaes.json")
         # why not self.assertTrue(Siae.objects.all().count()) ?
         # returns an error: django.db.utils.InternalError: variable not found in subplan target list
-        self.assertTrue(len(Siae.objects.all()) > 0)
+        self.assertTrue(len(Network.objects.all()) > 0)
+        self.assertTrue(len(SectorGroup.objects.all()) > 0)
+        self.assertTrue(len(Sector.objects.all()) > 0)
         self.assertTrue(len(SiaeGroup.objects.all()) > 0)
+        self.assertTrue(len(Siae.objects.all()) > 0)
         self.assertTrue(len(User.objects.all()) > 0)
         self.assertTrue(len(SiaeUser.objects.all()) > 0)
-        self.assertTrue(len(Sector.objects.all()) > 0)
-        self.assertTrue(len(SectorGroup.objects.all()) > 0)
-        self.assertTrue(len(Network.objects.all()) > 0)
         self.assertTrue(len(SiaeClientReference.objects.all()) > 0)
         self.assertTrue(len(SiaeLabel.objects.all()) > 0)
         self.assertTrue(len(SiaeOffer.objects.all()) > 0)
         self.assertTrue(len(Tender.objects.all()) > 0)
+        self.assertTrue(len(TenderQuestion.objects.all()) > 0)
         self.assertTrue(len(TenderSiae.objects.all()) > 0)

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -48,6 +48,7 @@
             {% endif %}
         {% endif %}
 
+        <!-- tender description -->
         <hr class="my-5">
 
         <h2>
@@ -58,6 +59,25 @@
         </h2>
         <p>{{ tender.description|safe|linebreaks }}</p>
 
+        <!-- tender questions -->
+        {% if source_form or not source_form and tender.questions_list|length %}
+            <hr class="my-5">
+
+            <h2>
+                {% if source_form or tender.author == request.user %}
+                    Questions à poser aux prestataires ciblés
+                {% else %}
+                    Questions du client
+                {% endif %}
+            </h2>
+            <ul>
+                {% for question in tender.questions_list %}
+                    <li>{{ question }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        <!-- tender constraints -->
         {% if source_form or not source_form and tender.constraints %}
             <hr class="my-5">
 
@@ -65,6 +85,7 @@
             <p>{{ tender.constraints|default:"-"|safe|linebreaks }}</p>
         {% endif %}
 
+        <!-- tender amount -->
         {% if source_form or tender.author == request.user or tender.accept_share_amount %}
             <hr class="my-5">
 

--- a/lemarche/templates/tenders/create_step_general.html
+++ b/lemarche/templates/tenders/create_step_general.html
@@ -21,7 +21,6 @@
                 </p>
             </div>
         </div>
-
     </div>
 </div>
 <div class="row">

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -32,7 +32,7 @@ def get_perimeter_filter(siae):
 
 class TenderQuerySet(models.QuerySet):
     def prefetch_many_to_many(self):
-        return self.prefetch_related("sectors")  # "perimeters", "siaes"
+        return self.prefetch_related("sectors")  # "perimeters", "siaes", "questions"
 
     def select_foreign_keys(self):
         return self.select_related("location")
@@ -408,8 +408,11 @@ class Tender(models.Model):
     def contact_full_name(self):
         return f"{self.contact_first_name} {self.contact_last_name}"
 
+    def sectors_list(self):
+        return self.sectors.form_filter_queryset().values_list("name", flat=True)
+
     def sectors_list_string(self, display_max=5):
-        sectors_name_list = self.sectors.form_filter_queryset().values_list("name", flat=True)
+        sectors_name_list = self.sectors_list()
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]
             sectors_name_list.append("…")
@@ -418,9 +421,15 @@ class Tender(models.Model):
     def sectors_full_list_string(self):
         return self.sectors_list_string(display_max=None)
 
+    def perimeter_list(self):
+        return self.perimeters.values_list("name", flat=True)
+
     @cached_property
     def perimeters_list_string(self):
-        return ", ".join(self.perimeters.values_list("name", flat=True))
+        return ", ".join(self.perimeter_list())
+
+    def questions_list(self):
+        return self.questions.values_list("text", flat=True)
 
     @cached_property
     def location_display(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -405,34 +405,31 @@ class Tender(models.Model):
                 raise e
 
     @cached_property
-    def contact_full_name(self):
+    def contact_full_name(self) -> str:
         return f"{self.contact_first_name} {self.contact_last_name}"
 
     def sectors_list(self):
         return self.sectors.form_filter_queryset().values_list("name", flat=True)
 
-    def sectors_list_string(self, display_max=5):
+    def sectors_list_string(self, display_max=5) -> str:
         sectors_name_list = self.sectors_list()
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]
             sectors_name_list.append("…")
         return ", ".join(sectors_name_list)
 
-    def sectors_full_list_string(self):
+    def sectors_full_list_string(self) -> str:
         return self.sectors_list_string(display_max=None)
 
-    def perimeter_list(self):
+    def perimeters_list(self):
         return self.perimeters.values_list("name", flat=True)
 
     @cached_property
-    def perimeters_list_string(self):
-        return ", ".join(self.perimeter_list())
-
-    def questions_list(self):
-        return self.questions.values_list("text", flat=True)
+    def perimeters_list_string(self) -> str:
+        return ", ".join(self.perimeters_list())
 
     @cached_property
-    def location_display(self):
+    def location_display(self) -> str:
         if self.is_country_area:
             return "France entière"
         elif self.location:
@@ -441,14 +438,17 @@ class Tender(models.Model):
             # maintain legacy perimeters display
             return self.perimeters_list_string
 
+    def questions_list(self):
+        return self.questions.values_list("text", flat=True)
+
     @cached_property
-    def external_link_title(self):
+    def external_link_title(self) -> str:
         if self.kind == tender_constants.KIND_TENDER:
             return "Voir l'appel d'offres"
         return "Lien partagé"
 
     @property
-    def cta_card_title_text(self):
+    def cta_card_title_text(self) -> str:
         if self.kind == tender_constants.KIND_TENDER:
             return "Cet appel d'offres vous intéresse ?"
         elif self.kind == tender_constants.KIND_QUOTE:


### PR DESCRIPTION
### Quoi ?

Suite à #742

- afficher les questions dans la page détail des besoins
- nouvelle méthode `Tender.questions_list`
- ajout de tests, fixtures

### Captures d'écran

|Auteur|Prestataire / anonyme|
|---|---|
|![image](https://github.com/betagouv/itou-marche/assets/7147385/de818f62-149d-4f44-b9de-f26da5c2bbc7)|![Screenshot from 2023-05-11 23-28-58](https://github.com/betagouv/itou-marche/assets/7147385/6e83ddee-979a-4d41-93bc-fd1e8c41ca7e)|