### PR TITLE
Filtre sur le chiffre d'affaires des prestataires ciblés et intéressés

### DIFF
--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -51,6 +51,9 @@
                                     {% bootstrap_field form.employees %}
                                 </div>
                                 <div class="col-12 col-md-6 col-lg-3">
+                                    {% bootstrap_field form.ca %}
+                                </div>
+                                <div class="col-12 col-md-6 col-lg-3">
                                     <span class="mb-2 d-none d-md-inline-block">&nbsp;</span>
                                     <button id="text-search-submit" class="btn btn-primary btn-block btn-ico" type="submit">
                                         <span>Filtrer</span>

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -887,7 +887,9 @@ class TenderSiaeListView(TestCase):
             post_code="38100",
             employees_insertion_count=103,
         )
-        cls.siae_2 = SiaeFactory(name="ABC Insertion", kind=siae_constants.KIND_EI, city="Grenoble", post_code="38000")
+        cls.siae_2 = SiaeFactory(
+            name="ABC Insertion", kind=siae_constants.KIND_EI, city="Grenoble", post_code="38000", ca=276000
+        )
         cls.siae_3 = SiaeFactory(
             name="Une autre structure", kind=siae_constants.KIND_ETTI, employees_insertion_count=53
         )
@@ -1010,6 +1012,12 @@ class TenderSiaeListView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["siaes"]), 1)
         self.assertEqual(response.context["siaes"][0].id, self.siae_3.id)
+        # filter by ca
+        url = reverse("tenders:detail-siae-list", kwargs={"slug": self.tender_1.slug}) + "?ca=100000-500000"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["siaes"]), 1)
+        self.assertEqual(response.context["siaes"][0].id, self.siae_2.id)
 
     def test_order_tender_siae_by_last_detail_contact_click_date(self):
         # TenderSiae are ordered by -created_at by default


### PR DESCRIPTION
### Quoi ?

Ajout d'un filtre sur le chiffre d'affaires dans la liste des prestataires ciblés et intéressés

### Pourquoi ?

Pour permettre aux acheteurs de filtrer les prestataires intéressés par leur dépôt de besoin.

### Comment ?

Activation du filtre "Chiffre d'affaires" déjà présent dans la recherche des prestataires.

### Captures d'écran

![image](https://github.com/betagouv/itou-marche/assets/17601807/10800c7a-e8f8-40e7-9b75-4b9a11aabf21)
