### PR TITLE
Structures : pouvoir indiquer des notes dans l'admin

### DIFF
--- a/lemarche/notes/tests.py
+++ b/lemarche/notes/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from lemarche.notes.factories import NoteFactory
 from lemarche.notes.models import Note
+from lemarche.siaes.factories import SiaeFactory
 from lemarche.tenders.factories import TenderFactory
 from lemarche.users.factories import UserFactory
 from lemarche.utils import constants
@@ -27,3 +28,14 @@ class NoteModelTest(TestCase):
         # reverse
         self.assertEqual(Note.objects.filter(tender__title=tender.title).count(), 2)
         self.assertEqual(tender.notes.count(), 2)
+
+    def test_create_siae_note_with_generic_relation(self):
+        siae = SiaeFactory()
+        NoteFactory(author=self.user, content_object=siae)
+        self.assertEqual(Note.objects.count(), 2 + 1)
+        # can create multiple notes for the same object
+        NoteFactory(author=self.user, content_object=siae)
+        self.assertEqual(Note.objects.count(), 2 + 1 + 1)
+        # reverse
+        self.assertEqual(Note.objects.filter(siae__name=siae.name).count(), 2)
+        self.assertEqual(siae.notes.count(), 2)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.measure import D
@@ -746,8 +747,8 @@ class Siae(models.Model):
     c1_last_sync_date = models.DateTimeField(blank=True, null=True)
     c1_sync_skip = models.BooleanField(blank=False, null=False, default=False)
 
-    source = models.CharField(max_length=20, choices=SOURCE_CHOICES, default=SOURCE_STAFF_C4_CREATED)
-    import_raw_object = models.JSONField(verbose_name="Donnée JSON brute", editable=False, null=True)
+    # admin
+    notes = GenericRelation("notes.Note", related_query_name="siae")
 
     # stats
     user_count = models.IntegerField("Nombre d'utilisateurs", default=0)
@@ -764,8 +765,9 @@ class Siae(models.Model):
     content_filled_basic_date = models.DateTimeField(
         "Date de remplissage (basique) de la fiche", blank=True, null=True
     )
-
     logs = models.JSONField(verbose_name="Logs historiques", editable=False, default=list)
+    source = models.CharField(max_length=20, choices=SOURCE_CHOICES, default=SOURCE_STAFF_C4_CREATED)
+    import_raw_object = models.JSONField(verbose_name="Donnée JSON brute", editable=False, null=True)
 
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de mise à jour", auto_now=True)


### PR DESCRIPTION
similaire à #845

### Quoi ?

Côté structures dans l'admin, et grâce au nouveau modèle Note, permettre à un admin de pouvoir indiquer 1 ou plusieurs notes.