### PR TITLE
Création d'un hubspot deal à la validation (côté admin) du dépôt de besoin

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -16,6 +16,7 @@ from lemarche.tenders import constants
 from lemarche.tenders.forms import TenderAdminForm
 from lemarche.tenders.models import PartnerShareTender, Tender, TenderQuestion
 from lemarche.utils.admin.admin_site import admin_site
+from lemarche.utils.apis import api_hubspot
 from lemarche.utils.fields import ChoiceArrayField, pretty_print_readonly_jsonfield
 from lemarche.www.tenders.tasks import (
     send_confirmation_published_email_to_author,
@@ -386,6 +387,8 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         if request.POST.get("_validate_tender"):
             update_and_send_tender_task(tender=obj)
             self.message_user(request, "Ce dépôt de besoin a été validé et envoyé aux structures")
+            api_hubspot.create_deal_from_tender(tender=obj)
+
             return HttpResponseRedirect(".")
         elif request.POST.get("_restart_tender"):
             restart_send_tender_task(tender=obj)

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -16,7 +16,6 @@ from lemarche.siaes.models import Siae, SiaeGroup
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender
 from lemarche.users.models import User
-from lemarche.utils.apis import api_hubspot
 from lemarche.utils.tracker import track
 from lemarche.www.pages.forms import (
     CompanyReferenceCalculatorForm,
@@ -362,8 +361,6 @@ def csrf_failure(request, reason=""):  # noqa C901
             tender.save()
         if settings.BITOUBI_ENV == "prod":
             notify_admin_tender_created(tender)
-            if tender.status != tender_constants.STATUS_DRAFT:
-                api_hubspot.create_deal_from_tender(tender=tender)
 
         messages.add_message(
             request,

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -16,7 +16,6 @@ from lemarche.siaes.models import Siae
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
-from lemarche.utils.apis import api_hubspot
 from lemarche.utils.data import get_choice
 from lemarche.utils.mixins import TenderAuthorOrAdminRequiredIfNotValidatedMixin, TenderAuthorOrAdminRequiredMixin
 from lemarche.www.siaes.forms import TenderSiaeFilterForm
@@ -175,8 +174,7 @@ class TenderCreateMultiStepView(SessionWizardView):
         # we notify the admin team
         if settings.BITOUBI_ENV == "prod":
             notify_admin_tender_created(self.instance)
-            if not is_draft:
-                api_hubspot.create_deal_from_tender(tender=self.instance)
+
         # validation & siae contacted? in tenders/admin.py
         # success message & response
         messages.add_message(


### PR DESCRIPTION
### Quoi ?

Création d'un hubspot deal à la validation (côté admin) du dépôt de besoin.

### Pourquoi ?

Faire gagner du temps au bizdevs.

### Comment ?

Création du "deal" à la validation côté admin.
