### PR TITLE
Inscription : rediriger les acheteurs vers le moteur de recherche

### DIFF
--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -120,7 +120,6 @@ class SignupFormTest(StaticLiveServerTestCase):
         return messages
 
     def test_siae_submits_signup_form_success(self):
-
         self._complete_form(user_profile=SIAE.copy(), with_submit=True)
 
         messages = self._assert_signup_success(redirect_url=reverse("dashboard:home"))
@@ -137,13 +136,11 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
     def test_buyer_submits_signup_form_success(self):
-
         self._complete_form(user_profile=BUYER, with_submit=True)
 
-        self._assert_signup_success(redirect_url=reverse("wagtail_serve", args=("",)))
+        self._assert_signup_success(redirect_url=reverse("siae:search_results"))
 
     def test_buyer_submits_signup_form_success_extra_data(self):
-
         self._complete_form(user_profile=BUYER, with_submit=False)
         nb_of_handicap = "3"
         nb_of_inclusive = "4"
@@ -169,7 +166,6 @@ class SignupFormTest(StaticLiveServerTestCase):
         self.assertEqual(self.driver.current_url, f"{self.live_server_url}{reverse('auth:signup')}")
 
     def test_partner_submits_signup_form_success(self):
-
         self._complete_form(user_profile=PARTNER, with_submit=False)
         self.driver.find_element(By.XPATH, "//select[@id='id_partner_kind']/option[text()='Réseaux IAE']").click()
         self.driver.find_element(By.CSS_SELECTOR, "form button").click()

--- a/lemarche/www/auth/views.py
+++ b/lemarche/www/auth/views.py
@@ -104,6 +104,8 @@ class SignupView(SuccessMessageMixin, CreateView):
                 return safe_url
         elif self.request.POST.get("kind") == User.KIND_SIAE:
             return reverse_lazy("dashboard:home")
+        elif self.request.POST.get("kind") == User.KIND_BUYER:
+            return reverse_lazy("siae:search_results")
         return success_url
 
     def get_success_message(self, cleaned_data):


### PR DESCRIPTION
Lié à #127

### Quoi ?

Lorsqu'un acheteur s'inscrit sur la plateforme, le rediriger vers le moteur de recherche.
(il est actuellement redirigé vers la page d'accueil)