### PR TITLE
[Dépôt de besoin] Ajouter une stat du nombre de structures qui ont cliqué OU vu

### DIFF
--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -104,7 +104,7 @@
                         </a>
                         <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEWED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-focus-2-line"></i>
-                            {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_email_send_date_count|pluralize }} qui {{ tender.siae_email_send_date_count|pluralize:'a,ont' }} vu
+                            {{ tender.siae_email_link_click_or_detail_display_count }} prestataire{{ tender.siae_email_link_click_or_detail_display_count|pluralize }} qui {{ tender.siae_email_link_click_or_detail_display_count|pluralize:'a,ont' }} vu
                         </a>
                         <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-interested-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-thumb-up-line"></i>
@@ -113,11 +113,11 @@
                     {% endif %}
                 {% else %}
                     {% if not tender.deadline_date_outdated %}
-                        {% if tender.siae_detail_display_date_count_all > 0 %}
+                        {% if tender.siae_email_link_click_or_detail_display_count > 0 %}
                             <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
                                 <p class="mb-0 fs-sm">
-                                    Déjà {{ tender.siae_detail_display_date_count_all }} prestataire{{ tender.siae_detail_display_date_count_all|pluralize }} inclusif{{ tender.siae_detail_display_date_count_all|pluralize }}
-                                    {{ tender.siae_detail_display_date_count_all|pluralize:"a,ont" }} vu le besoin de ce client.
+                                    Déjà {{ tender.siae_email_link_click_or_detail_display_count }} prestataire{{ tender.siae_email_link_click_or_detail_display_count|pluralize }} inclusif{{ tender.siae_email_link_click_or_detail_display_count|pluralize }}
+                                    {{ tender.siae_email_link_click_or_detail_display_count|pluralize:"a,ont" }} vu le besoin de ce client.
                                 </p>
                             </div>
                         {% endif %}

--- a/lemarche/templates/tenders/detail.html
+++ b/lemarche/templates/tenders/detail.html
@@ -104,7 +104,7 @@
                         </a>
                         <a href="{% url 'tenders:detail-siae-list' tender.slug "VIEWED" %}" id="show-tender-siae-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-focus-2-line"></i>
-                            {{ tender.siae_email_link_click_or_detail_display_count }} prestataire{{ tender.siae_email_link_click_or_detail_display_count|pluralize }} qui {{ tender.siae_email_link_click_or_detail_display_count|pluralize:'a,ont' }} vu
+                            {{ tender.siae_email_link_click_date_or_detail_display_date_count }} prestataire{{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize }} qui {{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize:'a,ont' }} vu
                         </a>
                         <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-interested-list-from-detail-btn" class="btn btn-primary mb-3">
                             <i class="ri-thumb-up-line"></i>
@@ -113,11 +113,11 @@
                     {% endif %}
                 {% else %}
                     {% if not tender.deadline_date_outdated %}
-                        {% if tender.siae_email_link_click_or_detail_display_count > 0 %}
+                        {% if tender.siae_email_link_click_date_or_detail_display_date_count > 0 %}
                             <div class="alert alert-warning mt-3 mt-lg-0" role="alert">
                                 <p class="mb-0 fs-sm">
-                                    Déjà {{ tender.siae_email_link_click_or_detail_display_count }} prestataire{{ tender.siae_email_link_click_or_detail_display_count|pluralize }} inclusif{{ tender.siae_email_link_click_or_detail_display_count|pluralize }}
-                                    {{ tender.siae_email_link_click_or_detail_display_count|pluralize:"a,ont" }} vu le besoin de ce client.
+                                    Déjà {{ tender.siae_email_link_click_date_or_detail_display_date_count }} prestataire{{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize }} inclusif{{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize }}
+                                    {{ tender.siae_email_link_click_date_or_detail_display_date_count|pluralize:"a,ont" }} vu le besoin de ce client.
                                 </p>
                             </div>
                         {% endif %}

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -133,6 +133,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         # "siae_email_send_count_with_link",
         "siae_email_link_click_count_with_link",
         "siae_detail_display_count_with_link",
+        # "siae_email_link_click_or_detail_display_count_with_link",
         "siae_detail_contact_click_count_with_link",
         "siae_transactioned",
         "created_at",
@@ -176,6 +177,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "siae_email_send_count_with_link",
         "siae_email_link_click_count_with_link",
         "siae_detail_display_count_with_link",
+        "siae_email_link_click_or_detail_display_count_with_link",
         "siae_detail_contact_click_count_with_link",
         "logs_display",
         "extra_data_display",
@@ -281,6 +283,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                     "siae_email_send_count_with_link",
                     "siae_email_link_click_count_with_link",
                     "siae_detail_display_count_with_link",
+                    "siae_email_link_click_or_detail_display_count_with_link",
                     "siae_detail_contact_click_count_with_link",
                 )
             },
@@ -445,6 +448,20 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
 
     siae_detail_display_count_with_link.short_description = "S. vues"
     siae_detail_display_count_with_link.admin_order_field = "siae_detail_display_count"
+
+    def siae_email_link_click_or_detail_display_count_with_link(self, tender):
+        url = (
+            reverse("admin:siaes_siae_changelist")
+            + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
+        )
+        return format_html(
+            f'<a href="{url}">{getattr(tender, "siae_email_link_click_or_detail_display_count", 0)}</a>'
+        )
+
+    siae_email_link_click_or_detail_display_count_with_link.short_description = "S. cliquées ou vues"
+    siae_email_link_click_or_detail_display_count_with_link.admin_order_field = (
+        "siae_email_link_click_or_detail_display_count"
+    )
 
     def siae_detail_contact_click_count_with_link(self, tender):
         url = (

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -571,6 +571,12 @@ class Tender(models.Model):
         return self.tendersiae_set.filter(email_send_date__isnull=False).count()
 
     @property
+    def siae_email_link_click_date_or_detail_display_date_count(self):
+        return self.tendersiae_set.filter(
+            Q(email_link_click_date__isnull=False) | Q(detail_display_date__isnull=False)
+        ).count()
+
+    @property
     def siae_detail_contact_click_date_count(self):
         return self.tendersiae_set.filter(detail_contact_click_date__isnull=False).count()
 

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -113,6 +113,17 @@ class TenderQuerySet(models.QuerySet):
                     When(tendersiae__detail_display_date__isnull=False, then=1), default=0, output_field=IntegerField()
                 )
             ),
+            siae_email_link_click_or_detail_display_count=Sum(
+                Case(
+                    When(
+                        Q(tendersiae__detail_display_date__isnull=False)
+                        | Q(tendersiae__detail_display_date__isnull=False),
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            ),
             siae_detail_contact_click_count=Sum(
                 Case(
                     When(tendersiae__detail_contact_click_date__isnull=False, then=1),
@@ -554,17 +565,6 @@ class Tender(models.Model):
     @property
     def siae_detail_display_date_count(self):
         return self.tendersiae_set.filter(detail_display_date__isnull=False).count()
-
-    @property
-    def siae_detail_display_date_count_all(self):
-        """
-        Return all siae that have seen the tender (via e-mail or link or both)
-        """
-        return (
-            self.tendersiae_set.filter(Q(email_link_click_date__isnull=False) | Q(detail_display_date__isnull=False))
-            .distinct()
-            .count()
-        )
 
     @property
     def siae_email_send_date_count(self):

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -310,6 +310,7 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(tender_with_siae_1.siae_email_send_count, 4)
         self.assertEqual(tender_with_siae_1.siae_email_link_click_count, 3)
         self.assertEqual(tender_with_siae_1.siae_detail_display_count, 2)
+        self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count, 2)
         self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count, 1)
         self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count, 1)
         tender_with_siae_2 = Tender.objects.with_siae_stats().filter(id=self.tender_with_siae_2.id).first()
@@ -317,6 +318,7 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(tender_with_siae_2.siae_count, 1)
         self.assertEqual(tender_with_siae_2.siae_email_send_count, 1)
         self.assertEqual(tender_with_siae_2.siae_detail_display_count, 1)
+        self.assertEqual(tender_with_siae_2.siae_email_link_click_or_detail_display_count, 1)
         self.assertEqual(tender_with_siae_2.siae_detail_contact_click_count, 1)
         self.assertEqual(tender_with_siae_2.siae_detail_contact_click_since_last_seen_date_count, 1)
         tender_without_siae = Tender.objects.with_siae_stats().filter(id=self.tender_without_siae.id).first()
@@ -324,6 +326,7 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(tender_without_siae.siae_count, 0)
         self.assertEqual(tender_without_siae.siae_email_send_count, 0)
         self.assertEqual(tender_without_siae.siae_detail_display_count, 0)
+        self.assertEqual(tender_without_siae.siae_email_link_click_or_detail_display_count, 0)
         self.assertEqual(tender_without_siae.siae_detail_contact_click_count, 0)
         self.assertEqual(tender_without_siae.siae_detail_contact_click_since_last_seen_date_count, 0)
 
@@ -367,6 +370,7 @@ class TenderModelQuerysetStatsTest(TestCase):
     #     self.assertEqual(tender_with_siae_1.siae_email_send_count, 4)
     #     self.assertEqual(tender_with_siae_1.siae_email_link_click_count, 3)
     #     self.assertEqual(tender_with_siae_1.siae_detail_display_count, 2)
+    #     self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count, 2)
     #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count, 1)
     #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count, 1)
 

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -613,10 +613,10 @@ class TenderDetailViewTest(TestCase):
         self.tender_1.siaes.add(self.siae_2)
         self.assertEqual(self.tender_1.tendersiae_set.count(), 1 + 1)
         self.assertEqual(self.tender_1.tendersiae_set.first().siae, self.siae_2)
-        self.assertEqual(self.tender_1.tendersiae_set.last().siae, self.siae_1)
         self.assertIsNone(self.tender_1.tendersiae_set.first().email_link_click_date)
         self.assertIsNone(self.tender_1.tendersiae_set.first().detail_display_date)
-        self.assertIsNotNone(self.tender_1.tendersiae_set.last().email_link_click_date)  # siae_1
+        self.assertEqual(self.tender_1.tendersiae_set.last().siae, self.siae_1)
+        self.assertIsNotNone(self.tender_1.tendersiae_set.last().email_link_click_date)
         self.assertIsNotNone(self.tender_1.tendersiae_set.last().detail_display_date)
         # first load anonymous
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})


### PR DESCRIPTION
### Quoi ?

Sur le modèle `Tender`, il y a une property `siae_detail_display_date_count_all`.
Mais il y avait une incohérence dans l'affichage du détail du besoin.

Modifications apportées : 
- renommé la property en `siae_email_link_click_date_or_detail_display_date_count`
- rajouté la stat `siae_email_link_click_or_detail_display_count` dans le calcul de la queryset `with_siae_stats()`
