### PR TITLE
Ajout du driver gecko dans l'image Docker pour les tests selenium

### DIFF
--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -34,6 +34,7 @@ RUN ./install-packages.sh
 FROM common-base AS dependencies
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+ENV GECKODRIVER_URL=https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux32.tar.gz
 
 RUN pip install poetry==$POETRY_VERSION
 RUN pip install -I uwsgi
@@ -44,6 +45,9 @@ COPY poetry.lock pyproject.toml /app/
 RUN poetry config virtualenvs.create false && \
     poetry config virtualenvs.path /opt/venv && \
     poetry install $(test $ENV == "prod" && echo "--no-dev") --no-interaction --no-ansi
+
+# Needed for selenium test
+RUN wget -qO- $GECKODRIVER_URL | tar xvz -C /usr/bin/
 
 # ----------------------------------------------------
 # Build project
@@ -71,18 +75,18 @@ ENV DJANGO_SETTINGS_MODULE="config.settings.dev" \
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/issue && cat /etc/motd' \
     >> /etc/bash.bashrc \
     ; echo "\
-===================================================================\n\
-= Bitoubi Dev Docker container                                =\n\
-===================================================================\n\
-\n\
-(c) plateforme de l'Inclusion\n\
-\n\
-Source directory is /app \n\
+    ===================================================================\n\
+    = Bitoubi Dev Docker container                                =\n\
+    ===================================================================\n\
+    \n\
+    (c) plateforme de l'Inclusion\n\
+    \n\
+    Source directory is /app \n\
 
-Run App with :\n\
-> python ./manage.py runserver \$HOST:\$PORT\n\
-\n\
-"\
+    Run App with :\n\
+    > python ./manage.py runserver \$HOST:\$PORT\n\
+    \n\
+    "\
     > /etc/motd
 
 CMD ["bash"]

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -34,7 +34,6 @@ RUN ./install-packages.sh
 FROM common-base AS dependencies
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-ENV GECKODRIVER_URL=https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux32.tar.gz
 
 RUN pip install poetry==$POETRY_VERSION
 RUN pip install -I uwsgi
@@ -45,9 +44,6 @@ COPY poetry.lock pyproject.toml /app/
 RUN poetry config virtualenvs.create false && \
     poetry config virtualenvs.path /opt/venv && \
     poetry install $(test $ENV == "prod" && echo "--no-dev") --no-interaction --no-ansi
-
-# Needed for selenium test
-RUN wget -qO- $GECKODRIVER_URL | tar xvz -C /usr/bin/
 
 # ----------------------------------------------------
 # Build project

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -35,7 +35,9 @@ apt-get -y install --no-install-recommends \
     libproj-dev \
     libsass1 \
     postgresql-client \
-    vim-tiny
+    vim-tiny \
+    firefox-esr \
+    wget
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -36,8 +36,7 @@ apt-get -y install --no-install-recommends \
     libsass1 \
     postgresql-client \
     vim-tiny \
-    firefox-esr \
-    wget
+    firefox-esr
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
### Quoi ?

Ajout du driver gecko dans l'environnement Docker

### Pourquoi ?

Pour que les tests puissent s'exécuter dans le conteneur.

### Comment ?

- installation du paquet Debian `firefox-esr`
- téléchargement du binaire du driver gecko
