### PR TITLE
Script de maj des dépendances : rendre poetry update optionnel

### DIFF
--- a/scripts/generate_python_dependencies.sh
+++ b/scripts/generate_python_dependencies.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
-poetry update
+
+# ask if the use wants to run poetry update
+printf "Run 'poetry update' first ? (y/n)"
+read answer
+if [ "$answer" != "${answer#[Yy]}" ]; then 
+    poetry update
+fi
+
+# update requirements .txt files
+echo "Updating 'requirements/dev.txt'"
 poetry export --without-hashes --with dev --output requirements/dev.txt
+echo "Updating 'requirements/staging.txt'"
 poetry export --without-hashes --output requirements/staging.txt


### PR DESCRIPTION
### Quoi ?

Dans mon environment la commande `poetry update` prend beaucoup de temps.
Et c'est une action à effectuer de temps en temps, mais pas nécessairement à chaque ajout / maj de nos dépendances ?

J'ai rendu son lancement optionnel en demandant à l'utilisateur ce qu'il souhaite faire :)