### PR TITLE
Filtre sur l'effectif des prestataires ciblés et intéressés

### DIFF
--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -48,6 +48,9 @@
                                     {% bootstrap_field form.territory %}
                                 </div>
                                 <div class="col-12 col-md-6 col-lg-3">
+                                    {% bootstrap_field form.employees %}
+                                </div>
+                                <div class="col-12 col-md-6 col-lg-3">
                                     <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
                                     <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
                                         <span>Filtrer</span>

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -880,10 +880,17 @@ class TenderSiaeListView(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.siae_1 = SiaeFactory(
-            name="ZZ ESI", kind=siae_constants.KIND_EI, is_qpv=True, city="Grenoble", post_code="38100"
+            name="ZZ ESI",
+            kind=siae_constants.KIND_EI,
+            is_qpv=True,
+            city="Grenoble",
+            post_code="38100",
+            employees_insertion_count=103,
         )
         cls.siae_2 = SiaeFactory(name="ABC Insertion", kind=siae_constants.KIND_EI, city="Grenoble", post_code="38000")
-        cls.siae_3 = SiaeFactory(name="Une autre structure", kind=siae_constants.KIND_ETTI)
+        cls.siae_3 = SiaeFactory(
+            name="Une autre structure", kind=siae_constants.KIND_ETTI, employees_insertion_count=53
+        )
         cls.siae_4 = SiaeFactory(name="Une dernière structure", kind=siae_constants.KIND_ETTI)
         cls.siae_user_1 = UserFactory(kind=User.KIND_SIAE, siaes=[cls.siae_1, cls.siae_2])
         cls.siae_user_2 = UserFactory(kind=User.KIND_SIAE, siaes=[cls.siae_3])
@@ -997,6 +1004,12 @@ class TenderSiaeListView(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["siaes"]), 1)  # email_send_date & QPV
+        # filter by count of employees
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug}) + "?employees=50-99"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["siaes"]), 1)
+        self.assertEqual(response.context["siaes"][0].id, self.siae_3.id)
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default


### PR DESCRIPTION
### Quoi ?

Ajout d'un filtre sur l'effectif dans la liste des prestataires ciblés et intéressés

### Pourquoi ?

Pour permettre aux acheteurs de filtrer les prestataires intéressés par leur dépôt de besoin. 

### Comment ?

Activation du filtre "Effectif" déjà présent dans la recherche des prestataires.

### Captures d'écran

![image](https://github.com/betagouv/itou-marche/assets/17601807/67f33e6c-48f6-4050-a80b-54cde16c8c8b)
