### PR TITLE
Structures : alternative pour filtrer plus simplement par périmètre 

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -28,9 +28,19 @@ from lemarche.utils.data import round_by_base
 from lemarche.utils.fields import ChoiceArrayField
 
 
-def get_filter_city(perimeter, with_country=False):
+def get_region_filter(perimeter):
+    return Q(region=perimeter.name)
+
+
+def get_department_filter(perimeter):
+    return Q(department=perimeter.insee_code)
+
+
+def get_city_filter(perimeter, with_country=False):
     """
-    used in Siae in_perimeters_area() queryset
+    used in Siae geo_range_in_perimeter_list() queryset
+    - if the perimeter is a CITY, return all Siae with the city's post_code
+    - also return the Siae in the same department (if not GEO_RANGE_CUSTOM)
     """
     filters = Q(post_code__in=perimeter.post_codes) | (
         ~Q(geo_range=siae_constants.GEO_RANGE_CUSTOM) & Q(department=perimeter.department_code)
@@ -230,9 +240,9 @@ class SiaeQuerySet(models.QuerySet):
             )
 
     def in_city_area(self, perimeter):
-        return self.filter(get_filter_city(perimeter))
+        return self.filter(get_city_filter(perimeter))
 
-    def in_perimeters_area(self, perimeters: models.QuerySet, with_country=False):
+    def geo_range_in_perimeter_list(self, perimeters: models.QuerySet, with_country=False):
         """
         Method to filter the Siaes depending on the perimeter filter.
         Depending on the type of Perimeter that were chosen, different cases arise:
@@ -252,11 +262,11 @@ class SiaeQuerySet(models.QuerySet):
         for perimeter in perimeters:
             if perimeter.kind == Perimeter.KIND_CITY:
                 # https://stackoverflow.com/questions/20222457/django-building-a-queryset-with-q-objects
-                conditions |= get_filter_city(perimeter, with_country)
+                conditions |= get_city_filter(perimeter, with_country)
             if perimeter.kind == Perimeter.KIND_DEPARTMENT:
-                conditions |= Q(department=perimeter.insee_code)
+                conditions |= get_department_filter(perimeter)
             if perimeter.kind == Perimeter.KIND_REGION:
-                conditions |= Q(region=perimeter.name)
+                conditions |= get_region_filter(perimeter)
         return self.filter(conditions)
 
     def within(self, point, distance_km=0):
@@ -310,7 +320,7 @@ class SiaeQuerySet(models.QuerySet):
             qs = qs.with_country_geo_range()
         else:
             if tender.perimeters.count():
-                qs = qs.in_perimeters_area(tender.perimeters.all(), with_country=True)
+                qs = qs.geo_range_in_perimeter_list(tender.perimeters.all(), with_country=True)
             if not tender.include_country_area:
                 qs = qs.exclude_country_geo_range()
         # filter by presta_type

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 
+from lemarche.perimeters.factories import PerimeterFactory
+from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.factories import SectorFactory
 from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.factories import SiaeFactory, SiaeGroupFactory, SiaeLabelFactory, SiaeOfferFactory
@@ -268,6 +270,59 @@ class SiaeModelQuerysetTest(TestCase):
         siae.users.add(user)
         self.assertEqual(Siae.objects.count(), 2)
         self.assertEqual(Siae.objects.has_user().count(), 1)
+
+    def test_geo_range_in_perimeter_list(self):
+        auvergne_rhone_alpes_perimeter = PerimeterFactory(
+            name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
+        )
+        guadeloupe_perimeter = PerimeterFactory(name="Guadeloupe", kind=Perimeter.KIND_REGION, insee_code="R01")
+        finistere_perimeter = PerimeterFactory(
+            name="Finistère", kind=Perimeter.KIND_DEPARTMENT, insee_code="29", region_code="53"
+        )
+        grenoble_perimeter = PerimeterFactory(
+            name="Grenoble",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38185",
+            department_code="38",
+            region_code="84",
+            post_codes=["38000", "38100", "38700"],
+            # coords=Point(5.7301, 45.1825),
+        )
+        chamrousse_perimeter = PerimeterFactory(
+            name="Chamrousse",
+            kind=Perimeter.KIND_CITY,
+            insee_code="38567",
+            department_code="38",
+            region_code="84",
+            post_codes=["38410"],
+            # coords=Point(5.8862, 45.1106),
+        )
+        SiaeFactory()
+        SiaeFactory(region="Guadeloupe")
+        SiaeFactory(region="Bretagne", department="29")
+        SiaeFactory(
+            city=grenoble_perimeter.name,
+            department=grenoble_perimeter.department_code,
+            region=auvergne_rhone_alpes_perimeter.name,
+            post_code=grenoble_perimeter.post_codes[0],
+        )
+        # basic filtering
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([]).count(), 4)
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([guadeloupe_perimeter]).count(), 1)
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([grenoble_perimeter]).count(), 1)
+        self.assertEqual(
+            Siae.objects.geo_range_in_perimeter_list([guadeloupe_perimeter, finistere_perimeter]).count(), 2
+        )
+        # with geo_range
+        SiaeFactory(
+            city=chamrousse_perimeter.name,
+            department=chamrousse_perimeter.department_code,
+            region=auvergne_rhone_alpes_perimeter.name,
+            post_code=chamrousse_perimeter.post_codes[0],
+            geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
+        )
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([]).count(), 4 + 1)
+        self.assertEqual(Siae.objects.geo_range_in_perimeter_list([grenoble_perimeter]).count(), 1 + 1)
 
     # def test_annotate_with_user_favorite_list_ids(self):
     # see favorites > tests.py

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -104,7 +104,7 @@ class SiaeSearchForm(forms.Form):
 
         perimeters = self.cleaned_data.get("perimeters", None)
         if perimeters:
-            qs = qs.in_perimeters_area(perimeters)
+            qs = qs.geo_range_in_perimeter_list(perimeters)
 
         kinds = self.cleaned_data.get("kind", None)
         if kinds:
@@ -301,6 +301,6 @@ class NetworkSiaeFilterForm(forms.Form):
 
         perimeter = self.cleaned_data.get("perimeter", None)
         if perimeter:
-            qs = qs.in_perimeters_area([perimeter])
+            qs = qs.geo_range_in_perimeter_list([perimeter])
 
         return qs

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -301,6 +301,6 @@ class NetworkSiaeFilterForm(forms.Form):
 
         perimeter = self.cleaned_data.get("perimeter", None)
         if perimeter:
-            qs = qs.geo_range_in_perimeter_list([perimeter])
+            qs = qs.address_in_perimeter_list([perimeter])
 
         return qs


### PR DESCRIPTION
### Quoi ?

Dans le modèle `Siae`
- renommé le queryset `in_perimeters_area` en `geo_range_in_perimeter_list`
- nouveau queryset `address_in_perimeter_list`
- ajout de tests
