### PR TITLE
Conversations : améliorer l'affichage admin

### DIFF
--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -9,8 +9,8 @@ from lemarche.utils.fields import pretty_print_readonly_jsonfield_to_table
 class ConversationAdmin(admin.ModelAdmin):
     list_display = ["id", "uuid", "title", "kind", "created_at"]
     list_filter = ["kind"]
-    search_fields = ["id", "uuid"]
-    search_help_text = "Cherche sur les champs : ID, UUID"
+    search_fields = ["id", "uuid", "sender_email"]
+    search_help_text = "Cherche sur les champs : ID, UUID, Initiateur (E-mail)"
 
     exclude = ["data"]
     readonly_fields = [

--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -7,7 +7,7 @@ from lemarche.utils.fields import pretty_print_readonly_jsonfield_to_table
 
 @admin.register(Conversation, site=admin_site)
 class ConversationAdmin(admin.ModelAdmin):
-    list_display = ["id", "title", "uuid", "kind", "created_at"]
+    list_display = ["id", "uuid", "title", "kind", "created_at"]
     list_filter = ["kind"]
     search_fields = ["id", "uuid"]
     search_help_text = "Cherche sur les champs : ID, UUID"

--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -5,10 +5,28 @@ from lemarche.utils.admin.admin_site import admin_site
 from lemarche.utils.fields import pretty_print_readonly_jsonfield_to_table
 
 
+class HasAnswerFilter(admin.SimpleListFilter):
+    """Custom admin filter to target conversations who have an answer."""
+
+    title = "Avec réponse ?"
+    parameter_name = "has_answer"
+
+    def lookups(self, request, model_admin):
+        return (("Yes", "Oui"), ("No", "Non"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "Yes":
+            return queryset.has_answer()
+        elif value == "No":
+            return queryset.filter(data=[])
+        return queryset
+
+
 @admin.register(Conversation, site=admin_site)
 class ConversationAdmin(admin.ModelAdmin):
     list_display = ["id", "uuid", "title", "kind", "answer_count", "created_at"]
-    list_filter = ["kind"]
+    list_filter = ["kind", HasAnswerFilter]
     search_fields = ["id", "uuid", "sender_email"]
     search_help_text = "Cherche sur les champs : ID, UUID, Initiateur (E-mail)"
 

--- a/lemarche/conversations/models.py
+++ b/lemarche/conversations/models.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.db import models
+from django.db.models import Func, IntegerField
 from django.utils import timezone
 from django_extensions.db.fields import ShortUUIDField
 from shortuuid import uuid
 
 
 class ConversationQuerySet(models.QuerySet):
-    pass
+    def with_answer_count(self):
+        return self.annotate(answer_count=Func("data", function="jsonb_array_length", output_field=IntegerField()))
 
 
 class Conversation(models.Model):

--- a/lemarche/conversations/models.py
+++ b/lemarche/conversations/models.py
@@ -7,6 +7,9 @@ from shortuuid import uuid
 
 
 class ConversationQuerySet(models.QuerySet):
+    def has_answer(self):
+        return self.exclude(data=[])
+
     def with_answer_count(self):
         return self.annotate(answer_count=Func("data", function="jsonb_array_length", output_field=IntegerField()))
 

--- a/lemarche/conversations/tests.py
+++ b/lemarche/conversations/tests.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+
+from lemarche.conversations.factories import ConversationFactory
+from lemarche.conversations.models import Conversation
+
+
+class ConversationModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.conversation = ConversationFactory(title="Je souhaite me renseigner")
+
+    def test_count(self):
+        self.assertEqual(Conversation.objects.count(), 1)
+
+    def test_uuid_field(self):
+        self.assertEqual(len(self.conversation.uuid), 22)
+
+    def test_str(self):
+        self.assertEqual(str(self.conversation), "Je souhaite me renseigner")
+
+
+class ConversationQuerysetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.conversation = ConversationFactory()
+        cls.conversation_with_answer = ConversationFactory(
+            data=[{"items": [{"To": [{"Name": "buyer"}], "From": {"Name": "siae"}}]}]
+        )
+
+    def test_has_answer(self):
+        self.assertEqual(Conversation.objects.has_answer().count(), 1)
+
+    def test_with_answer_count(self):
+        conversation_queryset = Conversation.objects.with_answer_count()
+        self.assertEqual(conversation_queryset.get(id=self.conversation.id).answer_count, 0)
+        self.assertEqual(conversation_queryset.get(id=self.conversation_with_answer.id).answer_count, 1)


### PR DESCRIPTION
### Quoi ?

- mettre le uuid à gauche du titre
- afficher le nombre de réponses
- chercher par sender_email
- filtre par répondu ou pas
- queryset, tests

### Captures d'écran

||Image|
|---|---|
|Avant|![image](https://github.com/betagouv/itou-marche/assets/7147385/92dc946d-03f9-4417-ab51-664842aad76d)|
|Après|![image](https://github.com/betagouv/itou-marche/assets/7147385/d2fd1788-96e1-4914-a1fb-409fcd9ba783)|