### PR TITLE
Activer les filtres avancées uniquement quand l'utilisateur est connecté

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -101,6 +101,7 @@ DJANGO_APPS = [
     "django.contrib.flatpages",
     "django.contrib.gis",
     "django.contrib.humanize",
+    "django.forms",
 ]
 
 THIRD_PARTY_APPS = [
@@ -798,3 +799,4 @@ SHELL_PLUS_POST_IMPORTS = [
     "from lemarche.siaes import constants as siae_constants",
     "from lemarche.tenders import constants as tender_constants",
 ]
+FORM_RENDERER = "django.forms.renderers.TemplatesSetting"

--- a/lemarche/static/itou_marche/components/_multiselect.scss
+++ b/lemarche/static/itou_marche/components/_multiselect.scss
@@ -37,6 +37,10 @@ button.multiselect {
     button.multiselect {
         background: none;
 
+        &:disabled {
+            background: #e6e6eb;
+        }
+
         &::after {
             display: inline-block;
             font-family: remixicon !important;

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -128,8 +128,7 @@
                                         <div class="col-12 col-md-6 col-lg-3">
                                             <div class="form-group">
                                                 <label for="id_locations">{{ form.locations.label }}</label>
-                                                <div id="dir_form_locations" data-input-name="{{ form.locations.name }}"></div>
-                                                <div id="locations-selected" class="mt-2"></div>
+                                                {{ form.locations }}
                                                 {{ current_locations|json_script:"current-locations" }}
                                             </div>
                                         </div>

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -318,13 +318,15 @@ document.addEventListener("DOMContentLoaded", function() {
     // init perimeters & locations form fields
     const perimetersAutoComplete = new PerimetersMultiAutocomplete();
     perimetersAutoComplete.init();
-    const LOCATION_AUTOCOMPLETE_ID = 'id_locations';
-    const LOCATION_AUTOCOMPLETE_CONTAINER_SELECTOR = '#dir_form_locations';
-    const LOCATION_SELECTED_CONTAINER_SELECTOR = '#locations-selected';
-    const LOCATION_HIDDEN_INPUT_SELECTOR_PREFIX = 'hiddenLocation';
-    const LOCATION_CURRENT_ID = 'current-locations';
-    const locationsAutoComplete = new PerimetersMultiAutocomplete(LOCATION_AUTOCOMPLETE_ID, LOCATION_AUTOCOMPLETE_CONTAINER_SELECTOR, LOCATION_SELECTED_CONTAINER_SELECTOR, LOCATION_HIDDEN_INPUT_SELECTOR_PREFIX, LOCATION_CURRENT_ID);
-    locationsAutoComplete.init();
+    {% if not form.locations.field.disabled %}
+        const LOCATION_AUTOCOMPLETE_ID = 'id_locations';
+        const LOCATION_AUTOCOMPLETE_CONTAINER_SELECTOR = '#dir_form_locations';
+        const LOCATION_SELECTED_CONTAINER_SELECTOR = '#locations-selected';
+        const LOCATION_HIDDEN_INPUT_SELECTOR_PREFIX = 'hiddenLocation';
+        const LOCATION_CURRENT_ID = 'current-locations';
+        const locationsAutoComplete = new PerimetersMultiAutocomplete(LOCATION_AUTOCOMPLETE_ID, LOCATION_AUTOCOMPLETE_CONTAINER_SELECTOR, LOCATION_SELECTED_CONTAINER_SELECTOR, LOCATION_HIDDEN_INPUT_SELECTOR_PREFIX, LOCATION_CURRENT_ID);
+        locationsAutoComplete.init();
+    {% endif %}
 });
     </script>
     <script type="text/javascript">

--- a/lemarche/templates/siaes/widgets/location_widget.html
+++ b/lemarche/templates/siaes/widgets/location_widget.html
@@ -1,0 +1,10 @@
+
+{% if is_disabled %}
+<select name="has_groups" disabled="" class="form-control" title="" id="{{ widget.attrs.id }}" placeholder="{{widget.attrs.placeholder}}">
+    <option value="" disabled selected>{{widget.attrs.placeholder}}</option>
+    {% comment %} <option value="" selected=""></option> {% endcomment %}
+</select>
+{% else %}
+<div id="dir_form_locations" data-input-name="{{ widget.name }}"></div>
+<div id="locations-selected" class="mt-2"></div>
+{% endif %}

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -11,6 +11,7 @@ from lemarche.siaes.models import Siae, SiaeClientReference, SiaeGroup
 from lemarche.tenders.models import Tender
 from lemarche.users.models import User
 from lemarche.utils.fields import GroupedModelMultipleChoiceField
+from lemarche.www.siaes.widgets import CustomLocationWidget
 
 
 FORM_KIND_CHOICES_GROUPED = (
@@ -81,6 +82,11 @@ class SiaeFilterForm(forms.Form):
         queryset=Perimeter.objects.all(),
         to_field_name="slug",
         required=False,
+        widget=CustomLocationWidget(
+            attrs={
+                "placeholder": "Région, département, ville",
+            }
+        ),
     )
 
     has_client_references = forms.ChoiceField(
@@ -121,6 +127,22 @@ class SiaeFilterForm(forms.Form):
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
+    DISABLED_FOR_ANONYMOUS = [
+        "kind",
+        "presta_type",
+        "territory",
+        "networks",
+        "locations",
+        "has_client_references",
+        "has_groups",
+    ]
+
+    def __init__(self, user=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not user or not user.is_authenticated:
+            for item in self.DISABLED_FOR_ANONYMOUS:
+                self.fields[item].disabled = True
+                self.fields[item].widget.attrs["disabled"] = True
 
     def filter_queryset(self, qs=None):  # noqa C901
         """

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -135,6 +135,8 @@ class SiaeFilterForm(forms.Form):
         "locations",
         "has_client_references",
         "has_groups",
+        "ca",
+        "legal_form",
     ]
 
     def __init__(self, user=None, *args, **kwargs):

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -139,9 +139,9 @@ class SiaeFilterForm(forms.Form):
         "legal_form",
     ]
 
-    def __init__(self, user=None, *args, **kwargs):
+    def __init__(self, user=None, advanced_search=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not user or not user.is_authenticated:
+        if not advanced_search:
             for item in self.DISABLED_FOR_ANONYMOUS:
                 self.fields[item].disabled = True
                 self.fields[item].widget.attrs["disabled"] = True

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -31,6 +31,10 @@ class SiaeKindSearchFilterTest(TestCase):
     def setUpTestData(cls):
         SiaeFactory(kind=siae_constants.KIND_EI)
         SiaeFactory(kind=siae_constants.KIND_AI)
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_kind_empty(self):
         url = reverse("siae:search_results")
@@ -62,6 +66,10 @@ class SiaePrestaTypeSearchFilterTest(TestCase):
     def setUpTestData(cls):
         SiaeFactory(presta_type=[siae_constants.PRESTA_DISP])
         SiaeFactory(presta_type=[siae_constants.PRESTA_DISP, siae_constants.PRESTA_BUILD])
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_presta_type_empty(self):
         url = reverse("siae:search_results")
@@ -91,6 +99,10 @@ class SiaeTerritorySearchFilterTest(TestCase):
     def setUpTestData(cls):
         SiaeFactory(is_qpv=True)
         SiaeFactory(is_zrr=True)
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_territory_empty(self):
         url = reverse("siae:search_results")
@@ -186,6 +198,10 @@ class SiaeNetworkSearchFilterTest(TestCase):
         SiaeFactory()
         siae_with_network = SiaeFactory()
         siae_with_network.networks.add(cls.network)
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_network_empty(self):
         url = reverse("siae:search_results")
@@ -215,6 +231,7 @@ class SiaeNetworkSearchFilterTest(TestCase):
 class SiaePerimeterSearchFilterTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.user = UserFactory()
         # create the Perimeters
         cls.auvergne_rhone_alpes_perimeter = PerimeterFactory(
             name="Auvergne-Rhône-Alpes", kind=Perimeter.KIND_REGION, insee_code="R84"
@@ -360,12 +377,12 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertEqual(Siae.objects.count(), 14)
 
     def test_search_perimeter_empty(self):
-        form = SiaeFilterForm({"perimeters": [""]})
+        form = SiaeFilterForm(data={"perimeters": [""]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
 
     def test_search_perimeter_not_exist(self):
-        form = SiaeFilterForm({"perimeters": ["-1"]})
+        form = SiaeFilterForm(data={"perimeters": ["-1"]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
         self.assertFalse(form.is_valid())
@@ -373,12 +390,12 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertIn("Sélectionnez un choix valide", form.errors["perimeters"][0])
 
     def test_search_perimeter_region(self):
-        form = SiaeFilterForm({"perimeters": [self.auvergne_rhone_alpes_perimeter.slug]})
+        form = SiaeFilterForm(data={"perimeters": [self.auvergne_rhone_alpes_perimeter.slug]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 10)
 
     def test_search_perimeter_department(self):
-        form = SiaeFilterForm({"perimeters": [self.isere_perimeter]})
+        form = SiaeFilterForm(data={"perimeters": [self.isere_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 6)
 
@@ -389,7 +406,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 new Siae: La Tronche. Chamrousse is outside)  # noqa
         """
-        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter.slug]})
+        form = SiaeFilterForm(data={"perimeters": [self.grenoble_perimeter.slug]})
         self.assertTrue(form.is_valid())
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 4 + 0 + 1)
@@ -401,7 +418,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the city's department (except GEO_RANGE_CUSTOM) - Isere (3 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble (1 Siae, 0 new: Chamrousse. Grenoble & La Tronche are outside)  # noqa
         """
-        form = SiaeFilterForm({"perimeters": [self.chamrousse_perimeter]})
+        form = SiaeFilterForm(data={"perimeters": [self.chamrousse_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 1 + 3 + 0)
 
@@ -412,7 +429,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Chamrousse (2 Siae, 1 new) # noqa
         """
-        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, self.chamrousse_perimeter]})
+        form = SiaeFilterForm(data={"perimeters": [self.grenoble_perimeter, self.chamrousse_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 5 + 0 + 1)
 
@@ -423,7 +440,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         + all the Siae in the cities departments (except GEO_RANGE_CUSTOM) - Isere & 29 (0 new Siae)
         + all the Siae with geo_range=GEO_RANGE_CUSTOM + coords in the geo_range_custom_distance range of Grenoble or Quimper (1 new Siae) # noqa
         """
-        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, self.quimper_perimeter]})
+        form = SiaeFilterForm(data={"perimeters": [self.grenoble_perimeter, self.quimper_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 8 + 0 + 1)
 
@@ -432,7 +449,7 @@ class SiaePerimeterSearchFilterTest(TestCase):
         test one perimeter is good and the other one is not
         We should return the default qs with error
         """
-        form = SiaeFilterForm({"perimeters": [self.grenoble_perimeter, "-1"]})
+        form = SiaeFilterForm(data={"perimeters": [self.grenoble_perimeter, "-1"]})
         qs = form.filter_queryset()
         self.assertFalse(form.is_valid())
         self.assertIn("perimeters", form.errors.keys())
@@ -440,12 +457,12 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertEqual(qs.count(), 14)
 
     def test_search_location_empty(self):
-        form = SiaeFilterForm({"locations": [""]})
+        form = SiaeFilterForm(data={"locations": [""]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
 
     def test_search_location_not_exist(self):
-        form = SiaeFilterForm({"locations": ["-1"]})
+        form = SiaeFilterForm(data={"locations": ["-1"]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 14)
         self.assertFalse(form.is_valid())
@@ -453,12 +470,12 @@ class SiaePerimeterSearchFilterTest(TestCase):
         self.assertIn("Sélectionnez un choix valide", form.errors["locations"][0])
 
     def test_search_location_region(self):
-        form = SiaeFilterForm({"locations": [self.auvergne_rhone_alpes_perimeter.slug]})
+        form = SiaeFilterForm(data={"locations": [self.auvergne_rhone_alpes_perimeter.slug]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 10)
 
     def test_search_location_department(self):
-        form = SiaeFilterForm({"locations": [self.isere_perimeter]})
+        form = SiaeFilterForm(data={"locations": [self.isere_perimeter]})
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 6)
 
@@ -466,10 +483,20 @@ class SiaePerimeterSearchFilterTest(TestCase):
         """
         We should return all the Siae exactly in the city - Grenoble (4 Siae)
         """
-        form = SiaeFilterForm({"locations": [self.grenoble_perimeter.slug]})
+        form = SiaeFilterForm(data={"locations": [self.grenoble_perimeter.slug]})
         self.assertTrue(form.is_valid())
         qs = form.filter_queryset()
         self.assertEqual(qs.count(), 4)
+
+    def test_disabled_fields_activated(self):
+        form = SiaeFilterForm(advanced_search=False)
+        for _field in form.DISABLED_FOR_ANONYMOUS:
+            self.assertTrue(form.fields.get(_field).disabled)
+
+    def test_disabled_fields_deactivated(self):
+        form = SiaeFilterForm()
+        for _field in form.DISABLED_FOR_ANONYMOUS:
+            self.assertFalse(form.fields.get(_field).disabled)
 
 
 class SiaeHasClientReferencesFilterTest(TestCase):
@@ -479,6 +506,10 @@ class SiaeHasClientReferencesFilterTest(TestCase):
         SiaeClientReferenceFactory(siae=cls.siae_with_client_reference)
         cls.siae_with_client_reference.save()  # to set client_reference_count=1
         cls.siae_without_client_reference = SiaeFactory()  # client_reference_count=0
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_has_client_references_empty(self):
         url = reverse("siae:search_results")
@@ -512,6 +543,10 @@ class SiaeHasGroupsFilterTest(TestCase):
     def setUpTestData(cls):
         cls.siae_with_group = SiaeFactory(group_count=1)
         cls.siae_without_group = SiaeFactory(group_count=0)
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_has_groups_empty(self):
         url = reverse("siae:search_results")
@@ -551,6 +586,10 @@ class SiaeCAFilterTest(TestCase):
         cls.siae_2m = SiaeFactory(ca=2000000, api_entreprise_ca=0)
         cls.siae_7m = SiaeFactory(api_entreprise_ca=7000000)
         cls.siae_50m = SiaeFactory(ca=0, api_entreprise_ca=50000000)
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_query_empty(self):
         url = reverse("siae:search_results")
@@ -608,6 +647,10 @@ class SiaeLegalFormFilterTest(TestCase):
         cls.siae_legal_form_sarl = SiaeFactory(legal_form="SARL")
         cls.siae_legal_form_sa = SiaeFactory(legal_form="SA")
         cls.siae_legal_form_empty = SiaeFactory(legal_form="")
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_legal_form_empty(self):
         url = reverse("siae:search_results")
@@ -643,6 +686,10 @@ class SiaeFullTextSearchTest(TestCase):
         cls.siae_2 = SiaeFactory(name="Une autre activité", siret="22222222222222")
         cls.siae_3 = SiaeFactory(name="ABC Insertion", siret="33333333344444")
         cls.siae_4 = SiaeFactory(name="Empty", brand="ETHICOFIL", siret="55555555555555")
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_search_query_empty(self):
         url = reverse("siae:search_results")
@@ -798,6 +845,10 @@ class SiaeSearchOrderTest(TestCase):
             # post_codes=["38000", "38100", "38700"],
             coords=Point(5.7301, 45.1825),
         )
+        cls.user = UserFactory()
+
+    def setUp(self):
+        self.client.force_login(self.user)
 
     def test_should_order_by_last_updated(self):
         url = reverse("siae:search_results", kwargs={})

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -54,7 +54,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         - filter and order using the SiaeFilterForm
         - if the user is authenticated, annotate with favorite info
         """
-        self.filter_form = SiaeFilterForm(data=self.request.GET)
+        self.filter_form = SiaeFilterForm(data=self.request.GET, user=self.request.user)
         results = self.filter_form.filter_queryset()
         results_ordered = self.filter_form.order_queryset(results)
         if self.request.user.is_authenticated:
@@ -86,7 +86,9 @@ class SiaeSearchResultsView(FormMixin, ListView):
         """
         context = super().get_context_data(**kwargs)
         context["position_promote_tenders"] = [5, 15]
-        siae_search_form = self.filter_form if self.filter_form else SiaeFilterForm(data=self.request.GET)
+        siae_search_form = (
+            self.filter_form if self.filter_form else SiaeFilterForm(data=self.request.GET, request=self.request)
+        )
         context["form"] = siae_search_form
         context["form_download"] = SiaeDownloadForm(data=self.request.GET)
         context["form_share"] = SiaeShareForm(data=self.request.GET, user=self.request.user)

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -43,10 +43,20 @@ SECTOR_GROUP_HYGIERE_SLUG_LIST = [
 class SiaeSearchResultsView(FormMixin, ListView):
     template_name = "siaes/search_results.html"
     form_class = SiaeFilterForm
+    filter_form = None
     # queryset = Siae.objects.all()
     context_object_name = "siaes"
     paginate_by = 20
     paginator_class = Paginator
+
+    def get_filter_form(self):
+        user = self.request.user
+        self.filter_form = (
+            self.filter_form
+            if self.filter_form
+            else SiaeFilterForm(data=self.request.GET, advanced_search=user.is_authenticated)
+        )
+        return self.filter_form
 
     def get_queryset(self):
         """
@@ -54,9 +64,9 @@ class SiaeSearchResultsView(FormMixin, ListView):
         - filter and order using the SiaeFilterForm
         - if the user is authenticated, annotate with favorite info
         """
-        self.filter_form = SiaeFilterForm(data=self.request.GET, user=self.request.user)
-        results = self.filter_form.filter_queryset()
-        results_ordered = self.filter_form.order_queryset(results)
+        filter_form = self.get_filter_form()
+        results = filter_form.filter_queryset()
+        results_ordered = filter_form.order_queryset(results)
         if self.request.user.is_authenticated:
             results_ordered = results_ordered.annotate_with_user_favorite_list_count(self.request.user)
         return results_ordered
@@ -86,9 +96,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         """
         context = super().get_context_data(**kwargs)
         context["position_promote_tenders"] = [5, 15]
-        siae_search_form = (
-            self.filter_form if self.filter_form else SiaeFilterForm(data=self.request.GET, request=self.request)
-        )
+        siae_search_form = self.get_filter_form()
         context["form"] = siae_search_form
         context["form_download"] = SiaeDownloadForm(data=self.request.GET)
         context["form_share"] = SiaeShareForm(data=self.request.GET, user=self.request.user)

--- a/lemarche/www/siaes/widgets.py
+++ b/lemarche/www/siaes/widgets.py
@@ -1,0 +1,13 @@
+from django.forms import widgets
+
+
+class CustomLocationWidget(widgets.SelectMultiple):
+    template_name = "siaes/widgets/location_widget.html"
+
+    def get_context(self, name, value, attrs):
+        _context = super().get_context(name, value, attrs)
+        _context["is_disabled"] = self.is_disabled()
+        return _context
+
+    def is_disabled(self):
+        return self.attrs.get("disabled", False)


### PR DESCRIPTION
### Quoi ?

Activer les filtres avancées uniquement quand l'utilisateur est connecté.

### Pourquoi ?

Pour inciter les utilisateurs à se connecter et/ou à s'inscrire. 

### Comment ?

- Création d'un customWidget pour gérer le filtre de location et le rendre disable plus facilement.
- Management d'une liste de champs à disable

### Autre (optionnel)

Reste à faire : 
- [x] Afficher une popup pour inciter l'utilisateur à se connecter pour activer les filtres avancées
- [x] Gérer l'ouverture des la recherche avancé quand la personne a activé un champs de recherche avancée