### PR TITLE
Dépôt de besoin: fix de l'écrasement des SiaeTenders par l'admin

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -308,7 +308,9 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         if not obj.id and not obj.author_id:
             obj.author = request.user
         obj.save()
-        obj.set_siae_found_list()
+        # we can add `and obj.status != obj.STATUS_DRAFT` to disable matching when is draft
+        if not obj.is_validated:
+            obj.set_siae_found_list()
 
     def is_validate(self, tender: Tender):
         return tender.validated_at is not None

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -378,7 +378,6 @@ class Tender(models.Model):
     def set_siae_found_list(self):
         """
         Where the Tender-Siae matching magic happens!
-        Called by Tender signals (and if not self.validated_at)
         """
         siae_found_list = Siae.objects.filter_with_tender(self)
         self.siaes.set(siae_found_list, clear=False)

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -536,6 +536,10 @@ class Tender(models.Model):
         if with_save:
             self.save()
 
+    @property
+    def is_validated(self) -> bool:
+        return self.validated_at and self.status == self.STATUS_VALIDATED
+
     def set_validated(self, with_save=True):
         self.validated_at = datetime.now()
         self.status = tender_constants.STATUS_VALIDATED

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -381,7 +381,7 @@ class Tender(models.Model):
         Called by Tender signals (and if not self.validated_at)
         """
         siae_found_list = Siae.objects.filter_with_tender(self)
-        self.siaes.set(siae_found_list, clear=True)
+        self.siaes.set(siae_found_list, clear=False)
 
     def save(self, *args, **kwargs):
         """


### PR DESCRIPTION
### Quoi ?

Dépôt de besoin: fix de l'écrasement des SiaeTenders par l'admin.

### Pourquoi ?

`Clear=True` placé dans une méthode `set` du querymanager.

### Comment ?

Fix du clear et une condition qui permet de ne plus calculer quand le dépôt de besoin est validé.
