### PR TITLE
Refactoring : renommer certaines views

### DIFF
--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -11,9 +11,9 @@ from lemarche.www.dashboard.views import (
     SiaeEditSearchView,
     SiaeSearchAdoptConfirmView,
     SiaeSearchBySiretView,
-    SiaeUserDelete,
-    SiaeUserRequestCancel,
-    SiaeUserRequestConfirm,
+    SiaeUserDeleteView,
+    SiaeUserRequestCancelView,
+    SiaeUserRequestConfirmView,
     SiaeUsersView,
 )
 
@@ -72,17 +72,17 @@ urlpatterns = [
     ),
     path(
         "prestataires/<str:slug>/collaborateurs/<str:siaeuserrequest_id>/accepter",
-        SiaeUserRequestConfirm.as_view(),
+        SiaeUserRequestConfirmView.as_view(),
         name="siae_user_request_confirm",
     ),
     path(
         "prestataires/<str:slug>/collaborateurs/<str:siaeuserrequest_id>/refuser",
-        SiaeUserRequestCancel.as_view(),
+        SiaeUserRequestCancelView.as_view(),
         name="siae_user_request_cancel",
     ),
     path(
         "prestataires/<str:slug>/collaborateurs/<str:siaeuser_id>/supprimer",
-        SiaeUserDelete.as_view(),
+        SiaeUserDeleteView.as_view(),
         name="siae_user_delete",
     ),
     # Redirects

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -337,7 +337,7 @@ class SiaeEditContactView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateVi
         return reverse_lazy("dashboard:siae_edit_contact", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserRequestConfirm(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeUserRequestConfirmView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeUserRequestForm
     template_name = "siaes/_siae_user_request_confirm_modal.html"
     context_object_name = "siaeuserrequest"
@@ -366,7 +366,7 @@ class SiaeUserRequestConfirm(SiaeMemberRequiredMixin, SuccessMessageMixin, Updat
         return reverse_lazy("dashboard:siae_users", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserRequestCancel(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
+class SiaeUserRequestCancelView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView):
     form_class = SiaeUserRequestForm
     template_name = "siaes/_siae_user_request_cancel_modal.html"
     context_object_name = "siaeuserrequest"
@@ -393,7 +393,7 @@ class SiaeUserRequestCancel(SiaeMemberRequiredMixin, SuccessMessageMixin, Update
         return reverse_lazy("dashboard:siae_users", args=[self.kwargs.get("slug")])
 
 
-class SiaeUserDelete(SiaeMemberRequiredMixin, SuccessMessageMixin, DeleteView):
+class SiaeUserDeleteView(SiaeMemberRequiredMixin, SuccessMessageMixin, DeleteView):
     template_name = "siaes/_siae_user_delete_modal.html"
     model = SiaeUser
     # success_message = "L'utilisateur a été supprimé de votre structure."

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -800,7 +800,7 @@ class TenderDetailViewTest(TestCase):
         self.assertContains(response, "Lien partagé")
 
 
-class TenderDetailContactClickStatViewTest(TestCase):
+class TenderDetailContactClickStatViewViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.siae = SiaeFactory(name="ZZ ESI")

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -3,7 +3,7 @@ from django.views.generic import RedirectView
 
 from lemarche.www.tenders.views import (
     TenderCreateMultiStepView,
-    TenderDetailContactClickStat,
+    TenderDetailContactClickStatView,
     TenderDetailSurveyTransactionedView,
     TenderDetailView,
     TenderListView,
@@ -29,7 +29,9 @@ urlpatterns = [
     ),  # TODO: delete in 2024
     path("<str:slug>/prestataires/statut/<status>", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
-    path("<str:slug>/contact-click-stat", TenderDetailContactClickStat.as_view(), name="detail-contact-click-stat"),
+    path(
+        "<str:slug>/contact-click-stat", TenderDetailContactClickStatView.as_view(), name="detail-contact-click-stat"
+    ),
     path(
         "<str:slug>/sondage-transaction",
         TenderDetailSurveyTransactionedView.as_view(),

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -336,7 +336,7 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
         return context
 
 
-class TenderDetailContactClickStat(LoginRequiredMixin, UpdateView):
+class TenderDetailContactClickStatView(LoginRequiredMixin, UpdateView):
     """
     Endpoint to track contact_clicks by interested Siaes
     We might also send a notification to the buyer


### PR DESCRIPTION
### Quoi ?

4 views étaient nommées sans le `View` à la fin
- `TenderDetailContactClickStat`
- `SiaeUserRequestConfirm`, `SiaeUserRequestCancel` & `SiaeUserDelete`
