### PR TITLE
Wagtail : répare l'affichage des title

### DIFF
--- a/lemarche/fixtures/django/20_cms.json
+++ b/lemarche/fixtures/django/20_cms.json
@@ -497,8 +497,8 @@
             "live": true,
             "first_published_at": "2023-03-28T11:33:31.399Z",
             "last_published_at": "2023-04-26T09:03:37.088Z",
-            "title": "Page d'accueil",
-            "draft_title": "Page d'accueil",
+            "title": "Accueil",
+            "draft_title": "Accueil",
             "slug": "accueil",
             "content_type": [
                 "cms",

--- a/lemarche/templates/cms/article_list.html
+++ b/lemarche/templates/cms/article_list.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% load wagtailcore_tags wagtailimages_tags wagtailroutablepage_tags %}
 {% block meta_description %}<meta name="description" content="{{ page.search_description }}">{% endblock %}
-{% block title %}{{ page.seo_title }} | {{ block.super }}{% endblock %}
+{% block title %}{{ page.seo_title }} {{ block.super }}{% endblock %}
 {% block body_class %}p-ressources{{ block.super }}{% endblock %}
 {% block breadcrumbs %}
     <section>

--- a/lemarche/templates/cms/article_page.html
+++ b/lemarche/templates/cms/article_page.html
@@ -6,7 +6,7 @@
 <meta name="description" content="{{ page.search_description }}">
 {% endblock %}
 
-{% block title %}{{ page.title }} | {{ block.super }}{% endblock %}
+{% block title %}{{ page.title }} {{ block.super }}{% endblock %}
 {% block body_class %}p-ressources{{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/lemarche/templates/cms/home_page.html
+++ b/lemarche/templates/cms/home_page.html
@@ -4,7 +4,7 @@
 {% load wagtailimages_tags %}
 {% block meta_description %}<meta name="description" content="{{ page.search_description }}">{% endblock %}
 {% block body_class %}p-homepage{{ block.super }}{% endblock %}
-{% block title %}{{ page.title }} | {{ block.super }}{% endblock %}
+{% block title %}{{ page.title }} {{ block.super }}{% endblock %}
 {% block content %}
     {% if sub_header_custom_message %}
         <section class="s-sub-header">

--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -4,7 +4,7 @@
 <html lang="fr">
 <head>
     <meta charset="utf-8" />
-    <title>{% block title %} - Le marché de l'inclusion{% endblock %}</title>
+    <title>{% block title %} — Le marché de l'inclusion{% endblock %}</title>
     {% block meta_description %}
         <meta name="description" content="Le marché de l'inclusion est un service numérique permettant de trouver un prestataire sociale inclusif proposant des produits ou services professionnels.">
     {% endblock %}

--- a/scripts/create_wagtail_homepage.py
+++ b/scripts/create_wagtail_homepage.py
@@ -6,7 +6,7 @@ from lemarche.cms.models import HomePage
 
 def create_homepage():
     root = Page.get_first_root_node()
-    homepage = HomePage(title="Page d'accueil", slug="accueil")
+    homepage = HomePage(title="Accueil", slug="accueil")
     root.add_child(instance=homepage)
 
 


### PR DESCRIPTION
### Quoi ?

Répare l'affichage des `title` des pages wagtail.
title = le nom des onglets du navigateur, et ce que les moteurs de recherche utilisent pour 

J'en ai profité pour homogénéiser avec https://inclusion.beta.gouv.fr & https://beta.gouv.fr : en utilisant `—`

|Avant|Après|
|---|---|
|Page d'accueil \| - Le marché de l'inclusion|Page d'accueil — Le marché de l'inclusion (v1)<br />Accueil — Le marché de l'inclusion (v2)|

### Capture d'écran

![image](https://github.com/betagouv/itou-marche/assets/7147385/dc5c5b6a-c00b-4977-a4a1-c9d4e2972fb9)
