### PR TITLE
[Dépôt de besoin] Inverser l'affichage des secteurs et de l'entreprise

### DIFF
--- a/lemarche/templates/tenders/_detail_card.html
+++ b/lemarche/templates/tenders/_detail_card.html
@@ -12,26 +12,25 @@
             <div class="col-md-12">
                 <h1>
                     {{ tender.title }}
-                    <span class="fs-sm badge badge-base badge-pill badge-emploi float-right"
-                          aria-hidden="true">{{ tender_kind_display|default:tender.get_kind_display }}</span>
+                    <span class="fs-sm badge badge-base badge-pill badge-emploi float-right" aria-hidden="true">{{ tender_kind_display|default:tender.get_kind_display }}</span>
                 </h1>
             </div>
         </div>
         <div class="row text-bold">
-            <div class="col" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
-                <i class="ri-award-line"></i>
-                {{ tender.sectors_list_string|safe }}
-            </div>
-            <div class="col" title="Lieu d'intervention">
-                <i class="ri-map-pin-2-line"></i>
-                {{ tender.location_display|safe }}
-            </div>
             {% if tender.contact_company_name_display %}
-                <div class="col" title="Entreprise">
+                <div class="col-md-4" title="Entreprise">
                     <i class="ri-building-4-line"></i>
                     {{ tender.contact_company_name_display }}
                 </div>
             {% endif %}
+            <div class="col-md-4" title="Lieu d'intervention">
+                <i class="ri-map-pin-2-line"></i>
+                {{ tender.location_display|safe }}
+            </div>
+            <div class="col-md-4" title="Secteurs d'activité : {{ tender.sectors_full_list_string|safe }}">
+                <i class="ri-award-line"></i>
+                {{ tender.sectors_list_string|safe }}
+            </div>
         </div>
         {% if not source_form %}
             {% if user.is_authenticated %}

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -23,19 +23,25 @@
                 <hr />
 
                 <div class="row">
+                    {% if tender.contact_company_name_display %}
+                        <div class="col-md-4" title="Entreprise">
+                            <i class="ri-building-4-line"></i>
+                            {{ tender.contact_company_name_display }}
+                        </div>
+                    {% endif %}
+                    <div class="col-md-4" title="{% get_verbose_name tender 'location' %}">
+                        {% if tender.perimeters_list_string %}
+                            <i class="ri-map-pin-2-line"></i>
+                            {{ tender.location_display|safe }}
+                        {% endif %}
+                    </div>
                     <div class="col-md-4" title="{% get_verbose_name tender 'sectors' %} : {{ tender.sectors_full_list_string|safe }}">
                         {% if tender.sectors.count %}
                             <i class="ri-award-line"></i>
                             {{ tender.sectors_list_string|safe }}
                         {% endif %}
                     </div>
-                    <div class="col-md-4 text-center" title="{% get_verbose_name tender 'location' %}">
-                        {% if tender.perimeters_list_string %}
-                            <i class="ri-map-pin-2-line"></i>
-                            {{ tender.location_display|safe }}
-                        {% endif %}
-                    </div>
-                    <div class="col-md-4 text-center" title="{% get_verbose_name tender 'amount' %}">
+                    <div class="col-md-4" title="{% get_verbose_name tender 'amount' %}">
                         {% if tender.amount %}
                             <i class="ri-money-euro-circle-line"></i>
                             {{ tender.get_amount_display|default:"-" }}

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -23,26 +23,30 @@
             </div>
         </div>
 
-        <a href="{% url 'tenders:detail' tender.slug %}" class="text-decoration-none">
-            <h2 class="py-2">{{ tender.title }}</h2>
-        </a>
+        <h2 class="py-2">{{ tender.title }}</h2>
 
         <hr />
 
         <div class="row">
+            {% if tender.contact_company_name_display %}
+                <div class="col-md-4" title="Entreprise">
+                    <i class="ri-building-4-line"></i>
+                    {{ tender.contact_company_name_display }}
+                </div>
+            {% endif %}
+            <div class="col-md-4" title="{% get_verbose_name tender 'location' %}">
+                {% if tender.perimeters_list_string %}
+                    <i class="ri-map-pin-2-line"></i>
+                    {{ tender.location_display|safe }}
+                {% endif %}
+            </div>
             <div class="col-md-4" title="{% get_verbose_name tender 'sectors' %} : {{ tender.sectors_full_list_string|safe }}">
                 {% if tender.sectors.count %}
                     <i class="ri-award-line"></i>
                     {{ tender.sectors_list_string|safe }}
                 {% endif %}
             </div>
-            <div class="col-md-4 text-center" title="{% get_verbose_name tender 'location' %}">
-                {% if tender.perimeters_list_string %}
-                    <i class="ri-map-pin-2-line"></i>
-                    {{ tender.location_display|safe }}
-                {% endif %}
-            </div>
-            <div class="col-md-4 text-center" title="{% get_verbose_name tender 'amount' %}">
+            <div class="col-md-4" title="{% get_verbose_name tender 'amount' %}">
                 {% if tender.amount %}
                     <i class="ri-money-euro-circle-line"></i>
                     {{ tender.get_amount_display|default:"-" }}


### PR DESCRIPTION
Suite de #942

### Quoi ?

Afficher maintenant l'entreprise en premier, la localisation en deuxième (déjà le cas), et les secteurs en troisième.

J'ai effectué ces changements : 
- dans l'aperçu du besoin
- mais aussi dans les listes affichées aux structures et aux réseaux

### Captures d'écran 

|Page|Avant|Après|
|---|---|---|
|Besoin|![image](https://github.com/betagouv/itou-marche/assets/7147385/388fa9aa-c55d-4bc4-a9ac-059f7ab7b0b0)|![image](https://github.com/betagouv/itou-marche/assets/7147385/2e16cf4e-5d08-4562-89f1-03997d5e1405)|
|Réseau > opportunités commerciales reçues par mes adhérents|![image](https://github.com/betagouv/itou-marche/assets/7147385/d007d24d-cb7b-43fb-9fa3-8f5945ec8408)|![Screenshot from 2023-10-11 11-42-32](https://github.com/betagouv/itou-marche/assets/7147385/b9e1b039-790b-441c-bdd0-9f5cd81a7c36)|