### PR TITLE
Conversations : utiliser send_mail au lieu de EmailMultiAlternatives

### DIFF
--- a/lemarche/api/emails/views.py
+++ b/lemarche/api/emails/views.py
@@ -29,7 +29,7 @@ class InboundParsingEmailView(APIView):
                 user_kind=user_kind,
                 email_subject=inboundEmail.get("Subject", conv.title),
                 email_body=inboundEmail.get("RawTextBody"),
-                html_email=inboundEmail.get("RawHtmlBody"),
+                email_body_html=inboundEmail.get("RawHtmlBody"),
             )
             return Response(conv.uuid, status=status.HTTP_201_CREATED)
         else:

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -31,11 +31,13 @@ def send_mail_async(
     email_body,
     recipient_list,
     from_email=settings.DEFAULT_FROM_EMAIL,
+    email_body_html=None,
     fail_silently=False,
 ):
     send_mail(
         subject=f"{EMAIL_SUBJECT_PREFIX}{email_subject}",
         message=email_body,
+        html_message=email_body_html,
         from_email=from_email,
         recipient_list=recipient_list,
         fail_silently=fail_silently,

--- a/lemarche/utils/emails.py
+++ b/lemarche/utils/emails.py
@@ -1,7 +1,7 @@
 import re
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives, send_mail
+from django.core.mail import send_mail
 from huey.contrib.djhuey import task
 
 
@@ -40,12 +40,3 @@ def send_mail_async(
         recipient_list=recipient_list,
         fail_silently=fail_silently,
     )
-
-
-@task()
-def send_email_html(email_subject, from_email, recipient_list, html_email=None, email_body=None):
-    email_subject = f"{EMAIL_SUBJECT_PREFIX}{email_subject}"
-    email_message = EmailMultiAlternatives(email_subject, email_body, from_email, recipient_list)
-    if html_email:
-        email_message.attach_alternative(html_email, "text/html")
-    return email_message.send()

--- a/lemarche/www/conversations/tasks.py
+++ b/lemarche/www/conversations/tasks.py
@@ -1,36 +1,41 @@
+from django.core.mail import send_mail
+
 from lemarche.conversations.models import Conversation
 from lemarche.siaes.models import Siae
-from lemarche.utils.emails import send_email_html, whitelist_recipient_list
+from lemarche.utils.emails import whitelist_recipient_list
 
 
 def send_first_email_from_conversation(conv: Conversation):
     siae: Siae = conv.siae
-    send_email_html(
-        recipient_list=whitelist_recipient_list([siae.contact_email]),
-        email_subject=conv.title,
-        email_body=conv.initial_body_message,
+    send_mail(
+        subject=conv.title,
+        message=conv.initial_body_message,
         from_email=conv.email_sender_buyer_encoded,
+        recipient_list=whitelist_recipient_list([siae.contact_email]),
+        fail_silently=False,
     )
 
 
 def send_email_from_conversation(
-    conv: Conversation, user_kind: str, email_subject: str, email_body: str, html_email: str
+    conv: Conversation, user_kind: str, email_subject: str, email_body: str, email_body_html: str
 ):
     if user_kind == Conversation.USER_KIND_SENDER_TO_SIAE:
-        send_email_html(
-            recipient_list=whitelist_recipient_list([conv.email_sender_siae]),
-            email_subject=email_subject,
-            email_body=email_body,
-            html_email=html_email,
+        send_mail(
+            subject=email_subject,
+            message=email_body,
+            html_message=email_body_html if email_body_html else None,
             from_email=conv.email_sender_buyer_encoded,
+            recipient_list=whitelist_recipient_list([conv.email_sender_siae]),
+            fail_silently=False,
         )
     elif user_kind == Conversation.USER_KIND_SENDER_TO_BUYER:
-        send_email_html(
-            recipient_list=whitelist_recipient_list([conv.email_sender_buyer]),
-            email_subject=email_subject,
-            email_body=email_body,
-            html_email=html_email,
+        send_mail(
+            subject=email_subject,
+            message=email_body,
+            html_message=email_body_html if email_body_html else None,
             from_email=conv.email_sender_siae_encoded,
+            recipient_list=whitelist_recipient_list([conv.email_sender_buyer]),
+            fail_silently=False,
         )
     # api_brevo.send_transactionnel_email(
     #     to={"email": siae.contact_email, "name": siae.contact_full_name},

--- a/lemarche/www/conversations/tasks.py
+++ b/lemarche/www/conversations/tasks.py
@@ -1,18 +1,15 @@
-from django.core.mail import send_mail
-
 from lemarche.conversations.models import Conversation
 from lemarche.siaes.models import Siae
-from lemarche.utils.emails import whitelist_recipient_list
+from lemarche.utils.emails import send_mail_async, whitelist_recipient_list
 
 
 def send_first_email_from_conversation(conv: Conversation):
     siae: Siae = conv.siae
-    send_mail(
-        subject=conv.title,
-        message=conv.initial_body_message,
-        from_email=conv.email_sender_buyer_encoded,
+    send_mail_async(
+        email_subject=conv.title,
+        email_body=conv.initial_body_message,
         recipient_list=whitelist_recipient_list([siae.contact_email]),
-        fail_silently=False,
+        from_email=conv.email_sender_buyer_encoded,
     )
 
 
@@ -20,22 +17,20 @@ def send_email_from_conversation(
     conv: Conversation, user_kind: str, email_subject: str, email_body: str, email_body_html: str
 ):
     if user_kind == Conversation.USER_KIND_SENDER_TO_SIAE:
-        send_mail(
-            subject=email_subject,
-            message=email_body,
-            html_message=email_body_html,
-            from_email=conv.email_sender_buyer_encoded,
+        send_mail_async(
+            email_subject=email_subject,
+            email_body=email_body,
             recipient_list=whitelist_recipient_list([conv.email_sender_siae]),
-            fail_silently=False,
+            from_email=conv.email_sender_buyer_encoded,
+            email_body_html=email_body_html,
         )
     elif user_kind == Conversation.USER_KIND_SENDER_TO_BUYER:
-        send_mail(
-            subject=email_subject,
-            message=email_body,
-            html_message=email_body_html,
-            from_email=conv.email_sender_siae_encoded,
+        send_mail_async(
+            email_subject=email_subject,
+            email_body=email_body,
             recipient_list=whitelist_recipient_list([conv.email_sender_buyer]),
-            fail_silently=False,
+            from_email=conv.email_sender_siae_encoded,
+            email_body_html=email_body_html,
         )
     # api_brevo.send_transactionnel_email(
     #     to={"email": siae.contact_email, "name": siae.contact_full_name},

--- a/lemarche/www/conversations/tasks.py
+++ b/lemarche/www/conversations/tasks.py
@@ -23,7 +23,7 @@ def send_email_from_conversation(
         send_mail(
             subject=email_subject,
             message=email_body,
-            html_message=email_body_html if email_body_html else None,
+            html_message=email_body_html,
             from_email=conv.email_sender_buyer_encoded,
             recipient_list=whitelist_recipient_list([conv.email_sender_siae]),
             fail_silently=False,
@@ -32,7 +32,7 @@ def send_email_from_conversation(
         send_mail(
             subject=email_subject,
             message=email_body,
-            html_message=email_body_html if email_body_html else None,
+            html_message=email_body_html,
             from_email=conv.email_sender_siae_encoded,
             recipient_list=whitelist_recipient_list([conv.email_sender_buyer]),
             fail_silently=False,


### PR DESCRIPTION
### Quoi ?

Utilise https://docs.djangoproject.com/en/4.2/topics/email/#send-mail

Permet de résoudre les problèmes d'envois lorsque le body n'est pas du HTML