### PR TITLE
Dépôt de besoin : ajouter le champ 'source' dans l'e-mail de notification

### DIFF
--- a/lemarche/templates/tenders/create_notification_email_admin_body.txt
+++ b/lemarche/templates/tenders/create_notification_email_admin_body.txt
@@ -8,5 +8,6 @@ contact : {{ tender_author_full_name|safe }}
 entreprise : {{ tender_author_company|safe }}
 si le Marché n'existait pas, auriez-vous consulté des prestataires inclusifs ? : {{ tender_scale_marche_useless|safe }}
 status : {{ tender_status|safe }}
+source: {{ tender_source|safe }}
 
 Lien dans l'admin : {{ tender_admin_url }}

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -414,6 +414,7 @@ def notify_admin_tender_created(tender: Tender):
             "tender_author_company": tender.author.company_name,
             "tender_scale_marche_useless": tender.get_scale_marche_useless_display(),
             "tender_status": tender.get_status_display(),
+            "tender_source": tender.get_source_display(),
             "tender_admin_url": tender_admin_url,
         },
     )


### PR DESCRIPTION
### Quoi ?

Ajouter le champ "source" dans l'e-mail de notification reçu par les admin après la création d'un besoin.
Cette info est aussi envoyée sur Slack.
