### PR TITLE
Fix du nom de l'entreprise d'un dépôt de besoin

### DIFF
--- a/lemarche/api/tenders/serializers.py
+++ b/lemarche/api/tenders/serializers.py
@@ -13,7 +13,6 @@ class TenderSerializer(serializers.ModelSerializer):
     location = serializers.SlugRelatedField(
         queryset=Perimeter.objects.all(), slug_field="slug", allow_null=True, required=False
     )
-    contact_company_name = serializers.CharField(required=False)
     extra_data = serializers.JSONField(required=False)
 
     class Meta:

--- a/lemarche/www/tenders/utils.py
+++ b/lemarche/www/tenders/utils.py
@@ -59,7 +59,7 @@ def get_or_create_user_from_anonymous_content(tender_dict: dict, source: str = U
             "first_name": tender_dict.get("contact_first_name"),
             "last_name": tender_dict.get("contact_last_name"),
             "phone": tender_dict.get("contact_phone"),
-            "company_name": tender_dict.pop("contact_company_name")
+            "company_name": tender_dict.get("contact_company_name")
             if tender_dict.get("contact_company_name")
             else "Particulier",
             "kind": User.KIND_BUYER,  # not necessarily true, could be a PARTNER


### PR DESCRIPTION
### Quoi ?
Fix du bug du nom de l'entreprise à l'ajout d'un dépôt de besoin via l'API.

### Pourquoi ?
Dans l'ancien modèle on ne spécifiait pas le nom de l'entreprise dans le dépôt de besoin, du coup on utilisait un `pop` pour extraire la valeur de `contact_company_name`.

### Comment ?

Utiliser un `get` à la place.
