### PR TITLE
Fiche structure : changer le label des salariés en insertion pour les ESAT/EA

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -998,8 +998,8 @@ class Siae(models.Model):
             return "l'ASP"
 
     @property
-    def kind_is_esat_or_ea(self):
-        return self.kind in [siae_constants.KIND_ESAT, siae_constants.KIND_EA]
+    def kind_is_esat_or_ea_or_eatt(self):
+        return self.kind in [siae_constants.KIND_ESAT, siae_constants.KIND_EA, siae_constants.KIND_EATT]
 
     @property
     def completion_percent(self):

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -924,6 +924,12 @@ class Siae(models.Model):
         return "non disponible"
 
     @property
+    def etp_count_label_display(self):
+        if self.kind_is_esat_or_ea_or_eatt:
+            return "Travailleurs en situation de handicap"
+        return "Salariés en insertion"
+
+    @property
     def etp_count_display(self):
         if self.employees_insertion_count:
             return self.employees_insertion_count

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -136,13 +136,14 @@ class SiaeModelTest(TestCase):
         siae_full_2.save()  # to update stats
         self.assertFalse(siae_full_2.is_missing_content)
 
-    def test_kind_is_esat_or_ea_property(self):
+    def test_kind_is_esat_or_ea_or_eatt_property(self):
         siae_esat = SiaeFactory(kind=siae_constants.KIND_ESAT)
-        self.assertTrue(siae_esat.kind_is_esat_or_ea)
         siae_ea = SiaeFactory(kind=siae_constants.KIND_EA)
-        self.assertTrue(siae_ea.kind_is_esat_or_ea)
+        siae_eatt = SiaeFactory(kind=siae_constants.KIND_EATT)
         siae_ei = SiaeFactory(kind=siae_constants.KIND_EI)
-        self.assertFalse(siae_ei.kind_is_esat_or_ea)
+        for siae in [siae_esat, siae_ea, siae_eatt]:
+            self.assertTrue(siae.kind_is_esat_or_ea_or_eatt)
+        self.assertFalse(siae_ei.kind_is_esat_or_ea_or_eatt)
 
 
 class SiaeModelSaveTest(TestCase):

--- a/lemarche/templates/dashboard/siae_edit_info.html
+++ b/lemarche/templates/dashboard/siae_edit_info.html
@@ -99,7 +99,7 @@
         <div class="col-12 col-lg-8">
             <div class="bg-white d-block rounded-lg shadow-lg p-3 p-lg-5">
                 <fieldset>
-                    <legend class="h5">{% get_verbose_name siae 'employees_insertion_count' %}</legend>
+                    <legend class="h5">Nombre de {{ siae.etp_count_label_display | lower }}</legend>
                     {% bootstrap_field form.employees_insertion_count show_label=False %}
                 </fieldset>
             </div>
@@ -111,7 +111,7 @@
                     <strong>Conseil</strong>
                 </p>
                 <p class="mb-0">
-                    Le nombre de salariés en insertion démontre à la fois votre capacité de production et l'impact social de votre structure.
+                    Le nombre de {{ siae.etp_count_label_display | lower }} démontre à la fois votre capacité de production et l'impact social de votre structure.
                 </p>
             </div>
         </div>

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -5,7 +5,7 @@
         <div class="col">
             <h4>Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
 
-            {% if siae.kind_is_esat_or_ea %}
+            {% if siae.kind_is_esat_or_ea_or_eatt %}
                 <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" target="_blank" id="track_siae_detail_partners_esat_ea" class="btn btn-sm btn-outline-primary btn-ico">
                     <span>Découvrez-les maintenant</span>
                     <i class="ri-arrow-right-up-line ri-lg"></i>

--- a/lemarche/templates/siaes/_useful_infos_siae.html
+++ b/lemarche/templates/siaes/_useful_infos_siae.html
@@ -47,7 +47,7 @@
         <div class="row">
             <div class="col-12">
                 <i class="ri-user-add-line"></i>
-                <strong>Salariés en insertion :</strong>
+                <strong>{{ siae.etp_count_label_display }} :</strong>
                 <span>{{ siae.etp_count_display|floatformat:0|default:"non disponible" }}</span>
             </div>
         </div>

--- a/lemarche/templates/siaes/_useful_infos_siae_v2.html
+++ b/lemarche/templates/siaes/_useful_infos_siae_v2.html
@@ -30,7 +30,7 @@
             </li>
             <li class="mb-2">
                 <i class="ri-user-add-line"></i>
-                <strong>Salariés en insertion :</strong>
+                <strong>{{ siae.etp_count_label_display }} :</strong>
                 <span>{{ siae.etp_count_display|floatformat:0|default:"non disponible" }}</span>
             </li>
             <li class="mb-2">

--- a/lemarche/templates/siaes/_useful_infos_siae_v2.html
+++ b/lemarche/templates/siaes/_useful_infos_siae_v2.html
@@ -1,4 +1,5 @@
 {% load array_choices_display %}
+
 <div class="row">
     <div class="col-12 col-md-6">
         <ul class="list-unstyled">


### PR DESCRIPTION
### Quoi ?

Pour les ESAT/EA/EATT, on ne parle pas de salariés en insertion, mais de travailleurs en situation de handicap

Modifications à 2 endroits
- sur la fiche des structures concernées
- sur le formulaire de modification de sa structure

### Captures d'écran

||Image|
|---|---|
|Fiche structure (EATT)|![image](https://github.com/betagouv/itou-marche/assets/7147385/7b0e6800-7a56-46d0-afd3-3b0720f21adb)|
|Formulaire de modification (EATT)|![image](https://github.com/betagouv/itou-marche/assets/7147385/3bb23b02-927c-4d66-8d50-876f6a934f66)|