### PR TITLE
Dépôt de besoin : bugfix sur la liste des prestataires concernés & intéressés

### DIFF
--- a/lemarche/siaes/management/commands/export_all_siae_to_file.py
+++ b/lemarche/siaes/management/commands/export_all_siae_to_file.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 
 from lemarche.utils.export import export_siae_to_csv, export_siae_to_excel
 from lemarche.utils.s3 import API_CONNECTION_DICT
-from lemarche.www.siaes.forms import SiaeSearchForm
+from lemarche.www.siaes.forms import SiaeFilterForm
 
 
 # init S3 config
@@ -36,7 +36,7 @@ class Command(BaseCommand):
     Export all Siae to a file (XLS or CSV)
 
     Steps:
-    1. Use the SiaeSearchForm to get the list of all the Siae available for the user
+    1. Use the SiaeFilterForm to get the list of all the Siae available for the user
     2. Generate the file (.xls or .csv or both)
     3. Upload to S3
     4. Cleanup
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         self.stdout.write("Task: export Siae list...")
 
         self.stdout.write("Step 1: fetching Siae list")
-        filter_form = SiaeSearchForm({})
+        filter_form = SiaeFilterForm({})
         siae_list = filter_form.filter_queryset()
         self.stdout.write(f"Found {len(siae_list)} Siae")
 

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -61,14 +61,14 @@
 
                 <li class="nav-item">
                     <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_LIST_URL }}?{{ current_search_query }}"
-                        class="nav-link{% if TENDER_SIAE_LIST_URL in request.get_full_path %} active{% endif %}"
+                        class="nav-link{% if request.path == TENDER_SIAE_LIST_URL %} active{% endif %}"
                         hx-target="#tenderSiaeList" hx-swap="outerHTML">
                         Prestataires ciblés
                     </a>
                 </li>
                 <li class="nav-item">
                     <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL }}?{{ current_search_query }}"
-                        class="nav-link{% if TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL in request.get_full_path %} active{% endif %}"
+                        class="nav-link{% if request.path == TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %} active{% endif %}"
                         hx-target="#tenderSiaeList" hx-swap="outerHTML">
                         Prestataires intéressés
                     </a>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -1,7 +1,7 @@
 {% extends BASE_TEMPLATE %}
 {% load bootstrap4 static %}
 
-{% block title %}Prestataires intéressés par mon besoin{{ block.super }}{% endblock %}
+{% block title %}Prestataires ciblés & intéressés par mon besoin{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
 <section>
@@ -14,7 +14,7 @@
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:list' %}">Mes besoins</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'tenders:detail' tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Prestataires intéressés</li>
+                        <li class="breadcrumb-item active" aria-current="page">Prestataires ciblés & intéressés</li>
                     </ol>
                 </nav>
             </div>

--- a/lemarche/www/pages/forms.py
+++ b/lemarche/www/pages/forms.py
@@ -3,7 +3,7 @@ from django.db.models import Case, Count, F, IntegerField, Sum, When
 
 from lemarche.siaes.models import Siae
 from lemarche.utils.constants import EMPTY_CHOICE
-from lemarche.www.siaes.forms import SiaeSearchForm
+from lemarche.www.siaes.forms import SiaeFilterForm
 
 
 class ContactForm(forms.Form):
@@ -37,7 +37,7 @@ class ContactForm(forms.Form):
     message = forms.CharField(label="Message", widget=forms.Textarea(attrs={"data-expandable": "true"}), required=True)
 
 
-class ImpactCalculatorForm(SiaeSearchForm):
+class ImpactCalculatorForm(SiaeFilterForm):
     class Meta:
         model = Siae
         fields = ["sectors", "perimeters", "presta_type"]
@@ -72,7 +72,7 @@ class SocialImpactBuyersCalculatorForm(forms.Form):
     amount = forms.IntegerField(min_value=100, max_value=10e8, label="Montant de votre achat (en €)")
 
 
-class CompanyReferenceCalculatorForm(SiaeSearchForm):
+class CompanyReferenceCalculatorForm(SiaeFilterForm):
     class Meta:
         model = Siae
         fields = ["company_client_reference"]

--- a/lemarche/www/pages/views.py
+++ b/lemarche/www/pages/views.py
@@ -148,7 +148,7 @@ class ImpactCalculatorView(FormMixin, ListView):
     def get_queryset(self):
         """
         Filter results.
-        - filter using the SiaeSearchForm
+        - filter using the SiaeFilterForm
         - aggregate on impact values
         """
         self.filter_form = ImpactCalculatorForm(data=self.request.GET)
@@ -229,7 +229,7 @@ class CompanyReferenceCalculatorView(FormMixin, ListView):
     def get_queryset(self):
         """
         Filter results.
-        - filter using the SiaeSearchForm
+        - filter using the SiaeFilterForm
         """
         self.filter_form = CompanyReferenceCalculatorForm(data=self.request.GET)
         if len(self.request.GET.keys()):

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -324,10 +324,7 @@ class TenderSiaeFilterForm(forms.Form):
         required=False,
     )
 
-    def filter_queryset(self, qs=None):  # noqa C901
-        if not qs:
-            qs = Siae.objects.search_query_set()
-
+    def filter_queryset(self, qs):  # noqa C901
         if not hasattr(self, "cleaned_data"):
             self.full_clean()
 

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -85,7 +85,7 @@ class SiaeSearchForm(forms.Form):
         Method to filter the Siaes depending on the search filters.
         We also make sure there are no duplicates.
         """
-        if not qs:
+        if qs is None:
             # we only display live Siae
             qs = Siae.objects.search_query_set()
 
@@ -305,46 +305,6 @@ class NetworkSiaeFilterForm(forms.Form):
         perimeter = self.cleaned_data.get("perimeter", None)
         if perimeter:
             qs = qs.address_in_perimeter_list([perimeter])
-
-        # avoid duplicates
-        qs = qs.distinct()
-
-        return qs
-
-
-class TenderSiaeFilterForm(forms.Form):
-    kind = forms.MultipleChoiceField(
-        label=Siae._meta.get_field("kind").verbose_name,
-        choices=FORM_KIND_CHOICES_GROUPED,
-        required=False,
-    )
-    territory = forms.MultipleChoiceField(
-        label="Territoire spécifique",
-        choices=FORM_TERRITORY_CHOICES,
-        required=False,
-    )
-
-    def filter_queryset(self, qs):  # noqa C901
-        if not hasattr(self, "cleaned_data"):
-            self.full_clean()
-
-        kinds = self.cleaned_data.get("kind", None)
-        if kinds:
-            qs = qs.filter(kind__in=kinds)
-
-        presta_types = self.cleaned_data.get("presta_type", None)
-        if presta_types:
-            qs = qs.filter(presta_type__overlap=presta_types)
-
-        territory = self.cleaned_data.get("territory", None)
-        if territory:
-            if len(territory) == 1:
-                if "QPV" in territory:
-                    qs = qs.filter(is_qpv=True)
-                elif "ZRR" in territory:
-                    qs = qs.filter(is_zrr=True)
-            elif len(territory) == 2:
-                qs = qs.filter(Q(is_qpv=True) | Q(is_zrr=True))
 
         # avoid duplicates
         qs = qs.distinct()

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -133,7 +133,6 @@ class SiaeFilterForm(forms.Form):
         tender = self.cleaned_data.get("tender", None)
         tender_status = self.cleaned_data.get("tender_status", None)
         if tender:
-            qs = qs.filter(tendersiae__tender=tender)
             if tender_status:  # status == "INTERESTED"
                 qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_contact_click_date__isnull=False)
             else:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -131,11 +131,13 @@ class SiaeSearchForm(forms.Form):
 
         # un auteur d'un dépôt de besoin peut exporter la liste des prestataires (ciblés ou intéressés)
         tender = self.cleaned_data.get("tender", None)
+        tender_status = self.cleaned_data.get("tender_status", None)
         if tender:
-            qs = qs.filter(tendersiae__tender=tender, tendersiae__email_send_date__isnull=False)
-            tender_status = self.cleaned_data.get("tender_status", None)
-            if tender_status:
-                qs = qs.filter(tendersiae__detail_contact_click_date__isnull=False)
+            qs = qs.filter(tendersiae__tender=tender)
+            if tender_status:  # status == "INTERESTED"
+                qs = qs.filter(tendersiae__tender=tender, tendersiae__detail_contact_click_date__isnull=False)
+            else:
+                qs = qs.filter(tendersiae__tender=tender, tendersiae__email_send_date__isnull=False)
 
         favorite_list = self.cleaned_data.get("favorite_list", None)
         if favorite_list:

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -23,7 +23,7 @@ FORM_TERRITORY_CHOICES = (
 )
 
 
-class SiaeSearchForm(forms.Form):
+class SiaeFilterForm(forms.Form):
     q = forms.CharField(
         label="Recherche via le numéro de SIRET ou le nom de votre structure",
         required=False,
@@ -222,7 +222,7 @@ class SiaeFavoriteForm(forms.ModelForm):
         fields = ["favorite_lists"]
 
 
-class SiaeDownloadForm(SiaeSearchForm):
+class SiaeDownloadForm(SiaeFilterForm):
     marche_benefits = forms.MultipleChoiceField(
         label="Pourquoi téléchargez-vous cette liste ?",
         choices=Tender._meta.get_field("marche_benefits").base_field.choices,
@@ -244,7 +244,7 @@ SHARE_PLATEFORM = (
 )
 
 
-class SiaeShareForm(SiaeSearchForm):
+class SiaeShareForm(SiaeFilterForm):
     # global field
     share_with = forms.ChoiceField(
         label="Partager par",
@@ -296,7 +296,7 @@ class NetworkSiaeFilterForm(forms.Form):
     )
 
     def filter_queryset(self, qs=None):
-        if not qs:
+        if qs is None:
             qs = Siae.objects.search_query_set()
 
         if not hasattr(self, "cleaned_data"):

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -10,7 +10,7 @@ from lemarche.siaes import constants as siae_constants
 from lemarche.siaes.factories import SiaeClientReferenceFactory, SiaeFactory, SiaeOfferFactory
 from lemarche.siaes.models import Siae
 from lemarche.users.factories import UserFactory
-from lemarche.www.siaes.forms import SiaeSearchForm
+from lemarche.www.siaes.forms import SiaeFilterForm
 
 
 class SiaeSearchFilterTest(TestCase):
@@ -360,17 +360,17 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertEqual(Siae.objects.count(), 14)
 
     def test_search_perimeter_empty(self):
-        form = SiaeSearchForm({"perimeters": [""]})
+        form = SiaeFilterForm({"perimeters": [""]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
 
     def test_search_perimeter_region(self):
-        form = SiaeSearchForm({"perimeters": [self.auvergne_rhone_alpes_perimeter.slug]})
+        form = SiaeFilterForm({"perimeters": [self.auvergne_rhone_alpes_perimeter.slug]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 10)
 
     def test_search_perimeter_not_exist(self):
-        form = SiaeSearchForm({"perimeters": ["-1"]})
+        form = SiaeFilterForm({"perimeters": ["-1"]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
         self.assertFalse(form.is_valid())
@@ -378,7 +378,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertIn("Sélectionnez un choix valide", form.errors["perimeters"][0])
 
     def test_search_perimeter_department(self):
-        form = SiaeSearchForm({"perimeters": [self.isere_perimeter]})
+        form = SiaeFilterForm({"perimeters": [self.isere_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 6)
 
@@ -389,7 +389,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 new Siae: La Tronche. Chamrousse is outside)  # noqa
         """
-        form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter.slug]})
+        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter.slug]})
         self.assertTrue(form.is_valid())
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 4 + 0 + 1)
@@ -401,7 +401,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (3 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 Siae, 0 new: Chamrousse. Grenoble & La Tronche are outside)  # noqa
         """
-        form = SiaeSearchForm({"perimeters": [self.chamrousse_perimeter]})
+        form = SiaeFilterForm({"perimeters": [self.chamrousse_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 1 + 3 + 0)
 
@@ -412,7 +412,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Chamrousse (2 Siae, 1 new) # noqa
         """
-        form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter, self.chamrousse_perimeter]})
+        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, self.chamrousse_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 5 + 0 + 1)
 
@@ -423,7 +423,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere & 29 (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Quimper (1 new Siae) # noqa
         """
-        form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter, self.quimper_perimeter]})
+        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, self.quimper_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 8 + 0 + 1)
 
@@ -432,7 +432,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         test one perimeter is good and the other one is not
         We should return the default qs with error
         """
-        form = SiaeSearchForm({"perimeters": [self.grenoble_perimeter, "-1"]})
+        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, "-1"]})
         qs = form.filter_queryset()
         self.assertFalse(form.is_valid())
         self.assertIn("perimeters", form.errors.keys())

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -22,7 +22,7 @@ from lemarche.utils.export import export_siae_to_csv, export_siae_to_excel
 from lemarche.utils.s3 import API_CONNECTION_DICT
 from lemarche.utils.urls import get_domain_url, get_encoded_url_from_params
 from lemarche.www.auth.tasks import add_to_contact_list
-from lemarche.www.siaes.forms import SiaeDownloadForm, SiaeFavoriteForm, SiaeSearchForm, SiaeShareForm
+from lemarche.www.siaes.forms import SiaeDownloadForm, SiaeFavoriteForm, SiaeFilterForm, SiaeShareForm
 
 
 CURRENT_SEARCH_QUERY_COOKIE_NAME = "current_search"
@@ -42,7 +42,7 @@ SECTOR_GROUP_HYGIERE_SLUG_LIST = [
 
 class SiaeSearchResultsView(FormMixin, ListView):
     template_name = "siaes/search_results.html"
-    form_class = SiaeSearchForm
+    form_class = SiaeFilterForm
     # queryset = Siae.objects.all()
     context_object_name = "siaes"
     paginate_by = 20
@@ -51,10 +51,10 @@ class SiaeSearchResultsView(FormMixin, ListView):
     def get_queryset(self):
         """
         Filter results.
-        - filter and order using the SiaeSearchForm
+        - filter and order using the SiaeFilterForm
         - if the user is authenticated, annotate with favorite info
         """
-        self.filter_form = SiaeSearchForm(data=self.request.GET)
+        self.filter_form = SiaeFilterForm(data=self.request.GET)
         results = self.filter_form.filter_queryset()
         results_ordered = self.filter_form.order_queryset(results)
         if self.request.user.is_authenticated:
@@ -86,7 +86,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         """
         context = super().get_context_data(**kwargs)
         context["position_promote_tenders"] = [5, 15]
-        siae_search_form = self.filter_form if self.filter_form else SiaeSearchForm(data=self.request.GET)
+        siae_search_form = self.filter_form if self.filter_form else SiaeFilterForm(data=self.request.GET)
         context["form"] = siae_search_form
         context["form_download"] = SiaeDownloadForm(data=self.request.GET)
         context["form_share"] = SiaeShareForm(data=self.request.GET, user=self.request.user)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -17,7 +17,7 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
 from lemarche.utils.mixins import TenderAuthorOrAdminRequiredIfNotValidatedMixin, TenderAuthorOrAdminRequiredMixin
-from lemarche.www.siaes.forms import SiaeSearchForm
+from lemarche.www.siaes.forms import SiaeFilterForm
 from lemarche.www.tenders.forms import (
     TenderCreateStepConfirmationForm,
     TenderCreateStepContactForm,
@@ -367,7 +367,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
 
 class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
     template_name = "tenders/siae_interested_list.html"
-    form_class = SiaeSearchForm
+    form_class = SiaeFilterForm
     queryset = Siae.objects.prefetch_related("tendersiae_set").all()
     context_object_name = "siaes"
     status = None
@@ -383,7 +383,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_send_date__isnull=False)
             qs = qs.order_by("-tendersiae__email_send_date")
         # then filter with the form
-        self.filter_form = SiaeSearchForm(data=self.request.GET)
+        self.filter_form = SiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         return qs
 
@@ -400,7 +400,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         context = super().get_context_data(**kwargs)
         context["tender"] = self.tender
         context["status"] = self.status
-        siae_search_form = self.filter_form if self.filter_form else SiaeSearchForm(data=self.request.GET)
+        siae_search_form = self.filter_form if self.filter_form else SiaeFilterForm(data=self.request.GET)
         context["form"] = siae_search_form
         context["current_search_query"] = self.request.GET.urlencode()
         return context

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
-from django.db.models import Q
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
@@ -377,11 +376,12 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         qs = super().get_queryset()
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
+        qs = qs.filter(tendersiae__tender=self.tender)
         if self.status:  # status == "INTERESTED"
-            qs = qs.filter(Q(tendersiae__tender=self.tender) & Q(tendersiae__detail_contact_click_date__isnull=False))
+            qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
         else:  # default
-            qs = qs.filter(Q(tendersiae__tender=self.tender) & Q(tendersiae__email_send_date__isnull=False))
+            qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_send_date__isnull=False)
             qs = qs.order_by("-tendersiae__email_send_date")
         # then filter with the form
         self.filter_form = TenderSiaeFilterForm(data=self.request.GET)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -17,7 +17,7 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
 from lemarche.utils.mixins import TenderAuthorOrAdminRequiredIfNotValidatedMixin, TenderAuthorOrAdminRequiredMixin
-from lemarche.www.siaes.forms import TenderSiaeFilterForm
+from lemarche.www.siaes.forms import SiaeSearchForm
 from lemarche.www.tenders.forms import (
     TenderCreateStepConfirmationForm,
     TenderCreateStepContactForm,
@@ -367,7 +367,7 @@ class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
 
 class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
     template_name = "tenders/siae_interested_list.html"
-    form_class = TenderSiaeFilterForm
+    form_class = SiaeSearchForm
     queryset = Siae.objects.prefetch_related("tendersiae_set").all()
     context_object_name = "siaes"
     status = None
@@ -376,8 +376,6 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         qs = super().get_queryset()
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
-        qs = qs.filter(tendersiae__tender=self.tender)
-
         if self.status:  # status == "INTERESTED"
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
@@ -385,7 +383,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_send_date__isnull=False)
             qs = qs.order_by("-tendersiae__email_send_date")
         # then filter with the form
-        self.filter_form = TenderSiaeFilterForm(data=self.request.GET)
+        self.filter_form = SiaeSearchForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         return qs
 
@@ -402,7 +400,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         context = super().get_context_data(**kwargs)
         context["tender"] = self.tender
         context["status"] = self.status
-        siae_search_form = self.filter_form if self.filter_form else TenderSiaeFilterForm(data=self.request.GET)
+        siae_search_form = self.filter_form if self.filter_form else SiaeSearchForm(data=self.request.GET)
         context["form"] = siae_search_form
         context["current_search_query"] = self.request.GET.urlencode()
         return context

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -377,6 +377,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
         qs = qs.filter(tendersiae__tender=self.tender)
+
         if self.status:  # status == "INTERESTED"
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")


### PR DESCRIPTION
### Quoi ?

Répare 2 bugs : 
- cas où il y avait 0 structures concernées ou intéressées, cela affichait *toutes* les structures
- l'onglet "concerné" était toujours sélectionné (même en allant sur "intéressés"
- renommé `SiaeSearchForm` en `SiaeFilterForm`
- supprimé `TenderSiaeFilterForm` pour utiliser `SiaeFilterForm` à la place