### PR TITLE
Dépôt de besoin : permettre à certains utilisateurs anonyme de se mettre en relation

### DIFF
--- a/lemarche/templates/auth/_login_or_signup_siae_tender_modal.html
+++ b/lemarche/templates/auth/_login_or_signup_siae_tender_modal.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load theme_inclusion %}
+
 <style>
   .remix {
   width: 24px;
@@ -7,6 +8,7 @@
   fill: #333;
 }
 </style>
+
 <div class="modal fade modal-siae"
      id="login_or_signup_siae_tender_modal"
      tabindex="-1"
@@ -42,6 +44,7 @@
         </div>
     </div>
 </div>
+
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
     const MODAL_ID = '#login_or_signup_siae_tender_modal';

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -34,7 +34,7 @@
         </div>
         {% if not source_form %}
             {% if user.is_authenticated %}
-                {% if tender.author == request.user %}
+                {% if user == tender.author %}
                     <hr class="my-5">
                     {% include "tenders/_detail_contact.html" with tender=tender %}
                 {% elif user_partner_can_display_tender_contact_details %}
@@ -58,7 +58,7 @@
         {% if source_form or not source_form and tender.questions_list|length %}
             <hr class="my-5">
             <h2>
-                {% if source_form or tender.author == request.user %}
+                {% if source_form or user == tender.author %}
                     Questions à poser aux prestataires ciblés
                 {% else %}
                     Questions du client
@@ -75,17 +75,17 @@
             <p>{{ tender.constraints|default:"-"|safe|linebreaks }}</p>
         {% endif %}
         <!-- tender amount -->
-        {% if source_form or tender.author == request.user or tender.accept_share_amount %}
+        {% if source_form or user == tender.author or tender.accept_share_amount %}
             <hr class="my-5">
             <h2>
-                {% if source_form or tender.author == request.user %}
+                {% if source_form or user == tender.author %}
                     Montant du marché
                 {% else %}
                     Budget du client
                 {% endif %}
             </h2>
             <p>{{ tender.get_amount_display|default:"-" }}</p>
-            {% if source_form or tender.author == request.user %}<p>{{ tender.accept_share_amount_display }}</p>{% endif %}
+            {% if source_form or user == tender.author %}<p>{{ tender.accept_share_amount_display }}</p>{% endif %}
         {% endif %}
     </div>
 </div>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -1,6 +1,6 @@
 
 <h2>
-    {% if tender.author == request.user %}
+    {% if user == tender.author %}
         Coordonnées
     {% else %}
         Contactez le client dès maintenant

--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -34,13 +34,11 @@ document.addEventListener("DOMContentLoaded", function() {
         var siaeIdParams = button.data('siae-id');
 
         // Update the modal's content
-        if (siaeIdParams) {
-            var modal = document.querySelector(MODAL_ID);
-            modal.querySelectorAll('#auth-link').forEach(link => {
-                var linkUrl = link.getAttribute('href');
-                link.setAttribute('href', linkUrl.replace('siae-id-params-to-replace', siaeIdParams));
-            });
-        }
+        var modal = document.querySelector(MODAL_ID);
+        modal.querySelectorAll('#auth-link').forEach(link => {
+            var linkUrl = link.getAttribute('href');
+            link.setAttribute('href', linkUrl.replace('siae-id-params-to-replace', siaeIdParams));
+        });
     });
 });
 </script>

--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -7,7 +7,7 @@
                     <i class="ri-close-line"></i>
                 </button>
             </div>
-            <form method="POST" action="{% url 'tenders:detail-contact-click-stat' tender.slug %}">
+            <form method="POST" action="{% url 'tenders:detail-contact-click-stat' tender.slug %}?siae_id=siae-id-params-to-replace">
                 {% csrf_token %}
                 <div class="modal-body home-content-body">
                     <p>
@@ -22,3 +22,25 @@
         </div>
     </div>
 </div>
+
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    const MODAL_ID = '#detail_contact_click_confirm_modal';
+    $(MODAL_ID).on('show.bs.modal', function (event) {
+        // Button that triggered the modal
+        var button = $(event.relatedTarget);
+
+        // Extract info from data-* attributes
+        var siaeIdParams = button.data('siae-id');
+
+        // Update the modal's content
+        if (siaeIdParams) {
+            var modal = document.querySelector(MODAL_ID);
+            modal.querySelectorAll('#auth-link').forEach(link => {
+                var linkUrl = link.getAttribute('href');
+                link.setAttribute('href', linkUrl.replace('siae-id-params-to-replace', siaeIdParams));
+            });
+        }
+    });
+});
+</script>

--- a/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
+++ b/lemarche/templates/tenders/_detail_contact_click_confirm_modal.html
@@ -35,10 +35,9 @@ document.addEventListener("DOMContentLoaded", function() {
 
         // Update the modal's content
         var modal = document.querySelector(MODAL_ID);
-        modal.querySelectorAll('#auth-link').forEach(link => {
-            var linkUrl = link.getAttribute('href');
-            link.setAttribute('href', linkUrl.replace('siae-id-params-to-replace', siaeIdParams));
-        });
+        var form = modal.querySelector('form');
+        var formAction = form.getAttribute('action');
+        form.setAttribute('action', formAction.replace('siae-id-params-to-replace', siaeIdParams));
     });
 });
 </script>

--- a/lemarche/templates/tenders/_detail_cta.html
+++ b/lemarche/templates/tenders/_detail_cta.html
@@ -4,8 +4,8 @@
         
         <p>{{ tender.cta_card_paragraph_text|safe }}</p>
 
-        {% if user.is_authenticated %}
-            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary btn-block" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" title="{{ tender.cta_card_button_text|safe }}">
+        {% if user_can_click %}
+            <button type="button" id="show-tender-contact-modal-btn" class="btn btn-primary btn-block" data-toggle="modal" data-target="#detail_contact_click_confirm_modal" data-siae-id="{{ siae_id }}" title="{{ tender.cta_card_button_text|safe }}">
                 {{ tender.cta_card_button_text|safe }}
             </button>
         {% else %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -28,34 +28,37 @@
 <section class="s-section">
     <div class="s-section__container container">
         {# Afficher les contacts en haut + conseil #}
-        {% if user_siae_has_detail_contact_click_date and not tender.deadline_date_outdated %}
-            <div class="row">
-                <div class="col-12 col-lg-8">
-                    <div class="alert alert-info fade show" role="status">
-                        {% include "tenders/_detail_contact.html" with tender=tender source="alert" %}
+        {% if not tender.deadline_date_outdated %}
+            {% if user_siae_has_detail_contact_click_date or siae_has_detail_contact_click_date %}
+                <div class="row">
+                    <div class="col-12 col-lg-8">
+                        <div class="alert alert-info fade show" role="status">
+                            {% include "tenders/_detail_contact.html" with tender=tender source="alert" %}
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-4">
+                        <div class="alert alert-info mt-3 mt-lg-0" role="alert">
+                            <p class="mb-1">
+                                <i class="ri-information-line ri-lg"></i>
+                                <strong>Conseil</strong>
+                            </p>
+                            <p class="mb-0 fs-sm">
+                                N'attendez pas et contactez dès maintenant le client.
+                                En fonction, envoyez lui un devis, une plaquette commerciale ou répondez à son marché.
+                            </p>
+                        </div>
                     </div>
                 </div>
-                <div class="col-12 col-lg-4">
-                    <div class="alert alert-info mt-3 mt-lg-0" role="alert">
-                        <p class="mb-1">
-                            <i class="ri-information-line ri-lg"></i>
-                            <strong>Conseil</strong>
-                        </p>
-                        <p class="mb-0 fs-sm">
-                            N'attendez pas et contactez dès maintenant le client.
-                            En fonction, envoyez lui un devis, une plaquette commerciale ou répondez à son marché.
-                        </p>
-                    </div>
-                </div>
-            </div>
+            {% endif %}
         {% endif %}
         <div class="row">
+            {# Main tender card #}
             <div class="col-12 col-lg-8 order-2">
                 {% include "tenders/_detail_card.html" with tender=tender %}
             </div>
-            {# Sidebar "actions" #}
+            {# Sidebar with actions #}
             <div class="col-12 col-lg-4 order-1 order-lg-2">
-                {% if tender.author == request.user %}
+                {% if user == tender.author %}
                     {% if is_draft %}
                         <div class="alert alert-warning fade show" role="status">
                             <div class="row">
@@ -104,54 +107,58 @@
                             {{ tender.siae_detail_contact_click_date_count }} prestataire{{ tender.siae_detail_contact_click_date_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_date_count|pluralize }}
                         </a>
                     {% endif %}
-                {% endif %}
-                {% if tender.author != request.user and not tender.deadline_date_outdated %}
-                    {% if tender.siae_detail_display_date_count_all > 0 %}
-                        <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
-                            <p class="mb-0 fs-sm">
-                                Déjà {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_detail_display_date_count_all|pluralize }} inclusif{{ tender.siae_detail_display_date_count_all|pluralize }}
-                                {{ tender.siae_detail_display_date_count_all|pluralize:"a,ont" }} vu le besoin de ce client.
-                            </p>
-                        </div>
-                    {% endif %}
-                    {% if user.is_authenticated %}
-                        {% if user.kind == user.KIND_PARTNER %}
-                            {% if not user_partner_can_display_tender_contact_details %}
-                                <div class="alert alert-info" role="alert">
-                                    <p class="mb-1">
-                                        <i class="ri-lightbulb-line ri-lg"></i>
-                                        <strong>Comment contacter le client ?</strong>
-                                    </p>
-                                    <p class="mb-0">
-                                        Contactez Sofiane via
-                                        <a href="mailto:{{ CONTACT_EMAIL }}?subject=Demande d'information pour {{ tender.title }}">{{ CONTACT_EMAIL }}</a>
-                                        pour être mis en relation avec le client.
-                                    </p>
-                                </div>
-                            {% endif %}
-                        {% elif user.kind == user.KIND_SIAE %}
-                            {% if not user.has_siae %}
-                                <div class="alert alert-info" role="alert">
-                                    <p class="mb-1">
-                                        <i class="ri-lightbulb-line ri-lg"></i>
-                                        <strong>Comment contacter le client ?</strong>
-                                    </p>
-                                    <p class="mb-0">
-                                        Pour accéder aux coordonnées du client, veuillez d'abord vous <a id="add-siae-btn" href="{% url 'dashboard_siaes:siae_search_by_siret' %}">rattacher à votre structure</a>.
-                                    </p>
-                                    <p>
-                                        Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite.
-                                    </p>
-                                </div>
-                            {% elif not user_siae_has_detail_contact_click_date %}
-                                {% include "tenders/_detail_cta.html" with user=user tender=tender %}
-                                <div id="show-tender-contact-content" style="display:none">
-                                    {% include "tenders/_detail_contact.html" with tender=tender %}
-                                </div>
-                            {% endif %}
+                {% else %}
+                    {% if not tender.deadline_date_outdated %}
+                        {% if tender.siae_detail_display_date_count_all > 0 %}
+                            <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
+                                <p class="mb-0 fs-sm">
+                                    Déjà {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_detail_display_date_count_all|pluralize }} inclusif{{ tender.siae_detail_display_date_count_all|pluralize }}
+                                    {{ tender.siae_detail_display_date_count_all|pluralize:"a,ont" }} vu le besoin de ce client.
+                                </p>
+                            </div>
                         {% endif %}
-                    {% else %}
-                        {% include "tenders/_detail_cta.html" with user=user tender=tender %}
+                        {% if user.is_authenticated %}
+                            {% if user.kind == user.KIND_PARTNER %}
+                                {% if not user_partner_can_display_tender_contact_details %}
+                                    <div class="alert alert-info" role="alert">
+                                        <p class="mb-1">
+                                            <i class="ri-lightbulb-line ri-lg"></i>
+                                            <strong>Comment contacter le client ?</strong>
+                                        </p>
+                                        <p class="mb-0">
+                                            Contactez Sofiane via
+                                            <a href="mailto:{{ CONTACT_EMAIL }}?subject=Demande d'information pour {{ tender.title }}">{{ CONTACT_EMAIL }}</a>
+                                            pour être mis en relation avec le client.
+                                        </p>
+                                    </div>
+                                {% endif %}
+                            {% elif user.kind == user.KIND_SIAE %}
+                                {% if not user.has_siae %}
+                                    <div class="alert alert-info" role="alert">
+                                        <p class="mb-1">
+                                            <i class="ri-lightbulb-line ri-lg"></i>
+                                            <strong>Comment contacter le client ?</strong>
+                                        </p>
+                                        <p class="mb-0">
+                                            Pour accéder aux coordonnées du client, veuillez d'abord vous <a id="add-siae-btn" href="{% url 'dashboard_siaes:siae_search_by_siret' %}">rattacher à votre structure</a>.
+                                        </p>
+                                        <p>
+                                            Besoin d'aide ? contacter le support via le chat en ligne qui se trouve en bas à droite.
+                                        </p>
+                                    </div>
+                                {% elif not user_siae_has_detail_contact_click_date %}
+                                    {% include "tenders/_detail_cta.html" with tender=tender user_can_click=True %}
+                                {% endif %}
+                            {% endif %}
+                        {% elif siae_id %}
+                            {% if not siae_has_detail_contact_click_date %}
+                                {% include "tenders/_detail_cta.html" with tender=tender user_can_click=True siae_id=siae_id %}
+                            {% else %}
+                                {% include "tenders/_detail_contact.html" with tender=tender %}
+                            {% endif %}
+                        {% else %}
+                            {% include "tenders/_detail_cta.html" with tender=tender user_can_click=False %}
+                        {% endif %}
                     {% endif %}
                 {% endif %}
             </div>

--- a/lemarche/utils/mixins.py
+++ b/lemarche/utils/mixins.py
@@ -171,6 +171,15 @@ class TenderAuthorOrAdminRequiredIfNotValidatedMixin(UserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("wagtail_serve", args=("",)))
 
 
+class LoginRequiredOrSiaeIdParamMixin(UserPassesTestMixin):
+    def test_func(self):
+        siae_id = self.request.GET.get("siae_id", None)
+        return self.request.user.is_authenticated or siae_id
+
+    def handle_no_permission(self):
+        return LoginRequiredUserPassesTestMixin.dispatch(self, self.request)
+
+
 class SesameTokenRequiredUserPassesTestMixin(UserPassesTestMixin):
     """
     Custom mixin that checks that a valid django-sesame token is passed

--- a/lemarche/utils/mixins.py
+++ b/lemarche/utils/mixins.py
@@ -171,13 +171,13 @@ class TenderAuthorOrAdminRequiredIfNotValidatedMixin(UserPassesTestMixin):
         return HttpResponseRedirect(reverse_lazy("wagtail_serve", args=("",)))
 
 
-class LoginRequiredOrSiaeIdParamMixin(UserPassesTestMixin):
+class SiaeUserRequiredOrSiaeIdParamMixin(UserPassesTestMixin):
     def test_func(self):
         siae_id = self.request.GET.get("siae_id", None)
-        return self.request.user.is_authenticated or siae_id
+        return SiaeUserRequiredMixin.test_func(self) or (siae_id and siae_id.isnumeric())
 
     def handle_no_permission(self):
-        return LoginRequiredUserPassesTestMixin.dispatch(self, self.request)
+        return HttpResponseForbidden()
 
 
 class SesameTokenRequiredUserPassesTestMixin(UserPassesTestMixin):

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -870,7 +870,7 @@ class TenderDetailContactClickStatViewViewTest(TestCase):
     def test_anonymous_user_cannot_call_tender_contact_click(self):
         url = reverse("tenders:detail-contact-click-stat", kwargs={"slug": self.tender.slug})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
 
     def test_only_siae_user_or_with_siae_id_param_can_call_tender_contact_click(self):
         # forbidden
@@ -893,6 +893,11 @@ class TenderDetailContactClickStatViewViewTest(TestCase):
         )
         response = self.client.post(url, data={"detail_contact_click_confirm": "false"})
         self.assertEqual(response.status_code, 302)
+        # forbidden because wrong siae_id parameter
+        self.client.logout()
+        url = reverse("tenders:detail-contact-click-stat", kwargs={"slug": self.tender.slug}) + "?siae_id=test"
+        response = self.client.post(url, data={"detail_contact_click_confirm": "false"})
+        self.assertEqual(response.status_code, 403)
 
     def test_update_tendersiae_stats_on_tender_contact_click(self):
         siae_2 = SiaeFactory(name="ABC Insertion")

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -18,8 +18,8 @@ from lemarche.tenders.models import Tender, TenderSiae
 from lemarche.users.models import User
 from lemarche.utils.data import get_choice
 from lemarche.utils.mixins import (
-    LoginRequiredOrSiaeIdParamMixin,
     SesameTenderAuthorRequiredMixin,
+    SiaeUserRequiredOrSiaeIdParamMixin,
     TenderAuthorOrAdminRequiredIfNotValidatedMixin,
     TenderAuthorOrAdminRequiredMixin,
 )
@@ -347,7 +347,7 @@ class TenderDetailView(TenderAuthorOrAdminRequiredIfNotValidatedMixin, DetailVie
         return context
 
 
-class TenderDetailContactClickStatView(LoginRequiredOrSiaeIdParamMixin, UpdateView):
+class TenderDetailContactClickStatView(SiaeUserRequiredOrSiaeIdParamMixin, UpdateView):
     """
     Endpoint to track contact_clicks by interested Siaes
     We might also send a notification to the buyer

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -364,7 +364,6 @@ class TenderDetailContactClickStatView(LoginRequiredOrSiaeIdParamMixin, UpdateVi
         user = self.request.user
         detail_contact_click_confirm = self.request.POST.get("detail_contact_click_confirm", False) == "true"
         siae_id = request.GET.get("siae_id", None)
-        print("TenderDetailContactClickStatView post", siae_id)
         if (user.is_authenticated and user.kind == User.KIND_SIAE) or siae_id:
             if detail_contact_click_confirm:
                 # update detail_contact_click_date
@@ -395,7 +394,7 @@ class TenderDetailContactClickStatView(LoginRequiredOrSiaeIdParamMixin, UpdateVi
         if detail_contact_click_confirm:
             success_url += "?nps=true"
             if siae_id:
-                success_url += "&siae_id=true"
+                success_url += f"&siae_id={siae_id}"
         return success_url
 
     def get_success_message(self, detail_contact_click_confirm):


### PR DESCRIPTION
### Quoi ?

Permettre aux utilisateurs anonyme de cliquer sur "Accéder aux coordonnées", grâce au `siae_id` dans l'url
- envoyer le paramètre `siae_id` dans les e-mails de mise en relation
- pouvoir cliquer sur "Accéder aux coordonnées" si le paramètre `siae_id` est fourni
- nouveau mixin `LoginRequiredOrSiaeIdParamMixin`
- ajout de tests