### PR TITLE
[Dépôt de besoin] Afficher seulement 3 secteurs d'activité max

### DIFF
--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1040,7 +1040,7 @@ class Siae(models.Model):
         score_percent = round(score / total, 2) * 100
         return round_by_base(score_percent, base=5)
 
-    def sectors_list_string(self, display_max=5):
+    def sectors_list_string(self, display_max=3):
         sectors_name_list = self.sectors.form_filter_queryset().values_list("name", flat=True)
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]

--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -1,4 +1,5 @@
-{% load bootstrap4 static array_choices_display humanize %}
+{% load bootstrap4 static humanize array_choices_display %}
+
 <div class="card c-card c-card--marche siae-card rounded-lg shadow-lg">
     <div class="card-header text-right bg-marche text-white fs-sm rounded-top rounded-lg p-3 mb-0">
         Date limite de réponse : {{ tender.deadline_date|default:"" }}
@@ -21,7 +22,7 @@
                 <i class="ri-award-line"></i>
                 {{ tender.sectors_list_string|safe }}
             </div>
-            <div class="col" title="Lieu d'éxécution">
+            <div class="col" title="Lieu d'intervention">
                 <i class="ri-map-pin-2-line"></i>
                 {{ tender.location_display|safe }}
             </div>

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -1,4 +1,4 @@
-{% load static humanize %}
+{% load static humanize get_verbose_name %}
 
 <div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'dashboard_networks:tender_detail' network.slug tender.slug %}">
     <div class="card-body">
@@ -23,19 +23,19 @@
                 <hr />
 
                 <div class="row">
-                    <div class="col-md-4" title="Secteurs d'activité">
+                    <div class="col-md-4" title="{% get_verbose_name tender 'sectors' %} : {{ tender.sectors_full_list_string|safe }}">
                         {% if tender.sectors.count %}
                             <i class="ri-award-line"></i>
                             {{ tender.sectors_list_string|safe }}
                         {% endif %}
                     </div>
-                    <div class="col-md-4 text-center" title="Lieu d'intervention">
+                    <div class="col-md-4 text-center" title="{% get_verbose_name tender 'location' %}">
                         {% if tender.perimeters_list_string %}
                             <i class="ri-map-pin-2-line"></i>
                             {{ tender.location_display|safe }}
                         {% endif %}
                     </div>
-                    <div class="col-md-4 text-center">
+                    <div class="col-md-4 text-center" title="{% get_verbose_name tender 'amount' %}">
                         {% if tender.amount %}
                             <i class="ri-money-euro-circle-line"></i>
                             {{ tender.get_amount_display|default:"-" }}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -1,4 +1,4 @@
-{% load static humanize %}
+{% load static humanize get_verbose_name %}
 
 <div class="card c-card c-card--marche c-card--link siae-card" role="button" data-url="{% url 'tenders:detail' tender.slug %}">
     <div class="card-body">
@@ -30,19 +30,19 @@
         <hr />
 
         <div class="row">
-            <div class="col-md-4" title="Secteurs d'activité">
+            <div class="col-md-4" title="{% get_verbose_name tender 'sectors' %} : {{ tender.sectors_full_list_string|safe }}">
                 {% if tender.sectors.count %}
                     <i class="ri-award-line"></i>
                     {{ tender.sectors_list_string|safe }}
                 {% endif %}
             </div>
-            <div class="col-md-4 text-center" title="Lieu d'intervention">
+            <div class="col-md-4 text-center" title="{% get_verbose_name tender 'location' %}">
                 {% if tender.perimeters_list_string %}
                     <i class="ri-map-pin-2-line"></i>
                     {{ tender.location_display|safe }}
                 {% endif %}
             </div>
-            <div class="col-md-4 text-center">
+            <div class="col-md-4 text-center" title="{% get_verbose_name tender 'amount' %}">
                 {% if tender.amount %}
                     <i class="ri-money-euro-circle-line"></i>
                     {{ tender.get_amount_display|default:"-" }}

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -464,7 +464,7 @@ class Tender(models.Model):
     def sectors_list(self):
         return self.sectors.form_filter_queryset().values_list("name", flat=True)
 
-    def sectors_list_string(self, display_max=5) -> str:
+    def sectors_list_string(self, display_max=3) -> str:
         sectors_name_list = self.sectors_list()
         if display_max and len(sectors_name_list) > display_max:
             sectors_name_list = sectors_name_list[:display_max]


### PR DESCRIPTION
### Quoi ?

Dans l'aperçu d'un besoin, on affiche actuellement les secteurs d'activités, en les limitant à 5.

On souhaite baisser cette limite à 3 pour que cela prenne un peu moins de place.

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/betagouv/itou-marche/assets/7147385/25afa35e-3a05-4bc9-b193-e05619735d6a)|![image](https://github.com/betagouv/itou-marche/assets/7147385/b952b130-1b14-4fb9-bb05-5ce643fc5594)|