### PR TITLE
Note : utiliser CKEditor dans l'admin

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -719,23 +719,26 @@ LOGGING = {
 # https://django-ckeditor.readthedocs.io/en/latest/#optional-customizing-ckeditor-editor
 # ------------------------------------------------------------------------------
 
+DEFAULT_CKEDITOR_CONFIG = {
+    "toolbar": "Custom",
+    "toolbar_Custom": [
+        ["Format", "Bold", "Italic", "Underline"],
+        ["NumberedList", "BulletedList"],
+        ["Link", "Unlink"],
+        ["SpecialChar"],
+        # ['HorizontalRule', 'Smiley'],
+        ["Undo", "Redo"],
+        ["Image", "Flash", "Table", "HorizontalRule", "Smiley", "SpecialChar", "Iframe"],
+        ["RemoveFormat", "Source"],
+    ],
+    # avoid special characters encoding
+    "basicEntities": False,
+    "entities": False,
+}
+
 CKEDITOR_CONFIGS = {
-    "default": {
-        "toolbar": "Custom",
-        "toolbar_Custom": [
-            ["Format", "Bold", "Italic", "Underline"],
-            ["NumberedList", "BulletedList"],
-            ["Link", "Unlink"],
-            ["SpecialChar"],
-            # ['HorizontalRule', 'Smiley'],
-            ["Undo", "Redo"],
-            ["Image", "Flash", "Table", "HorizontalRule", "Smiley", "SpecialChar", "Iframe"],
-            ["RemoveFormat", "Source"],
-        ],
-        # avoid special characters encoding
-        "basicEntities": False,
-        "entities": False,
-    }
+    "default": DEFAULT_CKEDITOR_CONFIG,
+    "admin_note_text": DEFAULT_CKEDITOR_CONFIG | {"height": 100},
 }
 
 

--- a/lemarche/notes/admin.py
+++ b/lemarche/notes/admin.py
@@ -1,4 +1,6 @@
+from ckeditor.widgets import CKEditorWidget
 from django.contrib import admin
+from django.db import models
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -21,6 +23,7 @@ class NoteAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
+    formfield_overrides = {models.TextField: {"widget": CKEditorWidget}}
 
     fieldsets = (
         (

--- a/lemarche/notes/admin.py
+++ b/lemarche/notes/admin.py
@@ -23,7 +23,7 @@ class NoteAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
-    formfield_overrides = {models.TextField: {"widget": CKEditorWidget}}
+    formfield_overrides = {models.TextField: {"widget": CKEditorWidget(config_name="admin_note_text")}}
 
     fieldsets = (
         (

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -1,3 +1,4 @@
+from ckeditor.widgets import CKEditorWidget
 from django import forms
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
@@ -84,7 +85,7 @@ class SiaeNoteInline(GenericTabularInline):
     extra = 1
 
     formfield_overrides = {
-        models.TextField: {"widget": forms.Textarea(attrs={"rows": 2})},
+        models.TextField: {"widget": CKEditorWidget(config_name="admin_note_text")},
     }
 
 

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -68,7 +68,7 @@ class TenderNoteInline(GenericTabularInline):
     extra = 1
 
     formfield_overrides = {
-        models.TextField: {"widget": forms.Textarea(attrs={"rows": 2})},
+        models.TextField: {"widget": CKEditorWidget(config_name="admin_note_text")},
     }
 
 

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -1,4 +1,4 @@
-from django import forms
+from ckeditor.widgets import CKEditorWidget
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.contenttypes.admin import GenericTabularInline
@@ -129,7 +129,7 @@ class UserNoteInline(GenericTabularInline):
     extra = 1
 
     formfield_overrides = {
-        models.TextField: {"widget": forms.Textarea(attrs={"rows": 2})},
+        models.TextField: {"widget": CKEditorWidget(config_name="admin_note_text")},
     }
 
 


### PR DESCRIPTION
### Quoi ?

Utiliser le widget proposé par CKEditor.
Ajout d'une config spécifique aux champs "note"

### Pourquoi ?

- pour pouvoir customiser le formattage de la note
- pour ne pas perdre le formattage des notes que l'on importera depuis Hubspot

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/betagouv/itou-marche/assets/7147385/c8a35c62-bfab-45a4-9ab7-0a5d02abe0b6)|![image](https://github.com/betagouv/itou-marche/assets/7147385/ef9ac522-6913-4df9-b635-3c13e47eafc8)|