### PR TITLE
[Dépôt de besoin - dashboard acheteur] ajout d'une vue pour voir les structures qui ont vu le DB

### DIFF
--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -102,6 +102,10 @@
                             <i class="ri-focus-2-line"></i>
                             {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
                         </a>
+                        <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEW" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
+                            <i class="ri-focus-2-line"></i>
+                            {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_email_send_date_count|pluralize }} qui {{ tender.siae_email_send_date_count|pluralize:'a,ont' }} vu
+                        </a>
                         <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-interested-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-thumb-up-line"></i>
                             {{ tender.siae_detail_contact_click_date_count }} prestataire{{ tender.siae_detail_contact_click_date_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_date_count|pluralize }}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -102,7 +102,7 @@
                             <i class="ri-focus-2-line"></i>
                             {{ tender.siae_email_send_date_count }} prestataire{{ tender.siae_email_send_date_count|pluralize }} ciblé{{ tender.siae_email_send_date_count|pluralize }}
                         </a>
-                        <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEW" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
+                        <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEWED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-focus-2-line"></i>
                             {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_email_send_date_count|pluralize }} qui {{ tender.siae_email_send_date_count|pluralize:'a,ont' }} vu
                         </a>

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -71,7 +71,7 @@
         <div id="tenderSiaeList">
             <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
                 {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
-                {% url 'tenders:detail-siae-list' slug=tender.slug status="VIEW" as TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL %}
+                {% url 'tenders:detail-siae-list' slug=tender.slug status="VIEWED" as TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL %}
                 {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
 
                 <li class="nav-item">

--- a/lemarche/templates/tenders/siae_interested_list.html
+++ b/lemarche/templates/tenders/siae_interested_list.html
@@ -71,6 +71,7 @@
         <div id="tenderSiaeList">
             <ul role="navigation" class="nav nav-tabs nav-tabs--marche" style="border-bottom:0;">
                 {% url 'tenders:detail-siae-list' slug=tender.slug as TENDER_SIAE_LIST_URL %}
+                {% url 'tenders:detail-siae-list' slug=tender.slug status="VIEW" as TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL %}
                 {% url 'tenders:detail-siae-list' slug=tender.slug status="INTERESTED" as TENDER_SIAE_DETAIL_CONTACT_CLICK_LIST_URL %}
 
                 <li class="nav-item">
@@ -78,6 +79,13 @@
                         class="nav-link{% if request.path == TENDER_SIAE_LIST_URL %} active{% endif %}"
                         hx-target="#tenderSiaeList" hx-swap="outerHTML">
                         Prestataires ciblés
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a role="button" hx-push-url="true" hx-get="{{ TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL }}?{{ current_search_query }}"
+                        class="nav-link{% if request.path == TENDER_SIAE_DETAIL_CONTACT_VIEW_LIST_URL %} active{% endif %}"
+                        hx-target="#tenderSiaeList" hx-swap="outerHTML">
+                        Prestataires qui ont vu
                     </a>
                 </li>
                 <li class="nav-item">

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -417,7 +417,7 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         if self.status == "INTERESTED":  # status == "INTERESTED"
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
-        elif self.status == "VIEW":  # status == "INTERESTED"
+        elif self.status == "VIEWED":  # status == "INTERESTED"
             qs = qs.filter(
                 Q(tendersiae__tender=self.tender)
                 & (

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
@@ -418,7 +418,13 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
         elif self.status == "VIEW":  # status == "INTERESTED"
-            qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_link_click_date__isnull=False)
+            qs = qs.filter(
+                Q(tendersiae__tender=self.tender)
+                & (
+                    Q(tendersiae__email_link_click_date__isnull=False)
+                    | Q(tendersiae__detail_display_date__isnull=False)
+                )
+            ).distinct()
             qs = qs.order_by("-tendersiae__email_link_click_date")
         else:  # default
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_send_date__isnull=False)

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -414,9 +414,12 @@ class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):
         qs = super().get_queryset()
         # first get the tender's siaes
         self.tender = Tender.objects.get(slug=self.kwargs.get("slug"))
-        if self.status:  # status == "INTERESTED"
+        if self.status == "INTERESTED":  # status == "INTERESTED"
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__detail_contact_click_date__isnull=False)
             qs = qs.order_by("-tendersiae__detail_contact_click_date")
+        elif self.status == "VIEW":  # status == "INTERESTED"
+            qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_link_click_date__isnull=False)
+            qs = qs.order_by("-tendersiae__email_link_click_date")
         else:  # default
             qs = qs.filter(tendersiae__tender=self.tender, tendersiae__email_send_date__isnull=False)
             qs = qs.order_by("-tendersiae__email_send_date")


### PR DESCRIPTION
### Quoi ?

 ajout d'une vue pour voir les structures qui ont vu le DB dans le dashboard acheteur


### Captures d'écran (optionnel)

| Avant | Après |
|--------|--------|
| <img width="1368" alt="image" src="https://github.com/betagouv/itou-marche/assets/12339682/e4b91a4b-dc03-4560-bed1-2a581fa4bc3b"> | <img width="1368" alt="image" src="https://github.com/betagouv/itou-marche/assets/12339682/a60eff2d-aa32-4dc7-858e-e0789887f9dc"> |
| <img width="1368" alt="image" src="https://github.com/betagouv/itou-marche/assets/12339682/6e227d08-1f57-4baa-b089-79011e177cc6"> | <img width="1368" alt="image" src="https://github.com/betagouv/itou-marche/assets/12339682/f5aa4fae-3ac5-47d5-b99b-cfa6a8fe6c2c"> | 