### PR TITLE
Ajout d'un lien avec le nombre de demandes reçues à lire

### DIFF
--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -22,7 +22,7 @@
                                 {% if user.kind == user.KIND_SIAE %}
                                     <li>
                                         <a href="{% url 'tenders:list' %}" class="btn btn-link">
-                                            Demandes reçues <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>
+                                            Demandes reçues{% if user.unread_tender_siae_count %} <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>{% endif %}
                                         </a>
                                     </li>
                                 {% endif %}

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -6,94 +6,35 @@
 {% endif %}
 
 <header role="banner" id="header">
-    <section class="s-header">
-        <div class="s-header__container container">
-            <div class="s-header__row row">
-                <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pr-0">
-                    <a href="{% url 'wagtail_serve' '' %}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
-                </div>
-                <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
-                    <a href="{% url 'wagtail_serve' '' %}"><img src="{% static_theme_images 'logo-marche-inclusion.svg' %}" alt="Le marché de l'inclusion"></a>
-                </div>
-                <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
-                    <nav role="navigation" id="nav-primary" aria-label="Navigation principale">
-                        <ul>
-                            {% if user.is_authenticated %}
-                                {% if user.kind == user.KIND_SIAE %}
-                                    <li>
-                                        <a href="{% url 'tenders:list' %}" class="btn btn-link">
-                                            Demandes reçues{% if user.unread_tender_siae_count %} <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>{% endif %}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                <li>
-                                    <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-primary btn-ico">
-                                        <i class="ri-mail-send-line ri-lg"></i>
-                                        <span>Publier un besoin d'achat</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <div class="dropdown">
-                                        <button class="btn btn-outline-primary dropdown-toggle" id="userDropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            Mon espace
-                                        </button>
-                                        <div class="dropdown-menu" aria-labelledby="userDropdownMenuButton">
-                                            <a href="{% url 'dashboard:home' %}" class="dropdown-item">
-                                                <i class="ri-dashboard-line"></i>
-                                                Tableau de bord
-                                            </a>
-                                            <a href="{% url 'dashboard_favorites:list' %}" id="header-favorites" class="dropdown-item">
-                                                <i class="ri-star-line"></i>
-                                                Favoris <span class="badge badge-pill badge-primary fs-xs">{{ user.favorite_list_count }}</span>
-                                            </a>
-                                            <a href="{% url 'dashboard:profile_edit' %}" class="dropdown-item">
-                                                <i class="ri-user-line"></i>
-                                                Mon profil
-                                            </a>
-                                            <div class="dropdown-divider"></div>
-                                            <a href="{% url 'auth:logout' %}" class="dropdown-item">
-                                                <i class="ri-logout-box-line"></i>
-                                                Déconnexion
-                                            </a>
-                                        </div>
-                                    </div>
-                                </li>
-                            {% else %}
-                                <li>
-                                    <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-link btn-ico">
-                                        <i class="ri-mail-send-line ri-lg"></i>
-                                        <span>Publier un besoin d'achat</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{% url 'auth:signup' %}" id="h_signup" class="btn btn-outline-primary btn-ico">
-                                        <i class="ri-user-add-line ri-lg"></i>
-                                        <span>S'inscrire</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{% url 'auth:login' %}" id="h_login" class="btn btn-primary btn-ico">
-                                        <i class="ri-login-box-line ri-lg"></i>
-                                        <span>Se connecter</span>
-                                    </a>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </nav>
-                </div>
-                <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger">
-                    <i class="ri-menu-line" id="open" role="button" tabindex="0" aria-label="Ouverture du menu de navigation principale pour mobile"></i>
-                    <i class="ri-close-line" id="close" role="button" tabindex="0" aria-label="Fermeture du menu de navigation principale pour mobile"></i>
-                </div>
-                <div id="burgerNav">
-                    <nav role="navigation" aria-label="Navigation principale pour mobile">
-                        {% include 'layouts/_header_nav_primary_items.html' with is_mobile=True %}
-                        {% include 'layouts/_header_nav_secondary_items.html' with is_mobile=True %}
-                    </nav>
+    {% with tender_siae_unread_count=user.tender_siae_unread_count %}
+        <section class="s-header">
+            <div class="s-header__container container">
+                <div class="s-header__row row">
+                    <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pr-0">
+                        <a href="{% url 'wagtail_serve' '' %}" class="s-header__logo-ministere"><img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française"></a>
+                    </div>
+                    <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
+                        <a href="{% url 'wagtail_serve' '' %}"><img src="{% static_theme_images 'logo-marche-inclusion.svg' %}" alt="Le marché de l'inclusion"></a>
+                    </div>
+                    <div class="s-header__col s-header__col--nav col d-none d-xl-inline-flex d-xl-flex align-items-center justify-content-end">
+                        <nav role="navigation" id="nav-primary" aria-label="Navigation principale">
+                            {% include 'layouts/_header_nav_primary_items.html' %}
+                        </nav>
+                    </div>
+                    <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none" data-toggle="burger">
+                        <i class="ri-menu-line" id="open" role="button" tabindex="0" aria-label="Ouverture du menu de navigation principale pour mobile"></i>
+                        <i class="ri-close-line" id="close" role="button" tabindex="0" aria-label="Fermeture du menu de navigation principale pour mobile"></i>
+                    </div>
+                    <div id="burgerNav">
+                        <nav role="navigation" aria-label="Navigation principale pour mobile">
+                            {% include 'layouts/_header_nav_primary_items.html' with is_mobile=True %}
+                            {% include 'layouts/_header_nav_secondary_items.html' with is_mobile=True %}
+                        </nav>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
+    {% endwith %}
     <section class="s-postheader d-none d-xl-block">
         <div class="s-postheader__container container">
             <div class="s-postheader__row row">

--- a/lemarche/templates/layouts/_header.html
+++ b/lemarche/templates/layouts/_header.html
@@ -19,57 +19,64 @@
                     <nav role="navigation" id="nav-primary" aria-label="Navigation principale">
                         <ul>
                             {% if user.is_authenticated %}
-                            <li>
-                                <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-primary btn-ico">
-                                    <i class="ri-mail-send-line ri-lg"></i>
-                                    <span>Publier un besoin d'achat</span>
-                                </a>
-                            </li>
-                            <li>
-                                <div class="dropdown">
-                                    <button class="btn btn-outline-primary dropdown-toggle" id="userDropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        Mon espace
-                                    </button>
-                                    <div class="dropdown-menu" aria-labelledby="userDropdownMenuButton">
-                                        <a href="{% url 'dashboard:home' %}" class="dropdown-item">
-                                            <i class="ri-dashboard-line"></i>
-                                            Tableau de bord
+                                {% if user.kind == user.KIND_SIAE %}
+                                    <li>
+                                        <a href="{% url 'tenders:list' %}" class="btn btn-link">
+                                            Demandes reçues <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>
                                         </a>
-                                        <a href="{% url 'dashboard_favorites:list' %}" id="header-favorites" class="dropdown-item">
-                                            <i class="ri-star-line"></i>
-                                            Favoris <span class="badge badge-pill badge-primary fs-xs">{{ user.favorite_list_count }}</span>
-                                        </a>
-                                        <a href="{% url 'dashboard:profile_edit' %}" class="dropdown-item">
-                                            <i class="ri-user-line"></i>
-                                            Mon profil
-                                        </a>
-                                        <div class="dropdown-divider"></div>
-                                        <a href="{% url 'auth:logout' %}" class="dropdown-item">
-                                            <i class="ri-logout-box-line"></i>
-                                            Déconnexion
-                                        </a>
+                                    </li>
+                                {% endif %}
+                                <li>
+                                    <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-primary btn-ico">
+                                        <i class="ri-mail-send-line ri-lg"></i>
+                                        <span>Publier un besoin d'achat</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <div class="dropdown">
+                                        <button class="btn btn-outline-primary dropdown-toggle" id="userDropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            Mon espace
+                                        </button>
+                                        <div class="dropdown-menu" aria-labelledby="userDropdownMenuButton">
+                                            <a href="{% url 'dashboard:home' %}" class="dropdown-item">
+                                                <i class="ri-dashboard-line"></i>
+                                                Tableau de bord
+                                            </a>
+                                            <a href="{% url 'dashboard_favorites:list' %}" id="header-favorites" class="dropdown-item">
+                                                <i class="ri-star-line"></i>
+                                                Favoris <span class="badge badge-pill badge-primary fs-xs">{{ user.favorite_list_count }}</span>
+                                            </a>
+                                            <a href="{% url 'dashboard:profile_edit' %}" class="dropdown-item">
+                                                <i class="ri-user-line"></i>
+                                                Mon profil
+                                            </a>
+                                            <div class="dropdown-divider"></div>
+                                            <a href="{% url 'auth:logout' %}" class="dropdown-item">
+                                                <i class="ri-logout-box-line"></i>
+                                                Déconnexion
+                                            </a>
+                                        </div>
                                     </div>
-                                </div>
-                            </li>
+                                </li>
                             {% else %}
-                            <li>
-                                <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-link btn-ico">
-                                    <i class="ri-mail-send-line ri-lg"></i>
-                                    <span>Publier un besoin d'achat</span>
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{% url 'auth:signup' %}" id="h_signup" class="btn btn-outline-primary btn-ico">
-                                    <i class="ri-user-add-line ri-lg"></i>
-                                    <span>S'inscrire</span>
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{% url 'auth:login' %}" id="h_login" class="btn btn-primary btn-ico">
-                                    <i class="ri-login-box-line ri-lg"></i>
-                                    <span>Se connecter</span>
-                                </a>
-                            </li>
+                                <li>
+                                    <a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-link btn-ico">
+                                        <i class="ri-mail-send-line ri-lg"></i>
+                                        <span>Publier un besoin d'achat</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{% url 'auth:signup' %}" id="h_signup" class="btn btn-outline-primary btn-ico">
+                                        <i class="ri-user-add-line ri-lg"></i>
+                                        <span>S'inscrire</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{% url 'auth:login' %}" id="h_login" class="btn btn-primary btn-ico">
+                                        <i class="ri-login-box-line ri-lg"></i>
+                                        <span>Se connecter</span>
+                                    </a>
+                                </li>
                             {% endif %}
                         </ul>
                     </nav>

--- a/lemarche/templates/layouts/_header_nav_primary_items.html
+++ b/lemarche/templates/layouts/_header_nav_primary_items.html
@@ -3,7 +3,7 @@
 		{% if user.kind == user.KIND_SIAE %}
 			<li>
 				<a href="{% url 'tenders:list' %}" class="btn btn-link">
-					Demandes reçues{% if user.unread_tender_siae_count %} <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>{% endif %}
+					Demandes reçues{% if tender_siae_unread_count %} <span class="badge badge-pill badge-important fs-xs">{{ tender_siae_unread_count }}</span>{% endif %}
 				</a>
 			</li>
 		{% endif %}
@@ -15,7 +15,7 @@
 		</li>
 		<li>
 			<div class="dropdown">
-				<button class="btn btn-outline-primary dropdown-toggle mb-3" type="button"
+				<button class="btn btn-outline-primary dropdown-toggle{% if is_mobile %} mb-3" type="button{% endif %}"
 					id="userDropdownMenuButton{% if is_mobile %}Mobile{% endif %}" data-toggle="dropdown"
 					aria-haspopup="true" aria-expanded="false">
 					Mon espace

--- a/lemarche/templates/layouts/_header_nav_primary_items.html
+++ b/lemarche/templates/layouts/_header_nav_primary_items.html
@@ -3,7 +3,7 @@
 		{% if user.kind == user.KIND_SIAE %}
 			<li>
 				<a href="{% url 'tenders:list' %}" class="btn btn-link">
-					Demandes reçues <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>
+					Demandes reçues{% if user.unread_tender_siae_count %} <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>{% endif %}
 				</a>
 			</li>
 		{% endif %}

--- a/lemarche/templates/layouts/_header_nav_primary_items.html
+++ b/lemarche/templates/layouts/_header_nav_primary_items.html
@@ -1,5 +1,12 @@
 <ul>
 	{% if user.is_authenticated %}
+		{% if user.kind == user.KIND_SIAE %}
+			<li>
+				<a href="{% url 'tenders:list' %}" class="btn btn-link">
+					Demandes reçues <span class="badge badge-pill badge-danger fs-xs">{{ user.unread_tender_siae_count }}</span>
+				</a>
+			</li>
+		{% endif %}
 		<li>
 			<a href="{% url 'tenders:create' %}" id="header-demande" class="btn btn-primary btn-ico">
 				<i class="ri-mail-send-line ri-lg"></i>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -10,7 +10,7 @@
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
                     {% if not tender.tendersiae_set.first.detail_display_date %}
-                        <span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>
+                        <span class="badge badge-sm badge-pill badge-important">Nouveau</span>
                     {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -9,6 +9,9 @@
                     {% if tender.deadline_date_is_outdated %}
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
+                    {% if not tender.tendersiae_set.first.detail_display_date %}
+                        <span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>
+                    {% endif %}
                     <span class="float-right badge badge-base badge-pill badge-emploi">
                         {% if tender.kind == "PROJ" %}
                             {{ title_kind_sourcing_siae|default:tender.get_kind_display }}

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -383,6 +383,15 @@ class User(AbstractUser):
             qs = qs.filter(tender=tender)
         return qs.exists()
 
+    @property
+    def unread_tender_siae_count(self, tender=None):
+        from lemarche.tenders.models import TenderSiae
+
+        qs = TenderSiae.objects.filter(siae__in=self.siaes.all(), tender__validated_at__isnull=False).filter(
+            detail_display_date__isnull=True
+        )
+        return qs.count()
+
 
 @receiver(post_save, sender=User)
 def user_post_save(sender, instance, **kwargs):

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -384,7 +384,7 @@ class User(AbstractUser):
         return qs.exists()
 
     @property
-    def unread_tender_siae_count(self, tender=None):
+    def tender_siae_unread_count(self):
         from lemarche.tenders.models import TenderSiae
 
         qs = TenderSiae.objects.filter(siae__in=self.siaes.all(), tender__validated_at__isnull=False).filter(

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -388,9 +388,7 @@ class TenderListViewTest(TestCase):
         self.assertContains(response, "2 prestataires ciblés")  # tender_3
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
         self.assertNotContains(response, "Demandes reçues")
-        self.assertNotContains(
-            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
-        )
+        self.assertNotContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
         self.client.force_login(self.user_partner)
@@ -414,11 +412,9 @@ class TenderListViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["tenders"]), 1)
         # The badge in header
-        self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-danger fs-xs">1</span>')
+        self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>')
         # The badge in tender list
-        self.assertContains(
-            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
-        )
+        self.assertContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
 
         # Open tender detail page
         detail_url = reverse("tenders:detail", kwargs={"slug": self.tender_3.slug})
@@ -426,10 +422,10 @@ class TenderListViewTest(TestCase):
 
         # The badges have disappeared
         response = self.client.get(url)
-        self.assertNotContains(response, 'Demandes reçues <span class="badge badge-pill badge-danger fs-xs">1</span>')
         self.assertNotContains(
-            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
+            response, 'Demandes reçues <span class="badge badge-pill badge-important fs-xs">1</span>'
         )
+        self.assertNotContains(response, '<span class="badge badge-sm badge-pill badge-important">Nouveau</span>')
 
 
 class TenderDetailViewTest(TestCase):

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -387,6 +387,10 @@ class TenderListViewTest(TestCase):
         self.assertEqual(len(response.context["tenders"]), 3)
         self.assertContains(response, "2 prestataires ciblés")  # tender_3
         self.assertContains(response, "1 prestataire intéressé")  # tender_3
+        self.assertNotContains(response, "Demandes reçues")
+        self.assertNotContains(
+            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
+        )
 
     def test_other_user_without_tender_should_not_see_any_tenders(self):
         self.client.force_login(self.user_partner)
@@ -402,6 +406,30 @@ class TenderListViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(User.objects.get(id=self.siae_user_1.id).tender_list_last_seen_date)
+
+    def test_siae_user_should_see_unread_badge(self):
+        self.client.force_login(self.siae_user_2)
+        url = reverse("tenders:list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["tenders"]), 1)
+        # The badge in header
+        self.assertContains(response, 'Demandes reçues <span class="badge badge-pill badge-danger fs-xs">1</span>')
+        # The badge in tender list
+        self.assertContains(
+            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
+        )
+
+        # Open tender detail page
+        detail_url = reverse("tenders:detail", kwargs={"slug": self.tender_3.slug})
+        self.client.get(detail_url)
+
+        # The badges have disappeared
+        response = self.client.get(url)
+        self.assertNotContains(response, 'Demandes reçues <span class="badge badge-pill badge-danger fs-xs">1</span>')
+        self.assertNotContains(
+            response, '<span class="float-right badge badge-base badge-pill badge-danger">Nouveau</span>'
+        )
 
 
 class TenderDetailViewTest(TestCase):


### PR DESCRIPTION
### Quoi ?

Ajout d'un lien au menu d'entête pour accéder directement à la liste des "opportunités". 
À côté du lien, un badge indique le nombre d'opportunités non consultées par un utilisateur de la structure.
Un badge "Nouveau" est aussi ajouté aux items de la liste qui n'ont pas encore été consulté.

### Pourquoi ?

Pour fidéliser les acheteurs en augmentant le nombre de réponses aux dépôts de besoin.

### Comment ?

En utilisant le champs date de consultation déjà présent sur la table de relation (`SiaeTender`) entre besoin et structure.

### Captures d'écran

![Capture Ordinateur](https://github.com/betagouv/itou-marche/assets/17601807/43568a28-69a8-49d7-9cdd-b15b77c0af62)

![Capture Mobile](https://github.com/betagouv/itou-marche/assets/17601807/6aa14eb8-8849-4a80-9c53-f8d254115f30)

![Toute lue](https://github.com/betagouv/itou-marche/assets/17601807/b4da6ccf-7dd0-4505-89fe-ab993fdf10e5)

