### PR TITLE
Dépôt de besoins : Obligé de sauvegarder deux fois un dépôt de besoin pour mettre à jour le nombre de structures

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -308,9 +308,13 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         if not obj.id and not obj.author_id:
             obj.author = request.user
         obj.save()
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request=request, form=form, formsets=formsets, change=change)
+        tender: Tender = form.instance
         # we can add `and obj.status != obj.STATUS_DRAFT` to disable matching when is draft
-        if not obj.is_validated:
-            obj.set_siae_found_list()
+        if not tender.is_validated:
+            tender.set_siae_found_list()
 
     def is_validate(self, tender: Tender):
         return tender.validated_at is not None

--- a/lemarche/utils/admin/admin_site.py
+++ b/lemarche/utils/admin/admin_site.py
@@ -3,8 +3,13 @@ from datetime import date
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.models import Site
+from django.urls import reverse
 
 from lemarche.utils.s3 import API_CONNECTION_DICT
+
+
+def get_admin_change_view_url(obj: object) -> str:
+    return reverse("admin:{}_{}_change".format(obj._meta.app_label, type(obj).__name__.lower()), args=(obj.pk,))
 
 
 class MarcheAdminSite(admin.AdminSite):


### PR DESCRIPTION
### Quoi ?

Obligé de sauvegarder deux fois un dépôt de besoin pour mettre à jour le nombre de structures.

### Pourquoi ?

La sauvegarde de modèle django  se fait en trois étapes (pour simplifier) : 

1. `save_form()`
2. `save_model()`
3. `save_related()`

et l'enregistrement de champs many2many se fait dans `save_related`, d'où l'obligation de sauvegarde de deux fois.
