### PR TITLE
Structures : Afficher le nombre d'ETP du C2 si nombre d'ETP pas renseigné 

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -866,6 +866,13 @@ class Siae(models.Model):
         return "non disponible"
 
     @property
+    def etp_count_display(self):
+        if self.employees_insertion_count:
+            return self.employees_insertion_count
+        elif self.c2_etp_count:
+            return self.c2_etp_count
+
+    @property
     def contact_full_name(self):
         return f"{self.contact_first_name} {self.contact_last_name}"
 

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -144,7 +144,7 @@
                                     <div class="col-12">
                                         <i class="ri-user-add-line"></i>
                                         <strong>Salariés en insertion :</strong>
-                                        <span>{{ siae.employees_insertion_count|default:"non disponible" }}</span>
+                                        <span>{{ siae.etp_count_display|floatformat:0|default:"non disponible" }}</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
### Quoi ?

Structures : Afficher le nombre d'ETP du C2 si nombre d'ETP pas renseigné.

### Pourquoi ?

Exploiter les données du C2 et inciter les structures à mettre à jours leurs données.

### Comment ?

Création d'une property dans le modèle `Siae`.
