### PR TITLE
Refactoring : séparer Dashboard & Networks

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("besoins/", include("lemarche.www.tenders.urls")),
     path("prestataires/", include("lemarche.www.siaes.urls")),
     path("profil/", include("lemarche.www.dashboard.urls")),
+    path("profil/reseaux/", include("lemarche.www.dashboard_networks.urls")),
     path("profil/listes-dachats/", include("lemarche.www.dashboard_favorites.urls")),
     path("select2/", include("django_select2.urls")),
     # admin blog

--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -124,7 +124,7 @@
                             </div>
                         </div>
                         <div class="card-footer pt-0 bg-white text-right">
-                            <a href="{% url 'dashboard:profile_network_detail' user.partner_network.slug %}" id="dashboard_network_detail" class="btn btn-link btn-ico">
+                            <a href="{% url 'dashboard_networks:detail' user.partner_network.slug %}" id="dashboard_network_detail" class="btn btn-link btn-ico">
                                 <span>Animer mon réseau</span>
                                 <i class="ri-arrow-right-s-line ri-xl"></i>
                             </a>

--- a/lemarche/templates/networks/dashboard_network_detail.html
+++ b/lemarche/templates/networks/dashboard_network_detail.html
@@ -48,7 +48,7 @@
                         </p>
                     </div>
                     <div class="card-footer pt-0 bg-white text-right">
-                        <a href="{% url 'dashboard:profile_network_siae_list' network.slug %}" id="dashboard-network-siae-list-btn" class="btn btn-link btn-ico">
+                        <a href="{% url 'dashboard_networks:siae_list' network.slug %}" id="dashboard-network-siae-list-btn" class="btn btn-link btn-ico">
                             <span>Voir la liste</span>
                             <i class="ri-arrow-right-s-line ri-xl"></i>
                         </a>
@@ -67,7 +67,7 @@
                         </p>
                     </div>
                     <div class="card-footer pt-0 bg-white text-right">
-                        <a href="{% url 'dashboard:profile_network_tender_list' network.slug %}" id="dashboard-network-tender-list-btn" class="btn btn-link btn-ico">
+                        <a href="{% url 'dashboard_networks:tender_list' network.slug %}" id="dashboard-network-tender-list-btn" class="btn btn-link btn-ico">
                             <span>Voir les opportunités</span>
                             <i class="ri-arrow-right-s-line ri-xl"></i>
                         </a>

--- a/lemarche/templates/networks/dashboard_network_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_list.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Mes adhérents</li>
                     </ol>
                 </nav>
@@ -86,21 +86,21 @@
                                 </td>
                                 <td>
                                     {% if siae.tender_email_send_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues" id="dashboard-network-siae-show-tender-email-send-list-btn">{{ siae.tender_email_send_count }}</a>
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues" id="dashboard-network-siae-show-tender-email-send-list-btn">{{ siae.tender_email_send_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_display_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues" id="dashboard-network-siae-show-tender-detail-display-list-btn">{{ siae.tender_detail_display_count }}</a>
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues" id="dashboard-network-siae-show-tender-detail-display-list-btn">{{ siae.tender_detail_display_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if siae.tender_detail_contact_click_count > 0 %}
-                                        <a href="{% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées" id="dashboard-network-siae-show-tender-detail-contact-click-list-btn">{{ siae.tender_detail_contact_click_count }}</a>
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées" id="dashboard-network-siae-show-tender-detail-contact-click-list-btn">{{ siae.tender_detail_contact_click_count }}</a>
                                     {% else %}
                                         0
                                     {% endif %}

--- a/lemarche/templates/networks/dashboard_network_siae_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_tender_list.html
@@ -12,8 +12,8 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_siae_list' network.slug %}">Mes adhérents</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:siae_list' network.slug %}">Mes adhérents</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ siae.name_display }}">{{ siae.name_display|truncatechars:25 }}</li>
                     </ol>
                 </nav>
@@ -37,9 +37,9 @@
                 {% block htmx %}
                 <div id="siaeTenderList">
                     <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
-                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug as NETWORK_SIAE_TENDER_LIST_URL %}
-                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "DISPLAY" as NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
-                        {% url 'dashboard:profile_network_siae_tender_list' network.slug siae.slug "CONTACT-CLICK" as NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
+                        {% url 'dashboard_networks:siae_tender_list' network.slug siae.slug as NETWORK_SIAE_TENDER_LIST_URL %}
+                        {% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "DISPLAY" as NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %}
+                        {% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "CONTACT-CLICK" as NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %}
                         <li class="nav-item">
                             <a role="button" hx-push-url="true" hx-get="{{ NETWORK_SIAE_TENDER_LIST_URL }}"
                                 class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"

--- a/lemarche/templates/networks/dashboard_network_tender_detail.html
+++ b/lemarche/templates/networks/dashboard_network_tender_detail.html
@@ -12,8 +12,8 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_list' network.slug %}">Opportunités commerciales</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:tender_list' network.slug %}">Opportunités commerciales</a></li>
                         <li class="breadcrumb-item active" aria-current="page" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</li>
                     </ol>
                 </nav>
@@ -32,11 +32,11 @@
             </div>
             {# Sidebar "actions" #}
             <div class="col-12 col-lg-4 order-1 order-lg-2">
-                <a href="{% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug %}" id="show-tender-siae-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
+                <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug %}" id="show-tender-siae-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
                     <i class="ri-focus-2-line"></i>
                     {{ tender.network_siae_email_send_count }} adhérent{{ tender.network_siae_email_send_count|pluralize }} notifié{{ tender.network_siae_email_send_count|pluralize }}
                 </a>
-                <a href="{% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug "CONTACT-CLICK" %}" id="show-tender-siae-interested-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
+                <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug "CONTACT-CLICK" %}" id="show-tender-siae-interested-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
                     <i class="ri-thumb-up-line"></i>
                     {{ tender.network_siae_detail_contact_click_count }} adhérent{{ tender.network_siae_detail_contact_click_count|pluralize }} intéressé{{ tender.network_siae_detail_contact_click_count|pluralize }}
                 </a>

--- a/lemarche/templates/networks/dashboard_network_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_list.html
@@ -12,7 +12,7 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Opportunités commerciales</li>
                     </ol>
                 </nav>

--- a/lemarche/templates/networks/dashboard_network_tender_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_siae_list.html
@@ -12,9 +12,9 @@
                     <ol class="breadcrumb">
                         <li class="breadcrumb-item"><a href="{% url 'wagtail_serve' '' %}">Accueil</a></li>
                         <li class="breadcrumb-item"><a href="{% url 'dashboard:home' %}">Tableau de bord</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_detail' network.slug %}">Mon réseau</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_list' network.slug %}">Opportunités commerciales</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:profile_network_tender_detail' network.slug tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:detail' network.slug %}">Mon réseau</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:tender_list' network.slug %}">Opportunités commerciales</a></li>
+                        <li class="breadcrumb-item"><a href="{% url 'dashboard_networks:tender_detail' network.slug tender.slug %}" title="{{ tender.title }}">{{ tender.title|truncatechars:25 }}</a></li>
                         <li class="breadcrumb-item active" aria-current="page">Adhérents notifiés</li>
                     </ol>
                 </nav>
@@ -38,8 +38,8 @@
                 {% block htmx %}
                 <div id="siaeTenderList">
                     <ul role="navigation" class="nav nav-tabs nav-tabs--marche">
-                        {% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug as NETWORK_TENDER_SIAE_LIST_URL %}
-                        {% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug "CONTACT-CLICK" as NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %}
+                        {% url 'dashboard_networks:tender_siae_list' network.slug tender.slug as NETWORK_TENDER_SIAE_LIST_URL %}
+                        {% url 'dashboard_networks:tender_siae_list' network.slug tender.slug "CONTACT-CLICK" as NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %}
                         <li class="nav-item">
                             <a role="button" hx-push-url="true" hx-get="{{ NETWORK_TENDER_SIAE_LIST_URL }}"
                                 class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %} active{% endif %}"

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -1,6 +1,6 @@
 {% load static humanize %}
 
-<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'dashboard:profile_network_tender_detail' network.slug tender.slug %}">
+<div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'dashboard_networks:tender_detail' network.slug tender.slug %}">
     <div class="card-body">
         <div class="row">
             <div class="col-md-8" style="border-right:1px solid;">
@@ -51,7 +51,7 @@
                             <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} notifié{{ tender.network_siae_email_send_count|pluralize }}
                         </p>
                         {% if tender.network_siae_email_send_count %}
-                            <a href="{% url 'dashboard:profile_network_tender_siae_list' network.slug tender.slug %}" id="dashboard-network-tender-show-siae-list-btn" class="btn btn-sm btn-primary">
+                            <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug %}" id="dashboard-network-tender-show-siae-list-btn" class="btn btn-sm btn-primary">
                                 Voir la liste
                             </a>
                         {% endif %}

--- a/lemarche/www/dashboard/tests.py
+++ b/lemarche/www/dashboard/tests.py
@@ -268,11 +268,11 @@ class DashboardNetworkViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.DASHBOARD_NETWORK_URLS = [
-            "dashboard:profile_network_detail",
-            "dashboard:profile_network_siae_list",
-            "dashboard:profile_network_tender_list",
-            # "dashboard:profile_network_tender_detail"
-            # "dashboard:profile_network_siae_tender_list"
+            "dashboard_networks:detail",
+            "dashboard_networks:siae_list",
+            "dashboard_networks:tender_list",
+            # "dashboard_networks:tender_detail"
+            # "dashboard_networks:siae_tender_list"
         ]
         cls.network_1 = NetworkFactory(name="Liste 1")
         cls.network_2 = NetworkFactory(name="Liste 2")
@@ -321,27 +321,27 @@ class DashboardNetworkViewTest(TestCase):
 
     def test_siae_list_in_network_siae_list(self):
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_siae_list", args=[self.network_1.slug])
+        url = reverse("dashboard_networks:siae_list", args=[self.network_1.slug])
         response = self.client.get(url)
         self.assertContains(response, self.siae_1.name_display)
         self.assertNotContains(response, self.siae_2.name_display)
 
     def test_only_network_siaes_can_display_network_siae_tender_list(self):
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_siae_tender_list", args=[self.network_1.slug, self.siae_1.slug])
+        url = reverse("dashboard_networks:siae_tender_list", args=[self.network_1.slug, self.siae_1.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.tender_1.title)
         # siae_2 not linked to network
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_siae_tender_list", args=[self.network_1.slug, self.siae_2.slug])
+        url = reverse("dashboard_networks:siae_tender_list", args=[self.network_1.slug, self.siae_2.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, f"/profil/reseaux/{self.network_1.slug}/prestataires/")
 
     def test_tender_list_in_network_tender_list(self):
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_tender_list", args=[self.network_1.slug])
+        url = reverse("dashboard_networks:tender_list", args=[self.network_1.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.tender_1.title)
@@ -350,7 +350,7 @@ class DashboardNetworkViewTest(TestCase):
 
     def test_tender_detail_in_network_tender_detail(self):
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_tender_detail", args=[self.network_1.slug, self.tender_1.slug])
+        url = reverse("dashboard_networks:tender_detail", args=[self.network_1.slug, self.tender_1.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.tender_1.title)
@@ -360,7 +360,7 @@ class DashboardNetworkViewTest(TestCase):
 
     def test_network_siae_list_in_network_tender_siae_list(self):
         self.client.force_login(self.user_network_1)
-        url = reverse("dashboard:profile_network_tender_siae_list", args=[self.network_1.slug, self.tender_1.slug])
+        url = reverse("dashboard_networks:tender_siae_list", args=[self.network_1.slug, self.tender_1.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.siae_1.name_display)

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -4,12 +4,6 @@ from django.views.generic.base import RedirectView
 from lemarche.www.dashboard.views import (
     DashboardHomeView,
     ProfileEditView,
-    ProfileNetworkDetailView,
-    ProfileNetworkSiaeListView,
-    ProfileNetworkSiaeTenderListView,
-    ProfileNetworkTenderDetailView,
-    ProfileNetworkTenderListView,
-    ProfileNetworkTenderSiaeListView,
     SiaeEditContactView,
     SiaeEditInfoView,
     SiaeEditLinksView,
@@ -32,34 +26,7 @@ urlpatterns = [
     # FavoriteList
     # see dashboard_favorites/urls.py
     # Network
-    path("reseaux/<str:slug>/", ProfileNetworkDetailView.as_view(), name="profile_network_detail"),
-    path("reseaux/<str:slug>/prestataires/", ProfileNetworkSiaeListView.as_view(), name="profile_network_siae_list"),
-    path(
-        "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/<status>",
-        ProfileNetworkSiaeTenderListView.as_view(),
-        name="profile_network_siae_tender_list",
-    ),
-    path(
-        "reseaux/<str:slug>/prestataires/<slug:siae_slug>/besoins/",
-        ProfileNetworkSiaeTenderListView.as_view(),
-        name="profile_network_siae_tender_list",
-    ),
-    path("reseaux/<str:slug>/besoins/", ProfileNetworkTenderListView.as_view(), name="profile_network_tender_list"),
-    path(
-        "reseaux/<str:slug>/besoins/<slug:tender_slug>/prestataires/<status>",
-        ProfileNetworkTenderSiaeListView.as_view(),
-        name="profile_network_tender_siae_list",
-    ),
-    path(
-        "reseaux/<str:slug>/besoins/<slug:tender_slug>/prestataires/",
-        ProfileNetworkTenderSiaeListView.as_view(),
-        name="profile_network_tender_siae_list",
-    ),
-    path(
-        "reseaux/<str:slug>/besoins/<slug:tender_slug>/",
-        ProfileNetworkTenderDetailView.as_view(),
-        name="profile_network_tender_detail",
-    ),
+    # see dashboard_networks/urls.py
     # Adopt Siae
     path("prestataires/rechercher/", SiaeSearchBySiretView.as_view(), name="siae_search_by_siret"),
     path("prestataires/<str:slug>/adopter/", SiaeSearchAdoptConfirmView.as_view(), name="siae_search_adopt_confirm"),

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -1,9 +1,8 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
-from django.core.paginator import Paginator
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -12,16 +11,10 @@ from django.views.generic.edit import FormMixin
 
 from lemarche.cms.models import ArticlePage
 from lemarche.cms.snippets import ArticleCategory
-from lemarche.networks.models import Network
 from lemarche.siaes.models import Siae, SiaeUser, SiaeUserRequest
-from lemarche.tenders.models import Tender, TenderSiae
+from lemarche.tenders.models import Tender
 from lemarche.users.models import User
-from lemarche.utils.mixins import (
-    NetworkMemberRequiredMixin,
-    SiaeMemberRequiredMixin,
-    SiaeUserAndNotMemberRequiredMixin,
-    SiaeUserRequiredMixin,
-)
+from lemarche.utils.mixins import SiaeMemberRequiredMixin, SiaeUserAndNotMemberRequiredMixin, SiaeUserRequiredMixin
 from lemarche.utils.s3 import S3Upload
 from lemarche.www.dashboard.forms import (
     ProfileEditForm,
@@ -42,7 +35,6 @@ from lemarche.www.dashboard.tasks import (
     send_siae_user_request_email_to_assignee,
     send_siae_user_request_response_email_to_initiator,
 )
-from lemarche.www.siaes.forms import NetworkSiaeFilterForm
 
 
 SLUG_RESSOURCES_CAT_SIAES = "solutions"
@@ -115,159 +107,6 @@ class ProfileEditView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
 
     def get_object(self):
         return self.request.user
-
-
-class ProfileNetworkDetailView(NetworkMemberRequiredMixin, DetailView):
-    template_name = "dashboard/profile_network_detail.html"
-    queryset = Network.objects.prefetch_related("siaes").all()
-    context_object_name = "network"
-
-
-class ProfileNetworkSiaeListView(NetworkMemberRequiredMixin, FormMixin, ListView):
-    template_name = "dashboard/profile_network_siae_list.html"
-    form_class = NetworkSiaeFilterForm
-    queryset = Siae.objects.prefetch_related("networks").all()
-    context_object_name = "siaes"
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        # first get the network's siaes
-        self.network = Network.objects.get(slug=self.kwargs.get("slug"))
-        qs = qs.filter(networks__in=[self.network]).with_tender_stats().annotate_with_brand_or_name(with_order_by=True)
-        # then filter with the form
-        self.filter_form = NetworkSiaeFilterForm(data=self.request.GET)
-        qs = self.filter_form.filter_queryset(qs)
-        return qs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["network"] = self.network
-        siae_search_form = self.filter_form if self.filter_form else NetworkSiaeFilterForm(data=self.request.GET)
-        context["form"] = siae_search_form
-        return context
-
-
-class ProfileNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
-    template_name = "dashboard/profile_network_siae_tender_list.html"
-    queryset = TenderSiae.objects.select_related("tender", "siae").all()
-    context_object_name = "tendersiaes"
-    status = None
-
-    def get(self, request, status=None, *args, **kwargs):
-        """
-        - check that both the Siae & the Network exist
-        - check that the Siae belongs to the Network
-        """
-        self.status = status
-        if "slug" in self.kwargs:
-            self.network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
-            if "siae_slug" in self.kwargs:
-                self.siae = get_object_or_404(Siae.objects.with_tender_stats(), slug=self.kwargs.get("siae_slug"))
-                if self.siae not in self.network.siaes.all():
-                    return redirect("dashboard:profile_network_siae_list", slug=self.network.slug)
-        return super().get(request, *args, **kwargs)
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        qs = qs.filter(siae=self.siae)
-        if self.status:
-            if self.status == "DISPLAY":
-                qs = qs.filter(detail_display_date__isnull=False)
-            elif self.status == "CONTACT-CLICK":
-                qs = qs.filter(detail_contact_click_date__isnull=False)
-        else:  # default
-            qs = qs.filter(email_send_date__isnull=False)
-        return qs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["network"] = self.network
-        context["siae"] = self.siae
-        return context
-
-
-class ProfileNetworkTenderListView(NetworkMemberRequiredMixin, ListView):
-    template_name = "dashboard/profile_network_tender_list.html"
-    queryset = Tender.objects.all()
-    context_object_name = "tenders"
-    paginate_by = 10
-    paginator_class = Paginator
-
-    def get(self, request, *args, **kwargs):
-        # self.network = self.get_object()
-        self.network = Network.objects.prefetch_related("siaes").get(slug=self.kwargs.get("slug"))
-        self.network_siaes = self.network.siaes.all()
-        return super().get(request, *args, **kwargs)
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        qs = qs.prefetch_many_to_many().select_foreign_keys()
-        qs = qs.filter_with_siaes(self.network_siaes)
-        qs = qs.with_network_siae_stats(self.network_siaes)
-        qs = qs.order_by_deadline_date()
-        return qs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["network"] = self.network
-        return context
-
-
-class ProfileNetworkTenderDetailView(NetworkMemberRequiredMixin, DetailView):
-    model = Tender
-    template_name = "dashboard/profile_network_tender_detail.html"
-    context_object_name = "tender"
-
-    def get_object(self):
-        self.network = Network.objects.prefetch_related("siaes").get(slug=self.kwargs.get("slug"))
-        self.network_siaes = self.network.siaes.all()
-        self.tender = get_object_or_404(
-            Tender.objects.validated().with_network_siae_stats(self.network_siaes),
-            slug=self.kwargs.get("tender_slug"),
-        )
-        return self.tender
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["network"] = self.network
-        return context
-
-
-class ProfileNetworkTenderSiaeListView(NetworkMemberRequiredMixin, ListView):
-    template_name = "dashboard/profile_network_tender_siae_list.html"
-    queryset = TenderSiae.objects.select_related("tender", "siae").all()
-    context_object_name = "tendersiaes"
-    status = None
-
-    def get(self, request, status=None, *args, **kwargs):
-        """
-        - fetch the Network & the Tender
-        """
-        self.status = status
-        if "slug" in self.kwargs:
-            self.network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
-            if "tender_slug" in self.kwargs:
-                self.network_siaes = self.network.siaes.all()
-                self.tender = get_object_or_404(
-                    Tender.objects.validated().with_network_siae_stats(self.network_siaes),
-                    slug=self.kwargs.get("tender_slug"),
-                )
-        return super().get(request, *args, **kwargs)
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        qs = qs.filter(tender=self.tender).filter(email_send_date__isnull=False)
-        qs = qs.filter(siae__in=self.network.siaes.all())
-        if self.status:
-            if self.status == "CONTACT-CLICK":
-                qs = qs.filter(detail_contact_click_date__isnull=False)
-        return qs
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["network"] = self.network
-        context["tender"] = self.tender
-        return context
 
 
 class SiaeSearchBySiretView(SiaeUserRequiredMixin, FormMixin, ListView):

--- a/lemarche/www/dashboard_networks/urls.py
+++ b/lemarche/www/dashboard_networks/urls.py
@@ -1,0 +1,44 @@
+from django.urls import path
+
+from lemarche.www.dashboard_networks.views import (
+    DashboardNetworkDetailView,
+    DashboardNetworkSiaeListView,
+    DashboardNetworkSiaeTenderListView,
+    DashboardNetworkTenderDetailView,
+    DashboardNetworkTenderListView,
+    DashboardNetworkTenderSiaeListView,
+)
+
+
+app_name = "dashboard_networks"
+
+urlpatterns = [
+    path("<str:slug>/", DashboardNetworkDetailView.as_view(), name="detail"),
+    path("<str:slug>/prestataires/", DashboardNetworkSiaeListView.as_view(), name="siae_list"),
+    path(
+        "<str:slug>/prestataires/<slug:siae_slug>/besoins/<status>",
+        DashboardNetworkSiaeTenderListView.as_view(),
+        name="siae_tender_list",
+    ),
+    path(
+        "<str:slug>/prestataires/<slug:siae_slug>/besoins/",
+        DashboardNetworkSiaeTenderListView.as_view(),
+        name="siae_tender_list",
+    ),
+    path("<str:slug>/besoins/", DashboardNetworkTenderListView.as_view(), name="tender_list"),
+    path(
+        "<str:slug>/besoins/<slug:tender_slug>/prestataires/<status>",
+        DashboardNetworkTenderSiaeListView.as_view(),
+        name="tender_siae_list",
+    ),
+    path(
+        "<str:slug>/besoins/<slug:tender_slug>/prestataires/",
+        DashboardNetworkTenderSiaeListView.as_view(),
+        name="tender_siae_list",
+    ),
+    path(
+        "<str:slug>/besoins/<slug:tender_slug>/",
+        DashboardNetworkTenderDetailView.as_view(),
+        name="tender_detail",
+    ),
+]

--- a/lemarche/www/dashboard_networks/views.py
+++ b/lemarche/www/dashboard_networks/views.py
@@ -1,0 +1,163 @@
+from django.core.paginator import Paginator
+from django.shortcuts import get_object_or_404, redirect
+from django.views.generic import DetailView, ListView
+from django.views.generic.edit import FormMixin
+
+from lemarche.networks.models import Network
+from lemarche.siaes.models import Siae
+from lemarche.tenders.models import Tender, TenderSiae
+from lemarche.utils.mixins import NetworkMemberRequiredMixin
+from lemarche.www.siaes.forms import NetworkSiaeFilterForm
+
+
+class DashboardNetworkDetailView(NetworkMemberRequiredMixin, DetailView):
+    template_name = "networks/dashboard_network_detail.html"
+    queryset = Network.objects.prefetch_related("siaes").all()
+    context_object_name = "network"
+
+
+class DashboardNetworkSiaeListView(NetworkMemberRequiredMixin, FormMixin, ListView):
+    template_name = "networks/dashboard_network_siae_list.html"
+    form_class = NetworkSiaeFilterForm
+    queryset = Siae.objects.prefetch_related("networks").all()
+    context_object_name = "siaes"
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        # first get the network's siaes
+        self.network = Network.objects.get(slug=self.kwargs.get("slug"))
+        qs = qs.filter(networks__in=[self.network]).with_tender_stats().annotate_with_brand_or_name(with_order_by=True)
+        # then filter with the form
+        self.filter_form = NetworkSiaeFilterForm(data=self.request.GET)
+        qs = self.filter_form.filter_queryset(qs)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = self.network
+        siae_search_form = self.filter_form if self.filter_form else NetworkSiaeFilterForm(data=self.request.GET)
+        context["form"] = siae_search_form
+        return context
+
+
+class DashboardNetworkSiaeTenderListView(NetworkMemberRequiredMixin, ListView):
+    template_name = "networks/dashboard_network_siae_tender_list.html"
+    queryset = TenderSiae.objects.select_related("tender", "siae").all()
+    context_object_name = "tendersiaes"
+    status = None
+
+    def get(self, request, status=None, *args, **kwargs):
+        """
+        - check that both the Siae & the Network exist
+        - check that the Siae belongs to the Network
+        """
+        self.status = status
+        if "slug" in self.kwargs:
+            self.network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
+            if "siae_slug" in self.kwargs:
+                self.siae = get_object_or_404(Siae.objects.with_tender_stats(), slug=self.kwargs.get("siae_slug"))
+                if self.siae not in self.network.siaes.all():
+                    return redirect("dashboard_networks:siae_list", slug=self.network.slug)
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = qs.filter(siae=self.siae)
+        if self.status:
+            if self.status == "DISPLAY":
+                qs = qs.filter(detail_display_date__isnull=False)
+            elif self.status == "CONTACT-CLICK":
+                qs = qs.filter(detail_contact_click_date__isnull=False)
+        else:  # default
+            qs = qs.filter(email_send_date__isnull=False)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = self.network
+        context["siae"] = self.siae
+        return context
+
+
+class DashboardNetworkTenderListView(NetworkMemberRequiredMixin, ListView):
+    template_name = "networks/dashboard_network_tender_list.html"
+    queryset = Tender.objects.all()
+    context_object_name = "tenders"
+    paginate_by = 10
+    paginator_class = Paginator
+
+    def get(self, request, *args, **kwargs):
+        # self.network = self.get_object()
+        self.network = Network.objects.prefetch_related("siaes").get(slug=self.kwargs.get("slug"))
+        self.network_siaes = self.network.siaes.all()
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = qs.prefetch_many_to_many().select_foreign_keys()
+        qs = qs.filter_with_siaes(self.network_siaes)
+        qs = qs.with_network_siae_stats(self.network_siaes)
+        qs = qs.order_by_deadline_date()
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = self.network
+        return context
+
+
+class DashboardNetworkTenderDetailView(NetworkMemberRequiredMixin, DetailView):
+    model = Tender
+    template_name = "networks/dashboard_network_tender_detail.html"
+    context_object_name = "tender"
+
+    def get_object(self):
+        self.network = Network.objects.prefetch_related("siaes").get(slug=self.kwargs.get("slug"))
+        self.network_siaes = self.network.siaes.all()
+        self.tender = get_object_or_404(
+            Tender.objects.validated().with_network_siae_stats(self.network_siaes),
+            slug=self.kwargs.get("tender_slug"),
+        )
+        return self.tender
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = self.network
+        return context
+
+
+class DashboardNetworkTenderSiaeListView(NetworkMemberRequiredMixin, ListView):
+    template_name = "networks/dashboard_network_tender_siae_list.html"
+    queryset = TenderSiae.objects.select_related("tender", "siae").all()
+    context_object_name = "tendersiaes"
+    status = None
+
+    def get(self, request, status=None, *args, **kwargs):
+        """
+        - fetch the Network & the Tender
+        """
+        self.status = status
+        if "slug" in self.kwargs:
+            self.network = get_object_or_404(Network, slug=self.kwargs.get("slug"))
+            if "tender_slug" in self.kwargs:
+                self.network_siaes = self.network.siaes.all()
+                self.tender = get_object_or_404(
+                    Tender.objects.validated().with_network_siae_stats(self.network_siaes),
+                    slug=self.kwargs.get("tender_slug"),
+                )
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = qs.filter(tender=self.tender).filter(email_send_date__isnull=False)
+        qs = qs.filter(siae__in=self.network.siaes.all())
+        if self.status:
+            if self.status == "CONTACT-CLICK":
+                qs = qs.filter(detail_contact_click_date__isnull=False)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["network"] = self.network
+        context["tender"] = self.tender
+        return context


### PR DESCRIPTION
Similaire à #720

### Quoi ?

Réduire la taille et la complexité du dossier `www/dashboard`, en mettant la logique des réseaux ailleurs
- nouveau dossier `www/dashboard_networks`
- nouveau dossier `templates/networks`
- renommer `ProfileNetwork` en `DashboardNetwork`