### PR TITLE
[Dépôt de besoin] Rajouter un message pour les besoins en provenance d'APProch

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -398,6 +398,7 @@ INBOUND_EMAIL_IS_ACTIVATED = env.bool("INBOUND_EMAIL_IS_ACTIVATED", True)
 HUBSPOT_API_KEY = env.str("HUBSPOT_API_KEY", "set-it")
 HUBSPOT_IS_ACTIVATED = env.bool("HUBSPOT_IS_ACTIVATED", False)
 
+
 # Security
 # ------------------------------------------------------------------------------
 
@@ -771,7 +772,7 @@ CKEDITOR_CONFIGS = {
 }
 
 
-# External URLs
+# Internal & external
 # (if you need these settings in the template, add them to settings_context_processor.expose_settings)
 # ------------------------------------------------------------------------------
 
@@ -784,6 +785,7 @@ FORM_PARTENAIRES = (
     "https://docs.google.com/forms/d/e/1FAIpQLScx1k-UJ-962_rSgPJGabc327gGjFUho6ypgcZHCubuwTl7Lg/viewform"
 )
 TALLY_NPS_FORM_ID = env.str("TALLY_NPS_FORM_ID", "")
+APPROCH_USER_ID = env.str("APPROCH_USER_ID", "")
 
 
 # Misc
@@ -836,6 +838,7 @@ SHELL_PLUS_POST_IMPORTS = [
     "from lemarche.tenders import constants as tender_constants",
 ]
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
+
 
 # MTCAPTCHA
 # ------------------------------------------------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -785,7 +785,7 @@ FORM_PARTENAIRES = (
     "https://docs.google.com/forms/d/e/1FAIpQLScx1k-UJ-962_rSgPJGabc327gGjFUho6ypgcZHCubuwTl7Lg/viewform"
 )
 TALLY_NPS_FORM_ID = env.str("TALLY_NPS_FORM_ID", "")
-APPROCH_USER_ID = env.str("APPROCH_USER_ID", "")
+APPROCH_USER_ID = env.int("APPROCH_USER_ID", 0)
 
 
 # Misc

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -40,18 +40,24 @@
         </div>
     {% endif %}
 </div>
+
 {% if tender.can_display_contact_external_link %}
     <div class="row">
         <div class="col-12">
             {% if tender.author.id == APPROCH_USER_ID %}
                 <p>
-                    Ce projet d'achat a été publié sur la plateforme <strong>APProch</strong>.
+                    <i class="ri-lightbulb-line ri-lg mr-1"></i>Ce projet d'achat a été publié sur la plateforme <strong>APProch</strong>.
+                    <br />
                     Pour plus d'informations, pour être informé des mises à jour sur ce projet
                     ou pour indiquer votre intérêt auprès de l'acheteur public, cliquez sur le lien ci-dessous.
                 </p>
             {% endif %}
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
-                {{ tender.external_link_title|safe }}
+                {% if tender.author.id == APPROCH_USER_ID %}
+                    Ça m'intéresse
+                {% else %}
+                    {{ tender.external_link_title|safe }}
+                {% endif %}
                 <i class="ri-external-link-line" aria-hidden="true"></i>
             </a>
         </div>

--- a/lemarche/templates/tenders/_detail_contact.html
+++ b/lemarche/templates/tenders/_detail_contact.html
@@ -43,6 +43,13 @@
 {% if tender.can_display_contact_external_link %}
     <div class="row">
         <div class="col-12">
+            {% if tender.author.id == APPROCH_USER_ID %}
+                <p>
+                    Ce projet d'achat a été publié sur la plateforme <strong>APProch</strong>.
+                    Pour plus d'informations, pour être informé des mises à jour sur ce projet
+                    ou pour indiquer votre intérêt auprès de l'acheteur public, cliquez sur le lien ci-dessous.
+                </p>
+            {% endif %}
             <a href="{{ tender.external_link }}" target="_blank" class="btn btn-outline-primary float-right">
                 {{ tender.external_link_title|safe }}
                 <i class="ri-external-link-line" aria-hidden="true"></i>

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -22,6 +22,7 @@ def expose_settings(request):
         "CONTACT_EMAIL": settings.CONTACT_EMAIL,
         "TEAM_CONTACT_EMAIL": settings.TEAM_CONTACT_EMAIL,
         "GIP_CONTACT_EMAIL": settings.GIP_CONTACT_EMAIL,
+        "APPROCH_USER_ID": settings.APPROCH_USER_ID,
         # forms & docs
         "FACILITATOR_SLIDE": settings.FACILITATOR_SLIDE,
         "FACILITATOR_LIST": settings.FACILITATOR_LIST,


### PR DESCRIPTION
### Quoi ?

Avec l'arrivée des besoins en provenance d'APProch, on souhaite rajouter un message spécifique pour les prestataires.

### Capture d'écran

![image](https://github.com/betagouv/itou-marche/assets/7147385/940c5406-613c-4872-9886-8f588e3ed23b)
edit : quid si le besoin a un `contact_full_name` et un `contact_company_name` ?