### PR TITLE
Tableau de bord : répare les URLs des ressources

### DIFF
--- a/lemarche/templates/dashboard/_ressource_card.html
+++ b/lemarche/templates/dashboard/_ressource_card.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags wagtailcore_tags advert_cms %}
+{% load wagtailcore_tags wagtailimages_tags advert_cms %}
 
 {% if user_kind == "BUYER" %}
     {% cms_advert layout="card" %}
@@ -12,7 +12,7 @@
                 M'informer sur les achats inclusifs
             {% endif %}
         </p>
-        {% for ressource in last_3_ressources %}
+        {% for ressource in ressources %}
             <ul class="list-group list-group-flush list-group-link">
                 <li class="list-group-item list-group-item-action">
                     <div class="d-flex align-items-center">
@@ -26,7 +26,7 @@
                         </picture>
                         <div>
                             <time class="fs-sm d-block" aria-label="Date de publication">{{ ressource.last_published_at }}</time>
-                            <a href="{{ ressource.url_path }}" class="d-block font-weight-bold stretched-link">{{ ressource.title }}</a>
+                            <a href="{% pageurl ressource %}" class="d-block font-weight-bold stretched-link">{{ ressource.title }}</a>
                         </div>
                     </div>
                 </li>
@@ -34,7 +34,7 @@
         {% endfor %}
     </div>
     <div class="card-footer pt-0 bg-white text-right">
-        <a href="/ressources/{% if current_slug_cat %}categories/{{current_slug_cat}}/{% endif %}" class="btn btn-link btn-ico">
+        <a href="/ressources/{% if category_slug %}categories/{{ category_slug }}/{% endif %}" class="btn btn-link btn-ico">
             <span>Voir toutes les ressources</span>
             <i class="ri-arrow-right-s-line ri-xl"></i>
         </a>

--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -179,7 +179,7 @@
                 </div>
             </div>
             <div class="s-section__col col-12 col-lg-7 mb-3 mb-lg-5">
-                {% include "dashboard/_ressource_card.html" with user_kind="BUYER" %}
+                {% include "dashboard/_ressource_card.html" with user_kind="BUYER" ressources=last_3_ressources category_slug=category_slug_cat %}
             </div>
         </div>
         <div class="s-section__row row">

--- a/lemarche/templates/dashboard/home_siae.html
+++ b/lemarche/templates/dashboard/home_siae.html
@@ -116,7 +116,7 @@
                 </div>
             </div>
             <div class="s-section__col col-12 col-lg-6 pb-5">
-                {% include "dashboard/_ressource_card.html" with user_kind="SIAE" %}
+                {% include "dashboard/_ressource_card.html" with user_kind="SIAE" ressources=last_3_ressources category_slug=category_slug_cat %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Quoi ?

Répare l'affichage des URLs wagtail (dans les tableaux de bord)

J'en ai profité pour refactorer un peu : spécifier les variables en dehors du templace `_ressource_card.html`