### PR TITLE
Dépôt de besoin : envoyer la date de clôture dans certains e-mails

### DIFF
--- a/lemarche/utils/admin/actions.py
+++ b/lemarche/utils/admin/actions.py
@@ -6,10 +6,7 @@ from django.http import HttpResponse
 from xlwt import Workbook, Worksheet, XFStyle
 
 from lemarche.utils.admin.export_excel import ExportAction
-
-
-def convert_data_date(value):
-    return value.strftime("%d/%m/%Y")
+from lemarche.utils.data import date_to_string
 
 
 def convert_boolean_field(value):
@@ -45,7 +42,7 @@ def export_as_xls(self, request, queryset):
             else:
                 value = getattr(obj, field)
                 if isinstance(value, datetime) or isinstance(value, date):
-                    value = convert_data_date(value)
+                    value = date_to_string(value)
                 elif isinstance(value, bool):
                     value = convert_boolean_field(value)
             find_content_link = re.search(pattern_link, str(value))

--- a/lemarche/utils/data.py
+++ b/lemarche/utils/data.py
@@ -34,3 +34,14 @@ def get_choice(choices, key):
 
 def round_by_base(x, base=5):
     return base * round(x / base)
+
+
+def date_to_string(date, format="%d/%m/%Y"):
+    """
+    datetime.date(2022, 3, 30) --> 30/03/2022
+    datetime.datetime(2022, 3, 24, 15, 8, 5, 965163, tzinfo=datetime.timezone.utc) --> 24/03/2022
+    None, '' --> ''
+    """
+    if date:
+        return date.strftime(format)
+    return ""

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import PartnerShareTender, Tender, TenderSiae
 from lemarche.utils.apis import api_mailjet, api_slack
+from lemarche.utils.data import date_to_string
 from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
 from lemarche.utils.urls import get_admin_url_object, get_share_url_object
 
@@ -87,6 +88,7 @@ def send_tender_email_to_partner(email_subject: str, tender: Tender, partner: Pa
             "TENDER_AUTHOR_COMPANY": tender.author.company_name,
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": get_share_url_object(tender),
         }
 
@@ -132,6 +134,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tender)}?siae_id={siae.id}",
         }
 
@@ -208,6 +211,7 @@ def send_tender_contacted_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
         }
 
@@ -280,6 +284,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
         }
 
@@ -320,6 +325,9 @@ def send_confirmation_published_email_to_author(tender: Tender, nb_matched_siaes
             "TENDER_AUTHOR_FIRST_NAME": tender.author.first_name,
             "TENDER_TITLE": tender.title,
             "TENDER_KIND": tender.get_kind_display(),
+            "TENDER_SECTORS": tender.sectors_list_string(),
+            "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_NB_MATCH": nb_matched_siaes,
             "TENDER_URL": get_share_url_object(tender),
         }


### PR DESCRIPTION
### Quoi ?

Envoyer `TENDER_DEADLINE_DATE` en paramètre de certains e-mails

### Pourquoi ?

Pour pouvoir afficher cette info dans le template mail Mailjet

### A faire aussi

Modifier les templates Mailjet après la MEP