### PR TITLE
[Aperçu du besoin] Ajout du bouton "Répondre en co-traitance"

### DIFF
--- a/lemarche/templates/layouts/base.html
+++ b/lemarche/templates/layouts/base.html
@@ -51,7 +51,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 
-<body id="top" class="{% block body_class %}{% endblock %}">
+<body id="top" class="{% block body_class %}{% endblock %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <!-- allow a user to go to the main content of the page -->
     <noscript>
         <div class="alert alert-danger" role="status">

--- a/lemarche/templates/tenders/_detail_cocontracting_click_confirm.html
+++ b/lemarche/templates/tenders/_detail_cocontracting_click_confirm.html
@@ -1,0 +1,6 @@
+<div class="alert alert-success mt-3 mt-lg-0" role="alert">
+    <p class="mb-0 fs-sm">
+        Nous avons bien pris en compte votre demande de mise en relation.
+        Notre équipe revient vers vous dans les plus brefs délais.
+    </p>
+</div>

--- a/lemarche/templates/tenders/_detail_cocontracting_click_error.html
+++ b/lemarche/templates/tenders/_detail_cocontracting_click_error.html
@@ -1,0 +1,5 @@
+<div class="alert alert-danger mt-3 mt-lg-0" role="alert">
+    <p class="mb-0 fs-sm">
+        N'ayant pu identifier votre structure, nous n'avons pas pu prendre en compte votre demande de mise en relation.
+    </p>
+</div>

--- a/lemarche/templates/tenders/_detail_cta_cocontracting.html
+++ b/lemarche/templates/tenders/_detail_cta_cocontracting.html
@@ -2,16 +2,14 @@
     <div class="card c-card rounded-lg shadow-lg">
         <div class="card-body">
             <h3>Répondre en co-traitance ?</h3>
-
             <p>Notre équipe vous met en relation avec d’autres structures désireuses de répondre en co-traitance.</p>
-
             {% if user.is_authenticated %}
                 <button type="button" class="btn btn-primary btn-block" title="Être mis en relation" hx-post="{% url 'tenders:detail-cocontracting-click' tender.slug %}" hx-target="#detail_cocontracting_container">
                     Être mis en relation
                 </button>
-            {% else %}
-                <button type="button" class="btn btn-primary btn-block" title="Être mis en relation">
-                    Être mis en relation pour {{ siae_id }}
+            {% elif siae_id %}
+                <button type="button" class="btn btn-primary btn-block" title="Être mis en relation" hx-post="{% url 'tenders:detail-cocontracting-click' tender.slug %}?siae_id={{siae_id}}" hx-target="#detail_cocontracting_container">
+                    Être mis en relation
                 </button>
             {% endif %}
         </div>

--- a/lemarche/templates/tenders/_detail_cta_cocontracting.html
+++ b/lemarche/templates/tenders/_detail_cta_cocontracting.html
@@ -1,0 +1,19 @@
+<div id="detail_cocontracting_container" class="mt-3">
+    <div class="card c-card rounded-lg shadow-lg">
+        <div class="card-body">
+            <h3>Répondre en co-traitance ?</h3>
+
+            <p>Notre équipe vous met en relation avec d’autres structures désireuses de répondre en co-traitance.</p>
+
+            {% if user.is_authenticated %}
+                <button type="button" class="btn btn-primary btn-block" title="Être mis en relation" hx-post="{% url 'tenders:detail-cocontracting-click' tender.slug %}" hx-target="#detail_cocontracting_container">
+                    Être mis en relation
+                </button>
+            {% else %}
+                <button type="button" class="btn btn-primary btn-block" title="Être mis en relation">
+                    Être mis en relation pour {{ siae_id }}
+                </button>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/lemarche/templates/tenders/cocontracting_notification_email_admin_body.txt
+++ b/lemarche/templates/tenders/cocontracting_notification_email_admin_body.txt
@@ -1,0 +1,8 @@
+La structure {{ siae_name|safe }} souhaite répondre en co-traitance
+
+Titre : {{ tender_title|safe }}
+Type : {{ tender_kind|safe }}
+Contact email de l'ESI: {{ siae_contact_email|safe }}
+SIRET : {{ siae_siret|safe }}
+
+Lien dans l'admin : {{ tender_admin_url }}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -148,11 +148,13 @@
                                     </div>
                                 {% elif not user_siae_has_detail_contact_click_date %}
                                     {% include "tenders/_detail_cta.html" with tender=tender user_can_click=True %}
+                                    {% include "tenders/_detail_cta_cocontracting.html" with tender=tender %}
                                 {% endif %}
                             {% endif %}
                         {% elif siae_id %}
                             {% if not siae_has_detail_contact_click_date %}
                                 {% include "tenders/_detail_cta.html" with tender=tender user_can_click=True siae_id=siae_id %}
+                                {% include "tenders/_detail_cta_cocontracting.html" with tender=tender siae_id=siae_id %}
                             {% else %}
                                 {% include "tenders/_detail_contact.html" with tender=tender %}
                             {% endif %}

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -555,4 +555,5 @@ def notify_admin_siae_wants_cocontracting(tender: Tender, siae: Siae):
         recipient_list=[settings.NOTIFY_EMAIL],
     )
 
-    # api_slack.send_message_to_channel(text=email_body, service_id=settings.SLACK_WEBHOOK_C4_SUPPORT_CHANNEL)
+    if settings.BITOUBI_ENV == "prod":
+        api_slack.send_message_to_channel(text=email_body, service_id=settings.SLACK_WEBHOOK_C4_SUPPORT_CHANNEL)

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -533,3 +533,26 @@ def send_tenders_author_30_days(tender: Tender, kind="feedback"):
         }
         tender.logs.append(log_item)
         tender.save()
+
+
+def notify_admin_siae_wants_cocontracting(tender: Tender, siae: Siae):
+    email_subject = f"Marché de l'inclusion : la structure {siae.name} souhaite répondre en co-traitance"
+    tender_admin_url = get_admin_url_object(tender)
+    email_body = render_to_string(
+        "tenders/cocontracting_notification_email_admin_body.txt",
+        {
+            "tender_title": tender.title,
+            "tender_kind": tender.get_kind_display(),
+            "tender_admin_url": tender_admin_url,
+            "siae_name": siae.name,
+            "siae_contact_email": siae.contact_email,
+            "siae_siret": siae.siret,
+        },
+    )
+    send_mail_async(
+        email_subject=email_subject,
+        email_body=email_body,
+        recipient_list=[settings.NOTIFY_EMAIL],
+    )
+
+    # api_slack.send_message_to_channel(text=email_body, service_id=settings.SLACK_WEBHOOK_C4_SUPPORT_CHANNEL)

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -3,6 +3,7 @@ from django.views.generic import RedirectView
 
 from lemarche.www.tenders.views import (
     TenderCreateMultiStepView,
+    TenderDetailCocontractingClickView,
     TenderDetailContactClickStatView,
     TenderDetailSurveyTransactionedView,
     TenderDetailView,
@@ -31,6 +32,11 @@ urlpatterns = [
     path("<str:slug>/prestataires", TenderSiaeListView.as_view(), name="detail-siae-list"),
     path(
         "<str:slug>/contact-click-stat", TenderDetailContactClickStatView.as_view(), name="detail-contact-click-stat"
+    ),
+    path(
+        "<str:slug>/cocontracting-click",
+        TenderDetailCocontractingClickView.as_view(),
+        name="detail-cocontracting-click",
     ),
     path(
         "<str:slug>/sondage-transaction",

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
 from django.db.models import Prefetch
-from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -32,6 +32,7 @@ from lemarche.www.tenders.forms import (
     TenderCreateStepSurveyForm,
 )
 from lemarche.www.tenders.tasks import (  # , send_tender_emails_to_siaes
+    notify_admin_siae_wants_cocontracting,
     notify_admin_tender_created,
     send_siae_interested_email_to_author,
 )
@@ -401,6 +402,27 @@ class TenderDetailContactClickStatView(SiaeUserRequiredOrSiaeIdParamMixin, Updat
         if detail_contact_click_confirm:
             return "<strong>Bravo !</strong><br />Vos coordonnées, ainsi que le lien vers votre fiche commerciale ont été transmis à l'acheteur. Assurez-vous d'avoir une fiche commerciale bien renseignée."  # noqa
         return f"<strong>{self.object.cta_card_button_text}</strong><br />Pour {self.object.cta_card_button_text.lower()}, vous devez accepter d'être mis en relation avec l'acheteur."  # noqa
+
+
+class TenderDetailCocontractingClickView(LoginRequiredMixin, DetailView):
+    """
+    Endpoint to handle cocontracting button click
+    """
+
+    template_name = "tenders/_detail_cocontracting_click_confirm.html"
+    model = Tender
+
+    def get_object(self):
+        return get_object_or_404(Tender, slug=self.kwargs.get("slug"))
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        user = self.request.user
+
+        if settings.BITOUBI_ENV == "prod":
+            notify_admin_siae_wants_cocontracting(self.object, user.siaes.first())
+
+        return self.get(request)
 
 
 class TenderSiaeListView(TenderAuthorOrAdminRequiredMixin, FormMixin, ListView):


### PR DESCRIPTION
### Quoi ?

Ajout d'un encart pour les réponses en co-traitance.

### Pourquoi ?

Pour inciter et organiser la co-traitance.

### Comment ?

Avec un bouton "¨Être mis en relation" qui notifie l'équipe de la plateforme.

### Captures d'écran

#### Encart sur l'aperçu des besoins
![Encart sur l'aperçu des besoins](https://github.com/betagouv/itou-marche/assets/17601807/df85c1b0-c50e-46b6-a1f0-59291034a9ef)

#### Message de confirmation
![Message de confirmation](https://github.com/betagouv/itou-marche/assets/17601807/9fde8a6e-b460-4737-8590-3970b8b0edb4)

#### Message d'erreur (si le `siae_id` est erroné par exemple):
![Message d'erreur](https://github.com/betagouv/itou-marche/assets/17601807/87bb763f-290f-40ff-96a7-da8c8f6547f6)




