### PR TITLE
Correction du flacky test sur les périmètres géographiques

### DIFF
--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -414,7 +414,7 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
             post_codes=["38410"],
             # coords=Point(5.8862, 45.1106),
         )
-        SiaeFactory()
+        SiaeFactory(region="Centre-Val de Loire")
         SiaeFactory(region="Guadeloupe")
         SiaeFactory(region="Bretagne", department="29")
         SiaeFactory(
@@ -431,14 +431,13 @@ class SiaeModelPerimeterQuerysetTest(TestCase):
             geo_range=siae_constants.GEO_RANGE_DEPARTMENT,
         )
 
-    # TODO : fix the flaky test
-    # def test_address_in_perimeter_list(self):
-    #     self.assertEqual(Siae.objects.address_in_perimeter_list([]).count(), 5)
-    #     self.assertEqual(Siae.objects.address_in_perimeter_list([self.guadeloupe_perimeter]).count(), 1)
-    #     self.assertEqual(Siae.objects.address_in_perimeter_list([self.grenoble_perimeter]).count(), 1)
-    #     self.assertEqual(
-    #         Siae.objects.address_in_perimeter_list([self.guadeloupe_perimeter, self.finistere_perimeter]).count(), 2
-    #     )
+    def test_address_in_perimeter_list(self):
+        self.assertEqual(Siae.objects.address_in_perimeter_list([]).count(), 5)
+        self.assertEqual(Siae.objects.address_in_perimeter_list([self.guadeloupe_perimeter]).count(), 1)
+        self.assertEqual(Siae.objects.address_in_perimeter_list([self.grenoble_perimeter]).count(), 1)
+        self.assertEqual(
+            Siae.objects.address_in_perimeter_list([self.guadeloupe_perimeter, self.finistere_perimeter]).count(), 2
+        )
 
     def test_geo_range_in_perimeter_list(self):
         self.assertEqual(Siae.objects.geo_range_in_perimeter_list([]).count(), 5)


### PR DESCRIPTION
### Quoi ?

Des tests sur les périmètres géographiques échouent aléatoirement.

### Pourquoi ?

Je pense que la SIAEFactory  sans région est générée avec une région au hasard et que celle-ci peut-être "Guadeloupe".
Je pense que ça peut même arriver sur la ville, mais il y a quand même beaucoup moins de chance que ça tombe sur Grenoble.

### Comment ?

En définissant une magnifique région pour la `SIAEFactory` qui n'en a pas.

### Captures d'écran

![image](https://github.com/betagouv/itou-marche/assets/17601807/33d5f1bf-56e2-42c3-bd45-00bfa1819939)
