### PR TITLE
[Recherche] Remonter les prestataires qui ont un logo

### DIFF
--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -335,23 +335,26 @@ class SiaeFilterForm(forms.Form):
         - push siae to update their profile, and have the freshest data at the top
         - we tried random order ("?"), but it had some bugs with pagination
         **BUT**
-        - if a Siae has a a SiaeOffer, or a description, or a User, then it is "boosted"
+        - if a Siae has a a SiaeOffer, or a description, or a logo, or a User, then it is "boosted"
         - if the search is on a CITY perimeter, we order by coordinates first
         - if the search is by keyword, order by "similarity" only
         """
         DEFAULT_ORDERING = ["-updated_at"]
-        ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_user"] + DEFAULT_ORDERING
+        ORDER_BY_FIELDS = ["-has_offer", "-has_description", "-has_logo", "-has_user"] + DEFAULT_ORDERING
         # annotate on description presence: https://stackoverflow.com/a/65014409/4293684
         # qs = qs.annotate(has_description=Exists(F("description")))  # doesn't work
+        qs = qs.annotate(
+            has_offer=Case(
+                When(offer_count__gte=1, then=Value(True)), default=Value(False), output_field=BooleanField()
+            )
+        )
         qs = qs.annotate(
             has_description=Case(
                 When(description__gte=1, then=Value(True)), default=Value(False), output_field=BooleanField()
             )
         )
         qs = qs.annotate(
-            has_offer=Case(
-                When(offer_count__gte=1, then=Value(True)), default=Value(False), output_field=BooleanField()
-            )
+            has_logo=Case(When(logo_url__gte=1, then=Value(True)), default=Value(False), output_field=BooleanField())
         )
         qs = qs.annotate(
             has_user=Case(When(user_count__gte=1, then=Value(True)), default=Value(False), output_field=BooleanField())

--- a/lemarche/www/siaes/tests.py
+++ b/lemarche/www/siaes/tests.py
@@ -1016,7 +1016,7 @@ class SiaeSearchOrderTest(TestCase):
         self.assertEqual(siaes[0].name, "ABC Insertion")
 
     def test_should_bring_the_siae_with_users_to_the_top(self):
-        siae_with_user = SiaeFactory(name="ZZ ESI")
+        siae_with_user = SiaeFactory(name="ZZ ESI user")
         user = UserFactory()
         siae_with_user.users.add(user)
         url = reverse("siae:search_results", kwargs={})
@@ -1024,19 +1024,28 @@ class SiaeSearchOrderTest(TestCase):
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_user, True)
-        self.assertEqual(siaes[0].name, "ZZ ESI")
+        self.assertEqual(siaes[0].name, "ZZ ESI user")
+
+    def test_should_bring_the_siae_with_logos_to_the_top(self):
+        SiaeFactory(name="ZZ ESI logo", logo_url="https://logo.png")
+        url = reverse("siae:search_results", kwargs={})
+        response = self.client.get(url)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 3 + 1)
+        self.assertEqual(siaes[0].has_logo, True)
+        self.assertEqual(siaes[0].name, "ZZ ESI logo")
 
     def test_should_bring_the_siae_with_descriptions_to_the_top(self):
-        SiaeFactory(name="ZZ ESI 2", description="coucou")
+        SiaeFactory(name="ZZ ESI description", description="coucou")
         url = reverse("siae:search_results", kwargs={})
         response = self.client.get(url)
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_description, True)
-        self.assertEqual(siaes[0].name, "ZZ ESI 2")
+        self.assertEqual(siaes[0].name, "ZZ ESI description")
 
     def test_should_bring_the_siae_with_offers_to_the_top(self):
-        siae_with_offer = SiaeFactory(name="ZZ ESI 3")
+        siae_with_offer = SiaeFactory(name="ZZ ESI offer")
         SiaeOfferFactory(siae=siae_with_offer)
         siae_with_offer.save()  # to update the siae count fields
         url = reverse("siae:search_results", kwargs={})
@@ -1044,7 +1053,7 @@ class SiaeSearchOrderTest(TestCase):
         siaes = list(response.context["siaes"])
         self.assertEqual(len(siaes), 3 + 1)
         self.assertEqual(siaes[0].has_offer, True)
-        self.assertEqual(siaes[0].name, "ZZ ESI 3")
+        self.assertEqual(siaes[0].name, "ZZ ESI offer")
 
     def test_should_bring_the_siae_closer_to_the_city_to_the_top(self):
         SiaeFactory(


### PR DESCRIPTION
### Quoi ?

Dans les résultats de recherche, booster la position des prestataires qui ont un logo (on boostait déjà ceux qui avaient rempli leur prestations et leur description)