### PR TITLE
Connexion : améliorer le message pour les nouveaux utilisateurs sans mot de passe

### DIFF
--- a/lemarche/templates/auth/login.html
+++ b/lemarche/templates/auth/login.html
@@ -41,7 +41,7 @@
                             </div>
                             <div class="col">
                                 <p class="mb-0">
-                                    Bonjour !<br />
+                                    Bienvenue sur le marché de l'inclusion !<br />
                                     Vous n'avez pas encore défini de mot de passe.<br />
                                     Pour le faire, veuillez cliquer <a href="{% url 'auth:password_reset' %}"><strong>ici</strong></a>.
                                 </p>

--- a/lemarche/templates/auth/login.html
+++ b/lemarche/templates/auth/login.html
@@ -31,20 +31,21 @@
 
 <section class="s-section">
     <div class="s-section__container container">
-        {% if email_exists_password_empty %}
+        {% if new_user_without_password %}
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
-                    <div id="post-migration-login-message" class="alert alert-success fade show" role="status">
+                    <div id="new-user-without-password-login-message" class="alert alert-warning fade show" role="status">
                         <div class="row">
-                        <div class="col-auto pr-0">
-                            <i class="ri-information-line ri-xl text-success"></i>
-                        </div>
-                        <div class="col">
-                            <p class="mb-0">
-                                Le marché de l'inclusion fait peau neuve ! <br>
-                                Pour accompagner les évolutions futures de la plateforme, nous vous invitons à <a href="{% url 'auth:password_reset' %}"><strong>redéfinir un nouveau mot de passe</strong></a>.!
-                            </p>
-                        </div>
+                            <div class="col-auto pr-0">
+                                <i class="ri-information-line ri-xl text-warning"></i>
+                            </div>
+                            <div class="col">
+                                <p class="mb-0">
+                                    Bonjour !<br />
+                                    Vous n'avez pas encore défini de mot de passe.<br />
+                                    Pour le faire, veuillez cliquer <a href="{% url 'auth:password_reset' %}"><strong>ici</strong></a>.
+                                </p>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -56,8 +57,7 @@
                     <form method="POST" action="" id="login-form">
                         {% csrf_token %}
 
-                        <!-- TODO: post-migration -->
-                        {% if not email_exists_password_empty %}
+                        {% if not new_user_without_password %}
                             {% bootstrap_form_errors form type="all" %}
                         {% endif %}
 

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -298,11 +298,11 @@ class LoginFormTest(StaticLiveServerTestCase):
 
         # should not submit form
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('auth:login')}")
-        # post-migration message should be displayed
+        # error message should be displayed
         messages = driver.find_element(By.CSS_SELECTOR, "div.alert-danger")
         self.assertTrue("aisissez un Adresse e-mail et un mot de passe valides" in messages.text)
 
-    def test_user_empty_credentials_should_see_post_migration_message(self):
+    def test_user_empty_credentials_should_see_password_reset_message(self):
         existing_user = UserFactory(email="existing-user@example.com", password="")
         # only way to have an empty password field
         User.objects.filter(id=existing_user.id).update(password="")
@@ -316,8 +316,8 @@ class LoginFormTest(StaticLiveServerTestCase):
 
         # should not submit form
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('auth:login')}")
-        # # post-migration message should be displayed
-        messages = driver.find_element(By.CSS_SELECTOR, "div#post-migration-login-message")
+        # # new-user-without-password-login-message message should be displayed
+        messages = driver.find_element(By.CSS_SELECTOR, "div#new-user-without-password-login-message")
         self.assertTrue("Le marché de l'inclusion fait peau neuve" in messages.text)
 
     @classmethod

--- a/lemarche/www/auth/tests.py
+++ b/lemarche/www/auth/tests.py
@@ -318,7 +318,7 @@ class LoginFormTest(StaticLiveServerTestCase):
         self.assertEqual(driver.current_url, f"{self.live_server_url}{reverse('auth:login')}")
         # # new-user-without-password-login-message message should be displayed
         messages = driver.find_element(By.CSS_SELECTOR, "div#new-user-without-password-login-message")
-        self.assertTrue("Le marché de l'inclusion fait peau neuve" in messages.text)
+        self.assertTrue("pas encore défini de mot de passe" in messages.text)
 
     @classmethod
     def tearDownClass(cls):

--- a/lemarche/www/auth/views.py
+++ b/lemarche/www/auth/views.py
@@ -40,7 +40,7 @@ class LoginView(auth_views.LoginView):
         if email:
             user = User.objects.filter(email=email.lower()).first()
             if user:
-                context["email_exists_password_empty"] = True if not getattr(user, "password", "") else False
+                context["new_user_without_password"] = True if not getattr(user, "password", "") else False
         next_url = self.request.GET.get("next", None)
         if next_url:
             context["next_param"] = f"?next={next_url}"


### PR DESCRIPTION
### Quoi ?

Lors d'un dépôt de besoin anonyme, on créé un compte à l'utilisateur, mais il doit passer par une étape de réinitialisation de son mot de passe.

Si il tente de se connecter sans passer par l'e-mail reçu, il voit un message d'information l'invitant à le réinitialiser.

Ce message était obsolète (ajouté ici https://github.com/betagouv/itou-marche/commit/503ed0271996d0f5f4bc429d6267a2fd569480b8 en 2021)

### Captures d'écran

||Image|
|---|---|
|Avant|![image](https://github.com/betagouv/itou-marche/assets/7147385/068a7c5d-bae5-4499-8318-fb40ed01e81a) |
|Après|![image](https://github.com/betagouv/itou-marche/assets/7147385/72d864c2-a757-4335-94a9-9ca9837261b4)|