### PR TITLE
Désactivation du cache lors des tests et parallélisation des tests dans la CI

### DIFF
--- a/.github/workflows/linting_testing.yml
+++ b/.github/workflows/linting_testing.yml
@@ -124,5 +124,5 @@ jobs:
         run: |
           source .venv/bin/activate
           python manage.py collectstatic
-          coverage run --source='./lemarche' ./manage.py test
+          coverage run --source='./lemarche' ./manage.py test --parallel
           coverage report

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -27,3 +27,10 @@ HUEY |= {
     "results": True,
     "store_none": True,
 }
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "LOCATION": "django_cache",
+    }
+}


### PR DESCRIPTION
### Quoi ?

- Désactivation du système de cache au niveau de l'ORM durant l'exécution des tests
- Parallélisation des tests dans la CI

### Pourquoi ?

- Pour éviter les erreurs aléatoires lors des tests notamment lors du comptage de structures.
- Pour réduire le temps d'exécution des tests

### Comment ?

- Ajout du backend de cache factice dans le fichier de settings de test.
- Ajout du paramètre `parallel` dans l'action Github
