### PR TITLE
Affichage de manière lisible des message des conversations

### DIFF
--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from lemarche.conversations.models import Conversation
 from lemarche.utils.admin.admin_site import admin_site
-from lemarche.utils.fields import pretty_print_readonly_jsonfield
+from lemarche.utils.fields import print_readonly_jsonfield
 
 
 @admin.register(Conversation, site=admin_site)
@@ -15,7 +15,10 @@ class ConversationAdmin(admin.ModelAdmin):
 
     def data_display(self, conversation: Conversation = None):
         if conversation:
-            return pretty_print_readonly_jsonfield(conversation.data)
+            return print_readonly_jsonfield(conversation.data, id_table="table_filter_data_message")
         return "-"
 
-    data_display.short_description = Conversation._meta.get_field("data").verbose_name
+    class Media:
+        js = ("js/filter_data_message.js",)
+
+    data_display.short_description = "Messages de la conversation"

--- a/lemarche/static/js/filter_data_message.js
+++ b/lemarche/static/js/filter_data_message.js
@@ -1,0 +1,45 @@
+function filterData(data, filterText) {
+    return data.filter(item => {
+        const from = `${item.items[0].From.Name} || ${item.items[0].From.Address}`;
+        const to = item.items[0].To[0].Address;
+        const RawHtmlBody = item.items[0].RawHtmlBody;
+        // filter fields
+        return from.includes(filterText) || to.includes(filterText) || RawHtmlBody.includes(filterText);
+    });
+}
+
+// Fonction pour générer les lignes du tableau HTML
+function generateTableRows(filteredData) {
+    const rows = filteredData.map(item => {
+        const sendAt = new Date(item.items[0].SentAtDate).strftime('%d/%m/%Y %Hh%M');
+        const from = `${item.items[0].From.Name} - ${item.items[0].From.Address}`;
+        const RawHtmlBody = item.items[0].RawHtmlBody;
+
+        return `<tr>
+                    <td>${sendAt}</td>
+                    <td>${from}</td>
+                    <td>${RawHtmlBody}</td>
+                </tr>`;
+    });
+
+    return rows.join('');
+}
+
+function init() {
+    const dataTableBody = document.getElementById('table_filter_data_message');
+    const rawData = JSON.parse(dataTableBody.dataset.data);
+
+    // Filter data
+    // const filterInput = document.getElementsByName('id_data_filter');
+    // const filterText = filterInput.value.trim().toLowerCase();
+    // const filteredData = filterData(rawData, filterText);
+
+    // generate rows
+    const tableRows = generateTableRows(rawData);
+
+    // insert rows
+    dataTableBody.innerHTML = tableRows;
+}
+
+// Appeler la fonction init lorsque la page est chargée
+document.addEventListener('DOMContentLoaded', init);

--- a/lemarche/utils/fields.py
+++ b/lemarche/utils/fields.py
@@ -77,6 +77,20 @@ def pretty_print_readonly_jsonfield(jsonfield_data):
     return result
 
 
+def print_readonly_jsonfield(jsonfield_data, id_table="id-table-body"):
+    """
+    Display a pretty readonly version of a JSONField
+    https://stackoverflow.com/a/60219265
+    """
+    result = ""
+
+    if jsonfield_data:
+        result = json.dumps(jsonfield_data, ensure_ascii=False)
+        result = mark_safe(f'<table id="{id_table}" data-data="{escape(result)}"></table>')
+
+    return result
+
+
 class BooleanNotEmptyField(forms.BooleanField):
     def to_python(self, value):
         if isinstance(value, str) and value.lower() in ("false", "0"):


### PR DESCRIPTION
### Quoi ?

Affichage de manière lisible des message des conversations.

### Comment ?

En manipulant data dans  l'admin en python et JS.

_TODO dans le future : rendre le js plus générique pour mieux adapter dans d'autres cas_
### Captures d'écran (optionnel)

<img width="1660" alt="image" src="https://github.com/betagouv/itou-marche/assets/12339682/83aae228-e989-4b9f-8cf5-99b664028600">

