### PR TITLE
Recherche : filtre avancé sur l'effectif

### DIFF
--- a/lemarche/fixtures/django/01_siaes.json
+++ b/lemarche/fixtures/django/01_siaes.json
@@ -25,7 +25,8 @@
             "is_first_page": true,
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:40:16.387Z",
-            "slug": "baluchon-a-table-citoyens-93"
+            "slug": "baluchon-a-table-citoyens-93",
+            "api_entreprise_employees": "50 à 99 salariés"
         }
     },
     {
@@ -82,7 +83,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:40:08.840Z",
-            "slug": "initiatives-solidaires-93"
+            "slug": "initiatives-solidaires-93",
+            "api_entreprise_employees": "Non renseigné"
         }
     },
     {
@@ -2546,7 +2548,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:39:37.601Z",
-            "slug": "commune-de-dunkerque-59"
+            "slug": "commune-de-dunkerque-59",
+            "api_entreprise_employees": "1 000 à 1 999 salariés"
         }
     },
     {
@@ -5138,7 +5141,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:38:04.734Z",
-            "slug": "commune-de-nancy-54"
+            "slug": "commune-de-nancy-54",
+            "api_entreprise_employees": "1 000 à 1 999 salariés"
         }
     },
     {
@@ -5894,7 +5898,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:38:06.218Z",
-            "slug": "departement-des-deux-sevres-79"
+            "slug": "departement-des-deux-sevres-79",
+            "api_entreprise_employees": "1 000 à 1 999 salariés"
         }
     },
     {
@@ -8027,7 +8032,9 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:38:10.225Z",
-            "slug": "ccas-paris-75"
+            "slug": "ccas-paris-75",
+            "c2_etp_count": 41.2,
+            "api_entreprise_employees": "1 000 à 1 999 salariés"
         }
     },
     {
@@ -9404,7 +9411,10 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:38:11.942Z",
-            "slug": "ass-lutte-contre-le-gaspillage-39"
+            "slug": "ass-lutte-contre-le-gaspillage-39",
+            "employees_insertion_count": 25,
+            "employees_permanent_count": 4,
+            "api_entreprise_employees": "20 à 49 salariés"
         }
     },
     {
@@ -38059,7 +38069,9 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:38:55.619Z",
-            "slug": "assoc-germa-ai-67"
+            "slug": "assoc-germa-ai-67",
+            "c2_etp_count": 10.0,
+            "api_entreprise_employees": "20 à 49 salariés"
         }
     },
     {
@@ -42973,7 +42985,10 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:39:02.226Z",
-            "slug": "agate-paysages-39"
+            "slug": "agate-paysages-39",
+            "employees_insertion_count": 180,
+            "employees_permanent_count": 23,
+            "api_entreprise_employees": "20 à 49 salariés"
         }
     },
     {
@@ -50047,7 +50062,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:39:10.686Z",
-            "slug": "assoc-haut-doubs-repassage-25"
+            "slug": "assoc-haut-doubs-repassage-25",
+            "api_entreprise_employees": "20 à 49 salariés"
         }
     },
     {
@@ -66251,7 +66267,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:40:07.981Z",
-            "slug": "resilience-93"
+            "slug": "resilience-93",
+            "api_entreprise_employees": "6 à 9 salariés"
         }
     },
     {
@@ -96165,7 +96182,8 @@
             "source": "ASP",
             "created_at": "2019-12-05T14:37:56.609Z",
             "updated_at": "2020-12-18T10:40:04.581Z",
-            "slug": "envie-autonomie-champagne-ardenne-51"
+            "slug": "envie-autonomie-champagne-ardenne-51",
+            "c2_etp_count": 3.0
         }
     },
     {
@@ -103374,7 +103392,11 @@
             "source": "ASP",
             "created_at": "2020-01-24T09:34:30.036Z",
             "updated_at": "2020-12-18T10:40:08.084Z",
-            "slug": "interinser-62"
+            "slug": "interinser-62",
+            "c2_etp_count": 112.62,
+            "employees_insertion_count": 764,
+            "employees_permanent_count": 28,
+            "api_entreprise_employees": "10 à 19 salariés"
         }
     },
     {

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -350,6 +350,41 @@ class SiaeModelQuerysetTest(TestCase):
         self.assertEqual(siae_queryset.get(id=siae_empty.id).content_filled_basic, False)
         self.assertEqual(siae_queryset.get(id=siae_filled_basic.id).content_filled_basic, True)
 
+    def test_with_employees_count(self):
+        siae_1 = SiaeFactory()
+        siae_2 = SiaeFactory(employees_insertion_count=10)
+        siae_3 = SiaeFactory(c2_etp_count=19.5)
+        siae_4 = SiaeFactory(employees_permanent_count=155)
+        siae_5 = SiaeFactory(employees_insertion_count=22, c2_etp_count=55)
+        siae_6 = SiaeFactory(employees_insertion_count=280, employees_permanent_count=105)
+        siae_7 = SiaeFactory(c2_etp_count=2550, employees_permanent_count=1500)
+        siae_8 = SiaeFactory(employees_insertion_count=125, c2_etp_count=158, employees_permanent_count=88)
+
+        siae_queryset = Siae.objects.with_employees_count()
+        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_insertion_count_with_c2_etp, None)
+        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_count, None)
+
+        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_insertion_count_with_c2_etp, 10)
+        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_count, 10)
+
+        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_insertion_count_with_c2_etp, 20)
+        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_count, 20)
+
+        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_insertion_count_with_c2_etp, None)
+        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_count, 155)
+
+        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_insertion_count_with_c2_etp, 22)
+        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_count, 22)
+
+        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_insertion_count_with_c2_etp, 280)
+        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_count, 280 + 105)
+
+        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_insertion_count_with_c2_etp, 2550)
+        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_count, 2550 + 1500)
+
+        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_insertion_count_with_c2_etp, 125)
+        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_count, 125 + 88)
+
 
 class SiaeModelPerimeterQuerysetTest(TestCase):
     @classmethod

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -145,6 +145,9 @@
                                         <div class="col-12 col-md-6 col-lg-3">
                                             {% bootstrap_field form.legal_form form_group_class="form-group use-multiselect" %}
                                         </div>
+                                        <div class="col-12 col-md-6 col-lg-3">
+                                            {% bootstrap_field form.employees %}
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="row d-lg-none">

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -49,7 +49,13 @@ EMPLOYEES_API_ENTREPRISE_MAPPING = {
     "50-99": ["50 à 99 salariés"],
     "100-249": ["100 à 199 salariés", "200 à 249 salariés"],
     "250-499": ["250 à 499 salariés"],
-    "500-": ["500 à 999 salariés", "1 000 à 1 999 salariés", "2 000 à 4 999 salariés", "5 000 à 9 999 salariés"],
+    "500-": [
+        "500 à 999 salariés",
+        "1 000 à 1 999 salariés",
+        "2 000 à 4 999 salariés",
+        "5 000 à 9 999 salariés",
+        "10 000 salariés et plus",
+    ],
 }
 
 


### PR DESCRIPTION
### Quoi ?

Ajout du filtre "Effectifs"

### Pourquoi ?

Pour permettre aux acheteurs de limiter les résultats de recherche selon les effectifs des prestataires 

### Comment ?

En regardant les champs dans l'ordre : `employees_insertion_count`, `c2_etp_count`, `employees_permanent_count` et `api_entreprise_employees`.

### Captures d'écran

![image](https://github.com/betagouv/itou-marche/assets/17601807/94e45556-cbe4-4a06-8eed-c46c7fb7701b)
