### PR TITLE
Suppression du chargement du désormais introuvable script js Mailjet

### DIFF
--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -136,9 +136,6 @@
     {% comment "migrate first" %}
     {% include '@CocoricoCore/Frontend/Common/_cookie_consent_js.html.twig' only %}
     {% endcomment %}
-    <!-- Mailjet newsletter -->
-    <data id="mj-w-res-data" data-token="0d87cc6eac81c8037144017a95fdecdb" class="mj-w-data" data-apikey="4guK" data-w-id="KAV" data-lang="fr_FR" data-base="https://app.mailjet.com" data-width="640" data-height="450" data-statics="statics"></data>
-    <script type="text/javascript" type="text/javascript" src="https://app.mailjet.com/statics/js/widget.modal.js"></script>
     {% endblock %}
 
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
### Quoi ?

Suppression du chargement du script javascript pour la popup Mailjet, pour laquel le lien a déjà été supprimé #725 

### Pourquoi ?

Pour éviter un chargement inutile d'autant plus que le script est désormais introuvable (404)

### Comment ?

Suppression de la balise `<script>`.
