### PR TITLE
[Fiche structure] Faire un encart dédié aux informations admin

### DIFF
--- a/lemarche/static/itou_marche/sections/_siae.scss
+++ b/lemarche/static/itou_marche/sections/_siae.scss
@@ -186,24 +186,8 @@
 		flex-wrap: wrap;
 	}
 
-	#user_profile {
+	#user_profile > .card {
 		background-color: $gray-400;
-		padding: 1rem;
-		margin: 0;
-		border-radius: 0.5rem;
-	}
-
-	#user_profile h3 {
-		margin-top: 0;
-		margin-bottom: 1rem;
-	}
-
-	#user_profile .gallery-small {
-		// margin: 0 0 20px;
-		overflow: hidden;
-		border-radius: 0.25rem;
-		position: relative;
-		text-align: center;
 	}
 
 	.active_sectors {

--- a/lemarche/templates/siaes/_annuaire_entreprises_button.html
+++ b/lemarche/templates/siaes/_annuaire_entreprises_button.html
@@ -1,5 +1,5 @@
 {% if siret %}
-    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ siret }}" target="_blank" id="siae-detail-annuaire-entreprises-btn" class="btn btn-sm btn-outline-primary btn-ico ">
+    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ siret }}" target="_blank" id="siae-detail-annuaire-entreprises-btn" class="btn btn-sm btn-outline-primary btn-ico">
         <i class="ri-newspaper-fill" aria-hidden="true"></i>
         <span>
             Voir plus d'informations légales&nbsp;

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<div id="user_profile" class="card c-card c-card--hovershadow siae-card">
+<div class="card c-card c-card--hovershadow siae-card">
     <div class="card-header">
         <div class="row">
             <div class="col-auto">
@@ -20,16 +20,16 @@
                         </h1>
                         {% if user.is_authenticated %}
                             {% if siae.in_user_favorite_list_count %}
-                                <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">
+                                <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">
                                     <i class="ri-star-fill ri-xl"></i>
                                 </a>
                                 {% else %}
-                                <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#favorite_item_add_modal" title="Ajouter à votre liste d'achat" >
+                                <a href="#" id="favorite-add-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_add_modal" title="Ajouter à votre liste d'achat" >
                                     <i class="ri-star-line ri-xl"></i>
                                 </a>
                             {% endif %}
                         {% else %}
-                            <a href="#" id="favorite-modal-btn" class="btn btn-favorite p-0" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}" title="Ajouter à votre liste d'achat">
+                            <a href="#" id="favorite-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#login_or_signup_modal" data-next-params="{% url 'siae:detail' siae.slug %}" title="Ajouter à votre liste d'achat">
                                 <i class="ri-star-line ri-xl"></i>
                             </a>
                         {% endif %}

--- a/lemarche/templates/siaes/_card_suggest_tender.html
+++ b/lemarche/templates/siaes/_card_suggest_tender.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="col-md">
             <span class="badge badge-sm badge-pill badge-important mb-2">Nouveauté</span>
-            <h2 class="h2 mb-2">Vos sourcing et RFI sont chronophages ?</h2>
+            <h2 class="h3">Vos sourcing et RFI sont chronophages ?</h2>
             <p>
                 Confier votre sourcing ou votre RFI à notre algorithme et recevez des réponses de prestataires inclusifs en moins de 24h.
             </p>

--- a/lemarche/templates/siaes/_detail_admin_extra_info.html
+++ b/lemarche/templates/siaes/_detail_admin_extra_info.html
@@ -1,7 +1,7 @@
-<div class="alert alert-warning mb-0">
-    <h4>Informations Admin</h4>
+<div class="alert alert-warning">
+    <h2 class="h3">Informations Admin</h2>
     <div class="row">
-        <div class="col-12 col-md-6">
+        <div class="col-12">
             <ul class="list-unstyled mb-0">
                 {% if siae.user_count %}
                     {% if siae.contact_short_name %}
@@ -23,15 +23,15 @@
                         <a href="tel:{{ siae.contact_phone }}" id="company_phone">{{ siae.contact_phone }}</a>
                     </li>
                 {% endif %}
+                <li>
+                    <a href="{% url 'admin:siaes_siae_change' siae.id %}" target="_blank" id="siae-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
+                        <span>
+                            Lien vers l'admin&nbsp;
+                            <i class="ri-external-link-line" aria-hidden="true"></i>
+                        </span>
+                    </a>
+                </li>
             </ul>
-        </div>
-        <div class="col-12 col-md-6">
-            <a href="{% url 'admin:siaes_siae_change' siae.id %}" target="_blank" id="siae-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
-                <span>
-                    Lien vers l'admin&nbsp;
-                    <i class="ri-external-link-line" aria-hidden="true"></i>
-                </span>
-            </a>
         </div>
     </div>
 </div>

--- a/lemarche/templates/siaes/_detail_admin_extra_info.html
+++ b/lemarche/templates/siaes/_detail_admin_extra_info.html
@@ -1,4 +1,4 @@
-<div class="alert alert-warning">
+<div class="alert alert-warning mb-0">
     <h4>Informations Admin</h4>
     <div class="row">
         <div class="col-12 col-md-6">

--- a/lemarche/templates/siaes/_detail_admin_extra_info.html
+++ b/lemarche/templates/siaes/_detail_admin_extra_info.html
@@ -1,0 +1,37 @@
+<div class="alert alert-warning">
+    <h4>Informations Admin</h4>
+    <div class="row">
+        <div class="col-12 col-md-6">
+            <ul class="list-unstyled mb-0">
+                {% if siae.user_count %}
+                    {% if siae.contact_short_name %}
+                        <li class="mb-2">
+                            <i class="ri-user-line"></i>
+                            <span>{{ siae.contact_short_name }}</span>
+                        </li>
+                    {% endif %}
+                {% endif %}
+                {% if siae.contact_email %}
+                    <li class="mb-2">
+                        <i class="ri-at-line"></i>
+                        <a href="mailto:{{ siae.contact_email }}" id="company_email">{{ siae.contact_email }}</a>
+                    </li>
+                {% endif %}
+                {% if siae.contact_phone %}
+                    <li class="mb-2">
+                        <i class="ri-phone-line"></i>
+                        <a href="tel:{{ siae.contact_phone }}" id="company_phone">{{ siae.contact_phone }}</a>
+                    </li>
+                {% endif %}
+            </ul>
+        </div>
+        <div class="col-12 col-md-6">
+            <a href="{% url 'admin:siaes_siae_change' siae.id %}" target="_blank" id="siae-detail-admin-btn" class="btn btn-sm btn-outline-primary btn-ico">
+                <span>
+                    Lien vers l'admin&nbsp;
+                    <i class="ri-external-link-line" aria-hidden="true"></i>
+                </span>
+            </a>
+        </div>
+    </div>
+</div>

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -3,7 +3,7 @@
 <div class="c-box">
     <div class="row">
         <div class="col">
-            <h4>Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
+            <h2 class="h3">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h2>
 
             {% if siae.kind_is_esat_or_ea_or_eatt %}
                 <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" target="_blank" id="track_siae_detail_partners_esat_ea" class="btn btn-sm btn-outline-primary btn-ico">

--- a/lemarche/templates/siaes/_useful_infos_siae_v2.html
+++ b/lemarche/templates/siaes/_useful_infos_siae_v2.html
@@ -61,30 +61,6 @@
 
     <!-- Second column -->
     <div class="col-12 col-md-6">
-        <ul class="list-unstyled mb-0">
-            {% if is_admin %}
-                {% if siae.user_count %}
-                    {% if siae.contact_short_name %}
-                        <li class="mb-2">
-                            <i class="ri-user-line"></i>
-                            <span>{{ siae.contact_short_name }}</span>
-                        </li>
-                    {% endif %}
-                {% endif %}
-                {% if siae.contact_email %}
-                    <li class="mb-2">
-                        <i class="ri-at-line"></i>
-                        <a href="mailto:{{ siae.contact_email }}" id="company_email">{{ siae.contact_email }}</a>
-                    </li>
-                {% endif %}
-                {% if siae.contact_phone %}
-                    <li class="mb-2">
-                        <i class="ri-phone-line"></i>
-                        <a href="tel:{{ siae.contact_phone }}" id="company_phone">{{ siae.contact_phone }}</a>
-                    </li>
-                {% endif %}
-            {% endif %}
-        </ul>
         <div class="map-holder mb-3">
             <div id="map-siae" class="map-canvas"></div>
         </div>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -35,7 +35,12 @@
         <div id="dir-profile" class="dir-profile-row row">
             <div id="content" class="col-12 listing-area">
                 <!-- profile-detail basic info -->
-                {% include "siaes/_card_detail.html" with siae=siae %}
+                <div id="user_profile">
+                    {% include "siaes/_card_detail.html" with siae=siae %}
+                    {% if is_admin %}
+                        {% include "siaes/_detail_admin_extra_info.html" with siae=siae %}
+                    {% endif %}
+                </div>
 
                 <!-- profile-detail sidebar -->
                 <aside id="sidebar">

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -37,15 +37,15 @@
                 <!-- profile-detail basic info -->
                 <div id="user_profile">
                     {% include "siaes/_card_detail.html" with siae=siae %}
-                    {% if is_admin %}
-                        {% include "siaes/_detail_admin_extra_info.html" with siae=siae %}
-                    {% endif %}
                 </div>
 
                 <!-- profile-detail sidebar -->
                 <aside id="sidebar">
                     <div class="profile mb-4">
                         <div class="profile_capsule">
+                            {% if is_admin %}
+                                {% include "siaes/_detail_admin_extra_info.html" with siae=siae %}
+                            {% endif %}
                             {% if inbound_email_is_activated %}
                                 {% include "siaes/_detail_cta_v2.html" with siae=siae %}
                             {% else %}


### PR DESCRIPTION
### Quoi ?

Les admin ont accès à certaines informations.

Mais c'est source de confusion, car ils pensent que ces informations sont disponibles à tous les utilisateurs, alors que cela n'est pas le cas.

Modifications apportées : 
- basculé ces info dans un "alert" dédié (à droite)
- rajouté un lien vers la fiche coté admin
- j'en ai profité pour homogénéiser les titres & padding de la page détails..

### Captures d'écran

||Image|
|---|---|
|Avant|![image](https://github.com/betagouv/itou-marche/assets/7147385/0000bf6b-efda-4eed-b7b8-b7816083c2a8)|
|Après|![image](https://github.com/betagouv/itou-marche/assets/7147385/1b5a7274-a9da-43c9-8f36-bb51abd7b147)|