### PR TITLE
Suppression des requêtes N+1 sur la recherche de partenaires

### DIFF
--- a/lemarche/utils/templatetags/siae_sectors_display.py
+++ b/lemarche/utils/templatetags/siae_sectors_display.py
@@ -10,10 +10,9 @@ register = template.Library()
 def siae_sectors_display(siae, display_max=5, current_search_query="", output_format="string"):
     """Pretty rendering of M2M fields."""
 
-    qs = siae.sectors.values()
-
-    # get values
-    values = list(qs)
+    values = []
+    for sector in siae.sectors.all():
+        values.append({"slug": sector.slug, "name": sector.name})
 
     # if the search query contains sectors, filter values on these sectors
     if "sectors=" in current_search_query:

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -27,6 +27,19 @@ class SiaeSearchFilterTest(TestCase):
         self.assertEqual(len(siaes), 1)
 
 
+class SiaeSearchNumQueriesTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        SiaeFactory.create_batch(30)
+
+    def test_search_num_queries(self):
+        url = reverse("siae:search_results")
+        with self.assertNumQueries(8):
+            response = self.client.get(url)
+            siaes = list(response.context["siaes"])
+            self.assertEqual(len(siaes), 20)
+
+
 class SiaeKindSearchFilterTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
### Quoi ?

Suppression des requêtes supplémentaires pour aller chercher les secteurs des partenaires.

### Pourquoi ?

Le nombre de requêtes augmente en lien avec le nombre de résultats affichés.

### Comment ?

Modification de la façon d'afficher les secteurs. Le `.values()`  force l'exécution d'une requête au lieu de tirer parti du `prefetch` `sectors` qui est déjà fait sur le modèle `Siae`.
