### PR TITLE
Label : pouvoir uploader un label dans l'admin

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -460,6 +460,7 @@ AWS_S3_USE_SSL = env.bool("AWS_S3_USE_SSL", False)
 SIAE_LOGO_FOLDER_NAME = "siae_logo"
 SIAE_IMAGE_FOLDER_NAME = "siae_image"
 SIAE_CLIENT_REFERENCE_LOGO_FOLDER_NAME = "client_reference_logo"
+LABEL_LOGO_FOLDER_NAME = "label_logo"
 USER_IMAGE_FOLDER_NAME = "user_image"
 SIAE_EXPORT_FOLDER_NAME = "siae_export"
 STAT_EXPORT_FOLDER_NAME = "stat_export"
@@ -481,6 +482,9 @@ STORAGE_UPLOAD_KINDS = {
     },
     "client_reference_logo": {
         "key_path": SIAE_CLIENT_REFERENCE_LOGO_FOLDER_NAME,
+    },
+    "label_logo": {
+        "key_path": LABEL_LOGO_FOLDER_NAME,
     },
     "user_image": {
         "key_path": USER_IMAGE_FOLDER_NAME,

--- a/lemarche/labels/admin.py
+++ b/lemarche/labels/admin.py
@@ -10,12 +10,13 @@ from lemarche.utils.s3 import S3Upload
 
 @admin.register(Label, site=admin_site)
 class LabelAdmin(admin.ModelAdmin):
-    list_display = ["id", "name", "siae_count_annotated_with_link", "created_at"]
+    list_display = ["id", "name", "siae_count_annotated_with_link", "has_logo", "created_at"]
     search_fields = ["id", "name", "description"]
     search_help_text = "Cherche sur les champs : ID, Nom, Description"
 
     readonly_fields = [
         "siae_count_annotated_with_link",
+        "has_logo",
         "logo_url_display",
         "data_last_sync_date",
         "logs_display",
@@ -77,6 +78,12 @@ class LabelAdmin(admin.ModelAdmin):
         if not obj:
             return {"slug": ("name",)}
         return {}
+
+    def has_logo(self, instance):
+        return instance.has_logo
+
+    has_logo.boolean = True
+    has_logo.short_description = "Logo ?"
 
     def logo_url_display(self, instance):
         if instance.logo_url:

--- a/lemarche/labels/models.py
+++ b/lemarche/labels/models.py
@@ -44,3 +44,7 @@ class Label(models.Model):
         """Generate the slug field before saving."""
         self.set_slug()
         super().save(*args, **kwargs)
+
+    @property
+    def has_logo(self):
+        return len(self.logo_url) > 0

--- a/lemarche/templates/labels/admin_change_form.html
+++ b/lemarche/templates/labels/admin_change_form.html
@@ -1,0 +1,30 @@
+{% extends 'admin/change_form.html' %}
+{% load static bootstrap4 theme_inclusion %}
+
+{% block after_related_objects %}
+    {{ block.super }}
+
+    {% import_static_JS_theme_inclusion %}
+
+    <div class="submit-row">
+        <div class="form-group">
+            <label for="logo_form" class="js-display-if-javascript-enabled">Importez votre logo</label>
+            {% include "storage/s3_upload_form.html" with dropzone_form_id="logo_form" %}
+        </div>
+    </div>
+
+    {{ s3_form_values_label_logo|json_script:"s3-form-values-label-logo" }}
+    {{ s3_upload_config_label_logo|json_script:"s3-upload-config-label-logo" }}
+    <script type="text/javascript">
+    // init dropzone
+    s3UploadInit({
+        dropzoneSelector: "#logo_form",
+        callbackLocationSelector: "#{{ adminform.form.logo_url.id_for_label }}",
+        s3FormValuesId: "s3-form-values-label-logo",
+        s3UploadConfigId: "s3-upload-config-label-logo",
+        // Not really nice
+        sentryInternalUrl: "{% url 'pages:sentry_debug' %}",
+        sentryCsrfToken: "{{ csrf_token }}"
+    });
+    </script>
+{% endblock %}


### PR DESCRIPTION
### Quoi ?

Dans l'admin, pour le modèle `Label`, permettre aux administrateurs d'uploader un logo. On utilise le même fonctionnement que pour les utilisateurs (s3 + dropzone). Dès que l'upload est effectué, le champ "Lien vers le logo" est rempli, et il suffit d'enregistrer pour sauvegarder.

J'ai aussi rajouté une colonne dans la vue "liste", pour indiquer si le label a un logo ou pas.

### Captures d'écran

|Page|Image|
|---|---|
|Admin : détail|![image](https://github.com/betagouv/itou-marche/assets/7147385/f3403fa3-5bd7-4f61-973c-20a9fe81e9ea)|
|Admin : liste|![image](https://github.com/betagouv/itou-marche/assets/7147385/96e1fe2e-7d0e-4fad-8666-6c01d2948dae)|
