### PR TITLE
[Dépôt de besoin] Simplification du formulaire en supprimant les informations de contact pour les utilisateurs connectés

### DIFF
--- a/lemarche/templates/tenders/create_step_contact.html
+++ b/lemarche/templates/tenders/create_step_contact.html
@@ -9,15 +9,13 @@
 {% csrf_token %}
 <div class="row">
     <div class="col-12 col-lg-7">
-        <div class="form-row">
-            {% bootstrap_field form.contact_first_name form_group_class="form-group col-12 col-md-6" %}
-            {% bootstrap_field form.contact_last_name form_group_class="form-group col-12 col-md-6" %}
-        </div>
         {% bootstrap_field form.contact_company_name %}
-        <div class="form-row">
-            {% bootstrap_field form.contact_email form_group_class="form-group col-12 col-md-6" %}
-            {% bootstrap_field form.contact_phone form_group_class="form-group col-12 col-md-6" %}
-        </div>
+        {% if not user.is_authenticated %}
+            <div class="form-row">
+                {% bootstrap_field form.contact_email form_group_class="form-group col-12 col-md-6" %}
+                {% bootstrap_field form.contact_phone form_group_class="form-group col-12 col-md-6" %}
+            </div>
+        {% endif %}
         {% bootstrap_field form.response_kind %}
         {% bootstrap_field form.deadline_date %}
     </div>

--- a/lemarche/templates/tenders/create_step_contact.html
+++ b/lemarche/templates/tenders/create_step_contact.html
@@ -9,6 +9,12 @@
 {% csrf_token %}
 <div class="row">
     <div class="col-12 col-lg-7">
+        {% if not user.is_authenticated %}
+            <div class="form-row">
+                {% bootstrap_field form.contact_first_name form_group_class="form-group col-12 col-md-6" %}
+                {% bootstrap_field form.contact_last_name form_group_class="form-group col-12 col-md-6" %}
+            </div>
+        {% endif %}
         {% bootstrap_field form.contact_company_name %}
         {% if not user.is_authenticated %}
             <div class="form-row">

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -135,8 +135,6 @@ class TenderCreateStepContactForm(forms.ModelForm):
     class Meta:
         model = Tender
         fields = [
-            "contact_first_name",
-            "contact_last_name",
             "contact_email",
             "contact_phone",
             "response_kind",
@@ -150,26 +148,22 @@ class TenderCreateStepContactForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.max_deadline_date = max_deadline_date
         self.external_link = external_link
-        user_is_anonymous = not user.is_authenticated
+        self.user_is_anonymous = not user.is_authenticated
 
         if self.instance.deadline_date:
             self.initial["deadline_date"] = self.instance.deadline_date.isoformat()
 
         # required fields
-        self.fields["contact_first_name"].required = True
-        self.fields["contact_last_name"].required = True
         self.fields["response_kind"].required = True
         self.fields["deadline_date"].required = True
-        if user_is_anonymous:
+        if self.user_is_anonymous:
             self.fields["contact_email"].required = True
             self.fields["contact_phone"].required = True
         else:
-            self.initial["contact_first_name"] = user.first_name
-            self.initial["contact_last_name"] = user.last_name
-            self.initial["contact_email"] = user.email
-            self.initial["contact_phone"] = user.phone
+            del self.fields["contact_email"]
+            del self.fields["contact_phone"]
 
-        user_does_not_have_company_name = user_is_anonymous or not user.company_name
+        user_does_not_have_company_name = self.user_is_anonymous or not user.company_name
         if user_does_not_have_company_name:
             self.fields["contact_company_name"].widget = forms.TextInput()  # HiddenInput() by default
             self.fields["contact_company_name"].required = True
@@ -194,18 +188,20 @@ class TenderCreateStepContactForm(forms.ModelForm):
             self.add_error(
                 "deadline_date", "La date de clôture des réponses ne doit pas être antérieure à aujourd'hui."
             )
-        # contact_email must be filled if RESPONSE_KIND_TEL
-        if self.cleaned_data.get("response_kind") and (
-            Tender.RESPONSE_KIND_EMAIL in self.cleaned_data.get("response_kind")
-            and not self.cleaned_data.get("contact_email")
-        ):
-            self.add_error("response_kind", "E-mail sélectionné mais aucun e-mail renseigné.")
-        # contact_phone must be filled if RESPONSE_KIND_TEL
-        if self.cleaned_data.get("response_kind") and (
-            Tender.RESPONSE_KIND_TEL in self.cleaned_data.get("response_kind")
-            and not self.cleaned_data.get("contact_phone")
-        ):
-            self.add_error("response_kind", "Téléphone sélectionné mais aucun téléphone renseigné.")
+
+        if self.user_is_anonymous:
+            # contact_email must be filled if RESPONSE_KIND_EMAIL
+            if self.cleaned_data.get("response_kind") and (
+                Tender.RESPONSE_KIND_EMAIL in self.cleaned_data.get("response_kind")
+                and not self.cleaned_data.get("contact_email")
+            ):
+                self.add_error("response_kind", "E-mail sélectionné mais aucun e-mail renseigné.")
+            # contact_phone must be filled if RESPONSE_KIND_TEL
+            if self.cleaned_data.get("response_kind") and (
+                Tender.RESPONSE_KIND_TEL in self.cleaned_data.get("response_kind")
+                and not self.cleaned_data.get("contact_phone")
+            ):
+                self.add_error("response_kind", "Téléphone sélectionné mais aucun téléphone renseigné.")
         # external_link must be filled if RESPONSE_KIND_EXTERNAL
         if self.cleaned_data.get("response_kind") and (
             Tender.RESPONSE_KIND_EXTERNAL in self.cleaned_data.get("response_kind") and not self.external_link

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -135,6 +135,8 @@ class TenderCreateStepContactForm(forms.ModelForm):
     class Meta:
         model = Tender
         fields = [
+            "contact_first_name",
+            "contact_last_name",
             "contact_email",
             "contact_phone",
             "response_kind",
@@ -157,9 +159,13 @@ class TenderCreateStepContactForm(forms.ModelForm):
         self.fields["response_kind"].required = True
         self.fields["deadline_date"].required = True
         if self.user_is_anonymous:
+            self.fields["contact_first_name"].required = True
+            self.fields["contact_last_name"].required = True
             self.fields["contact_email"].required = True
             self.fields["contact_phone"].required = True
         else:
+            del self.fields["contact_first_name"]
+            del self.fields["contact_last_name"]
             del self.fields["contact_email"]
             del self.fields["contact_phone"]
 

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -145,6 +145,12 @@ class TenderCreateStepContactForm(forms.ModelForm):
         widgets = {
             "deadline_date": forms.widgets.DateInput(attrs={"class": "form-control", "type": "date"}),
         }
+        labels = {
+            "contact_first_name": "Prénom",
+            "contact_last_name": "Nom",
+            "contact_email": "E-mail",
+            "contact_phone": "Téléphone",
+        }
 
     def __init__(self, max_deadline_date, external_link, user: User, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -55,6 +55,8 @@ class TenderCreateViewTest(TestCase):
         } | _step_2
         step_3 = {
             "tender_create_multi_step_view-current_step": "contact",
+            "contact-contact_first_name": tender_not_saved.contact_first_name,
+            "contact-contact_last_name": tender_not_saved.contact_last_name,
             "contact-contact_email": tender_not_saved.contact_email,
             "contact-contact_phone": "0123456789",
             "contact-contact_company_name": "TEST",

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -55,8 +55,6 @@ class TenderCreateViewTest(TestCase):
         } | _step_2
         step_3 = {
             "tender_create_multi_step_view-current_step": "contact",
-            "contact-contact_first_name": tender_not_saved.contact_first_name,
-            "contact-contact_last_name": tender_not_saved.contact_last_name,
             "contact-contact_email": tender_not_saved.contact_email,
             "contact-contact_phone": "0123456789",
             "contact-contact_company_name": "TEST",
@@ -119,6 +117,11 @@ class TenderCreateViewTest(TestCase):
                 TenderCreateMultiStepView, tenders_step_data, tender, is_draft=False
             ),
         )
+        self.assertEqual(tender.contact_first_name, self.user_buyer.first_name)
+        self.assertEqual(tender.contact_last_name, self.user_buyer.last_name)
+        self.assertEqual(tender.contact_email, self.user_buyer.email)
+        self.assertEqual(tender.contact_phone, self.user_buyer.phone)
+
 
     def test_tender_wizard_form_not_created(self):
         self.client.force_login(self.user_buyer)

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -122,7 +122,6 @@ class TenderCreateViewTest(TestCase):
         self.assertEqual(tender.contact_email, self.user_buyer.email)
         self.assertEqual(tender.contact_phone, self.user_buyer.phone)
 
-
     def test_tender_wizard_form_not_created(self):
         self.client.force_login(self.user_buyer)
         tenders_step_data = self._generate_fake_data_form()

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -56,8 +56,8 @@ def get_or_create_user_from_anonymous_content(tender_dict: dict, source: str = U
     user, created = User.objects.get_or_create(
         email=email,
         defaults={
-            "first_name": "",
-            "last_name": "",
+            "first_name": tender_dict.get("contact_first_name"),
+            "last_name": tender_dict.get("contact_last_name"),
             "phone": tender_dict.get("contact_phone"),
             "company_name": tender_dict.pop("contact_company_name")
             if tender_dict.get("contact_company_name")

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -56,8 +56,8 @@ def get_or_create_user_from_anonymous_content(tender_dict: dict, source: str = U
     user, created = User.objects.get_or_create(
         email=email,
         defaults={
-            "first_name": tender_dict.get("contact_first_name"),
-            "last_name": tender_dict.get("contact_last_name"),
+            "first_name": "",
+            "last_name": "",
             "phone": tender_dict.get("contact_phone"),
             "company_name": tender_dict.pop("contact_company_name")
             if tender_dict.get("contact_company_name")

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -177,9 +177,22 @@ class TenderCreateMultiStepView(SessionWizardView):
                     elif step == self.STEP_SURVEY:
                         setattr(self.instance, "scale_marche_useless", tender_dict.get("scale_marche_useless"))
                         self.instance.extra_data.update(tender_dict.get("extra_data"))
+            if self.request.user.is_authenticated:
+                self.instance.contact_first_name = self.request.user.first_name
+                self.instance.contact_last_name = self.request.user.last_name
+                self.instance.contact_email = self.request.user.email
+                self.instance.contact_phone = self.request.user.phone
+
             self.instance.save()
         else:
             tender_dict |= {"status": tender_status, "published_at": tender_published_at}
+            if self.request.user.is_authenticated:
+                tender_dict |= {
+                    "contact_first_name": self.request.user.first_name,
+                    "contact_last_name": self.request.user.last_name,
+                    "contact_email": self.request.user.email,
+                    "contact_phone": self.request.user.phone,
+                }
             self.instance = create_tender_from_dict(tender_dict)
 
     def done(self, _, form_dict, **kwargs):

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -152,6 +152,15 @@ class TenderCreateMultiStepView(SessionWizardView):
     def save_instance_tender(self, tender_dict: dict, form_dict: dict, is_draft: bool):
         tender_status = tender_constants.STATUS_DRAFT if is_draft else tender_constants.STATUS_PUBLISHED
         tender_published_at = None if is_draft else timezone.now()
+
+        if self.request.user.is_authenticated:
+            tender_dict |= {
+                "contact_first_name": self.request.user.first_name,
+                "contact_last_name": self.request.user.last_name,
+                "contact_email": self.request.user.email,
+                "contact_phone": self.request.user.phone,
+            }
+
         if self.instance.id:
             # update
             self.instance.status = tender_status
@@ -161,38 +170,26 @@ class TenderCreateMultiStepView(SessionWizardView):
                 if model_form.has_changed():
                     if step != self.STEP_SURVEY:
                         for attribute in model_form.changed_data:
-                            if attribute == "sectors":
-                                sectors = tender_dict.get("sectors", None)
-                                self.instance.sectors.set(sectors)
-                            elif attribute == "location":
-                                location = tender_dict.get("location")
-                                self.instance.location = location
-                                self.instance.perimeters.set([location])
-                            elif attribute == "questions_list":
-                                update_or_create_questions_list(
-                                    tender=self.instance, questions_list=tender_dict.get("questions_list")
-                                )
-                            else:
-                                setattr(self.instance, attribute, tender_dict.get(attribute))
+                            match attribute:
+                                case "sectors":
+                                    sectors = tender_dict.get("sectors", None)
+                                    self.instance.sectors.set(sectors)
+                                case "location":
+                                    location = tender_dict.get("location")
+                                    self.instance.location = location
+                                    self.instance.perimeters.set([location])
+                                case "questions_list":
+                                    update_or_create_questions_list(
+                                        tender=self.instance, questions_list=tender_dict.get("questions_list")
+                                    )
+                                case _:
+                                    setattr(self.instance, attribute, tender_dict.get(attribute))
                     elif step == self.STEP_SURVEY:
                         setattr(self.instance, "scale_marche_useless", tender_dict.get("scale_marche_useless"))
                         self.instance.extra_data.update(tender_dict.get("extra_data"))
-            if self.request.user.is_authenticated:
-                self.instance.contact_first_name = self.request.user.first_name
-                self.instance.contact_last_name = self.request.user.last_name
-                self.instance.contact_email = self.request.user.email
-                self.instance.contact_phone = self.request.user.phone
-
             self.instance.save()
         else:
             tender_dict |= {"status": tender_status, "published_at": tender_published_at}
-            if self.request.user.is_authenticated:
-                tender_dict |= {
-                    "contact_first_name": self.request.user.first_name,
-                    "contact_last_name": self.request.user.last_name,
-                    "contact_email": self.request.user.email,
-                    "contact_phone": self.request.user.phone,
-                }
             self.instance = create_tender_from_dict(tender_dict)
 
     def done(self, _, form_dict, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ use_parentheses = true
 
 [tool.black]
 line-length = 119
-target-version = ['py38', 'py39']
+target-version = ['py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Quoi ?

Suppression des champs liés au contact (prénom, nom, e-mail, téléphone) quand l'utilisateur est connecté

### Pourquoi ?

Pour rendre le formulaire plus simple à remplir.

### Comment ?

Les champs sont automatiquement renseignés avec les informations du contact authentifié.

### Capture d'écran

Étape de contact pour un utilisateur non connecté

![Étape de contact pour un utilisateur non connecté](https://github.com/betagouv/itou-marche/assets/17601807/0471e07d-c704-40dc-ab3b-4138b987bf7e)

Étape de contact pour un utilisateur connecté
![Étape de contact pour un utilisateur connecté](https://github.com/betagouv/itou-marche/assets/17601807/420d5b12-d202-4b24-82bb-0cdbd9095580)

