### PR TITLE
Dépôt de besoin : Admin : filtre "montant renseigné ?"

### DIFF
--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -42,6 +42,22 @@ class SourceFilter(MultiChoice):
     BUTTON_LABEL = "Appliquer"
 
 
+class HasAmountFilter(admin.SimpleListFilter):
+    title = "Montant renseigné ?"
+    parameter_name = "has_amount"
+
+    def lookups(self, request, model_admin):
+        return (("Yes", "Oui"), ("No", "Non"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "Yes":
+            return queryset.has_amount()
+        elif value == "No":
+            return queryset.filter(amount__isnull=True, amount_exact__isnull=True)
+        return queryset
+
+
 class AmountFilter(MultiChoice):
     FILTER_LABEL = Tender._meta.get_field("amount").verbose_name
     BUTTON_LABEL = "Appliquer"
@@ -128,6 +144,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "status",
         ("scale_marche_useless", ScaleMarcheUselessFilter),
         ("source", SourceFilter),
+        HasAmountFilter,
         ("amount", AmountFilter),
         "deadline_date",
         "start_working_date",

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -53,6 +53,9 @@ class TenderQuerySet(models.QuerySet):
     def is_live(self):
         return self.validated().filter(deadline_date__gte=datetime.today())
 
+    def has_amount(self):
+        return self.filter(Q(amount__isnull=False) | Q(amount_exact__isnull=False))
+
     def in_perimeters(self, post_code, department, region):
         filters = (
             Q(perimeters__post_codes__contains=[post_code])

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -174,6 +174,15 @@ class TenderModelQuerysetTest(TestCase):
         # TenderFactory(deadline_date=None)  # cannot be None
         self.assertEqual(Tender.objects.is_live().count(), 1)
 
+    def test_has_amount_queryset(self):
+        TenderFactory()
+        TenderFactory(amount=tender_constants.AMOUNT_RANGE_0_1)
+        TenderFactory(amount_exact=1000)
+        TenderFactory(amount=tender_constants.AMOUNT_RANGE_0_1, amount_exact=1000)
+        self.assertEqual(Tender.objects.count(), 4)
+        self.assertEqual(Tender.objects.has_amount().count(), 3)
+        self.assertEqual(Tender.objects.filter(amount__isnull=True, amount_exact__isnull=True).count(), 1)
+
     def test_in_sectors_queryset(self):
         sector_1 = SectorFactory(name="Un secteur")
         sector_2 = SectorFactory(name="Un deuxieme secteur")


### PR DESCRIPTION
### Quoi ?

Nouveau filtre coté admin, pour trouver les besoins dont aucun montant n'est renseigné (montant renseigné par l'acheteur et montant renseigné par un admin)