### PR TITLE
Dépôt de besoin : Fix du bouton sauvegardé en brouillon

### DIFF
--- a/lemarche/templates/tenders/create_step_confirmation.html
+++ b/lemarche/templates/tenders/create_step_confirmation.html
@@ -18,7 +18,8 @@
         <button type="submit"
                 id="tender-create-draft-form-btn"
                 class="btn btn-block btn-ico btn-outline-primary"
-                name="is_draft">
+                name="is_draft"
+                value="1">
             <i class="ri-save-line ri-lg"></i>
             <span>Enregistrer le brouillon</span>
         </button>

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -362,15 +362,23 @@ def csrf_failure(request, reason=""):  # noqa C901
         if settings.BITOUBI_ENV == "prod":
             notify_admin_tender_created(tender)
 
-        messages.add_message(
-            request=request,
-            level=messages.INFO if tender.status != tender_constants.STATUS_DRAFT else messages.SUCCESS,
-            message=TenderCreateMultiStepView.get_success_message(
-                TenderCreateMultiStepView, tender_dict, tender, is_draft=False
-            ),
-            extra_tags="modal_message_bizdev",
-        )
-
+        if tender.status == tender_constants.STATUS_DRAFT:
+            messages.add_message(
+                request=request,
+                level=messages.INFO,
+                message=TenderCreateMultiStepView.get_success_message(
+                    TenderCreateMultiStepView, tender_dict, tender, is_draft=True
+                ),
+            )
+        else:
+            messages.add_message(
+                request=request,
+                level=messages.SUCCESS,
+                message=TenderCreateMultiStepView.get_success_message(
+                    TenderCreateMultiStepView, tender_dict, tender, is_draft=False
+                ),
+                extra_tags="modal_message_bizdev",
+            )
         return HttpResponseRedirect(TenderCreateMultiStepView.success_url)
 
     # return HttpResponseForbidden()

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -126,6 +126,7 @@ class TenderCreateViewTest(TestCase):
         tender = Tender.objects.get(title=tenders_step_data[0].get("general-title"))
         self.assertIsNotNone(tender)
         self.assertIsInstance(tender, Tender)
+        self.assertEqual(tender.status, Tender.STATUS_PUBLISHED)
 
     def test_tender_wizard_form_all_good_perimeters(self):
         self.client.force_login(self.user_buyer)
@@ -142,6 +143,14 @@ class TenderCreateViewTest(TestCase):
         tender_list_sector_slug = [sector.slug for sector in tenders_sectors]
         self.assertEqual(len(tender_list_sector_slug), tenders_sectors.count())
         self.assertEqual(tender_list_sector_slug.sort(), self.sectors.sort())
+
+    def test_tender_wizard_form_draft(self):
+        tenders_step_data = self._generate_fake_data_form(_step_5={"is_draft": "1"})
+        self._check_every_step(tenders_step_data, final_redirect_page=reverse("siae:search_results"))
+        tender: Tender = Tender.objects.get(title=tenders_step_data[0].get("general-title"))
+        self.assertIsNotNone(tender)
+        self.assertIsInstance(tender, Tender)
+        self.assertEqual(tender.status, Tender.STATUS_DRAFT)
 
 
 class TenderMatchingTest(TestCase):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -178,12 +178,19 @@ class TenderCreateMultiStepView(SessionWizardView):
 
         # validation & siae contacted? in tenders/admin.py
         # success message & response
-        messages.add_message(
-            request=self.request,
-            level=messages.INFO if is_draft else messages.SUCCESS,
-            message=self.get_success_message(cleaned_data, self.instance, is_draft=is_draft),
-            extra_tags="modal_message_bizdev",
-        )
+        if is_draft:
+            messages.add_message(
+                request=self.request,
+                level=messages.INFO,
+                message=self.get_success_message(cleaned_data, self.instance, is_draft=is_draft),
+            )
+        else:
+            messages.add_message(
+                request=self.request,
+                level=messages.SUCCESS,
+                message=self.get_success_message(cleaned_data, self.instance, is_draft=is_draft),
+                extra_tags="modal_message_bizdev",
+            )
         return redirect(self.get_success_url())
 
     def get_success_url(self):


### PR DESCRIPTION
### Quoi ?

Dépôt de besoin : Fix du bouton sauvegardé en brouillon

### Pourquoi ?

La `value` du bouton "sauvegarder comme brouillon" n'était pas assigné.
