### PR TITLE
Refactoring : clarifier si une stat vient d'une annotation

### DIFF
--- a/lemarche/api/networks/tests.py
+++ b/lemarche/api/networks/tests.py
@@ -8,8 +8,8 @@ from lemarche.users.factories import UserFactory
 class NetworkApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        NetworkFactory()
-        NetworkFactory()
+        NetworkFactory(name="Reseau 1")
+        NetworkFactory(name="Reseau 2")
         UserFactory(api_key="admin")
 
     def test_should_return_network_list(self):

--- a/lemarche/api/siaes/tests.py
+++ b/lemarche/api/siaes/tests.py
@@ -74,8 +74,8 @@ class SiaeListFilterApiTest(TestCase):
             kind=siae_constants.KIND_EI, presta_type=[siae_constants.PRESTA_DISP], department="01"
         )
         siae_with_sector_2.sectors.add(cls.sector_2)
-        cls.network_1 = NetworkFactory()
-        cls.network_2 = NetworkFactory()
+        cls.network_1 = NetworkFactory(name="Reseau 1")
+        cls.network_2 = NetworkFactory(name="Reseau 2")
         siae_with_network_1 = SiaeFactory(
             kind=siae_constants.KIND_EI, presta_type=[siae_constants.PRESTA_DISP], department="01"
         )

--- a/lemarche/companies/factories.py
+++ b/lemarche/companies/factories.py
@@ -11,3 +11,8 @@ class CompanyFactory(DjangoModelFactory):
     name = factory.Faker("company", locale="fr_FR")
     # slug: auto-generated
     website = "https://example.com"
+
+    @factory.post_generation
+    def users(self, create, extracted, **kwargs):
+        if extracted:
+            self.users.add(*extracted)

--- a/lemarche/companies/models.py
+++ b/lemarche/companies/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Count
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 from django_better_admin_arrayfield.models.fields import ArrayField
@@ -10,6 +11,9 @@ class CompanyQuerySet(models.QuerySet):
 
     def has_email_domain(self):
         return self.exclude(email_domain_list=[])
+
+    def with_user_stats(self):
+        return self.annotate(user_count_annotated=Count("users", distinct=True))
 
 
 class Company(models.Model):

--- a/lemarche/companies/tests.py
+++ b/lemarche/companies/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
 from lemarche.companies.factories import CompanyFactory
+from lemarche.companies.models import Company
+from lemarche.users.factories import UserFactory
 
 
 class CompanyModelTest(TestCase):
@@ -13,3 +15,17 @@ class CompanyModelTest(TestCase):
 
     def test_str(self):
         self.assertEqual(str(self.company), "Mon entreprise")
+
+
+class CompanyQuerysetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_1 = UserFactory()
+        cls.user_2 = UserFactory()
+        cls.company_with_users = CompanyFactory(users=[cls.user_1, cls.user_2])
+        cls.company = CompanyFactory()
+
+    def test_with_user_stats(self):
+        company_queryset = Company.objects.with_user_stats()
+        self.assertEqual(company_queryset.get(id=self.company.id).user_count_annotated, 0)
+        self.assertEqual(company_queryset.get(id=self.company_with_users.id).user_count_annotated, 2)

--- a/lemarche/conversations/admin.py
+++ b/lemarche/conversations/admin.py
@@ -45,7 +45,16 @@ class IsValidatedFilter(admin.SimpleListFilter):
 
 @admin.register(Conversation, site=admin_site)
 class ConversationAdmin(admin.ModelAdmin):
-    list_display = ["id", "uuid", "sender_encoded", "is_validate", "title", "kind", "answer_count", "created_at"]
+    list_display = [
+        "id",
+        "uuid",
+        "sender_encoded",
+        "is_validate",
+        "title",
+        "kind",
+        "answer_count_annotated",
+        "created_at",
+    ]
     list_filter = ["kind", HasAnswerFilter, IsValidatedFilter]
     search_fields = ["id", "uuid", "sender_email"]
     search_help_text = "Cherche sur les champs : ID, UUID, Initiateur (E-mail)"
@@ -61,7 +70,7 @@ class ConversationAdmin(admin.ModelAdmin):
         "sender_first_name",
         "sender_last_name",
         "sender_email",
-        "answer_count",
+        "answer_count_annotated",
         "data_display",
         "created_at",
         "updated_at",
@@ -77,7 +86,7 @@ class ConversationAdmin(admin.ModelAdmin):
             "Contenu de la conversation",
             {
                 "fields": (
-                    "answer_count",
+                    "answer_count_annotated",
                     "data_display",
                 )
             },
@@ -92,7 +101,7 @@ class ConversationAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.with_answer_count()
+        qs = qs.with_answer_stats()
         return qs
 
     def is_validate(self, conversation: Conversation):
@@ -101,11 +110,11 @@ class ConversationAdmin(admin.ModelAdmin):
     is_validate.boolean = True
     is_validate.short_description = "Validé"
 
-    def answer_count(self, conversation):
-        return getattr(conversation, "answer_count", 0)
+    def answer_count_annotated(self, conversation):
+        return getattr(conversation, "answer_count_annotated", 0)
 
-    answer_count.short_description = "Nombre de réponses"
-    answer_count.admin_order_field = "answer_count"
+    answer_count_annotated.short_description = "Nombre de réponses"
+    answer_count_annotated.admin_order_field = "answer_count_annotated"
 
     def response_change(self, request, obj: Conversation):
         if request.POST.get("_validate_conversation"):

--- a/lemarche/conversations/models.py
+++ b/lemarche/conversations/models.py
@@ -13,8 +13,10 @@ class ConversationQuerySet(models.QuerySet):
     def has_answer(self):
         return self.exclude(data=[])
 
-    def with_answer_count(self):
-        return self.annotate(answer_count=Func("data", function="jsonb_array_length", output_field=IntegerField()))
+    def with_answer_stats(self):
+        return self.annotate(
+            answer_count_annotated=Func("data", function="jsonb_array_length", output_field=IntegerField())
+        )
 
     def get_conv_from_uuid(self, conv_uuid: str, version=1):
         """get conv form

--- a/lemarche/conversations/tests.py
+++ b/lemarche/conversations/tests.py
@@ -60,7 +60,7 @@ class ConversationQuerysetTest(TestCase):
     def test_has_answer(self):
         self.assertEqual(Conversation.objects.has_answer().count(), 1)
 
-    def test_with_answer_count(self):
-        conversation_queryset = Conversation.objects.with_answer_count()
-        self.assertEqual(conversation_queryset.get(id=self.conversation.id).answer_count, 0)
-        self.assertEqual(conversation_queryset.get(id=self.conversation_with_answer.id).answer_count, 1)
+    def test_with_answer_stats(self):
+        conversation_queryset = Conversation.objects.with_answer_stats()
+        self.assertEqual(conversation_queryset.get(id=self.conversation.id).answer_count_annotated, 0)
+        self.assertEqual(conversation_queryset.get(id=self.conversation_with_answer.id).answer_count_annotated, 1)

--- a/lemarche/cpv/models.py
+++ b/lemarche/cpv/models.py
@@ -1,5 +1,6 @@
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.db.models import Count
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 
@@ -8,6 +9,9 @@ class CodeQuerySet(models.QuerySet):
     def has_sector(self):
         """Only return codes who have at least 1 Sector."""
         return self.prefetch_related("sectors").filter(sectors__isnull=False).distinct()
+
+    def with_sector_stats(self):
+        return self.annotate(sector_count_annotated=Count("sectors", distinct=True))
 
 
 class Code(models.Model):

--- a/lemarche/cpv/tests.py
+++ b/lemarche/cpv/tests.py
@@ -48,3 +48,8 @@ class CodeModelQuerySetTest(TestCase):
     def test_has_sector(self):
         self.assertEqual(Code.objects.count(), 2)
         self.assertEqual(Code.objects.has_sector().count(), 1)
+
+    def test_with_sector_stats(self):
+        code_queryset = Code.objects.with_sector_stats()
+        self.assertEqual(code_queryset.get(id=self.code.id).sector_count_annotated, 0)
+        self.assertEqual(code_queryset.get(id=self.code_with_sector.id).sector_count_annotated, 1)

--- a/lemarche/favorites/admin.py
+++ b/lemarche/favorites/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.db.models import Count
 from django.urls import reverse
 from django.utils.html import format_html
 from fieldsets_with_inlines import FieldsetsInlineMixin
@@ -17,7 +16,7 @@ class FavoriteItemInline(admin.TabularInline):
 
 @admin.register(FavoriteList, site=admin_site)
 class FavoriteListAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
-    list_display = ["id", "name", "user_with_link", "nb_siaes", "created_at", "updated_at"]
+    list_display = ["id", "name", "user_with_link", "siae_count_annotated_with_link", "created_at", "updated_at"]
     search_fields = ["id", "name", "slug", "user__id", "user__email"]
     search_help_text = "Cherche sur les champs : ID, Nom, Slug, Utilisateur (ID, E-mail)"
 
@@ -42,8 +41,7 @@ class FavoriteListAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.prefetch_related("siaes")
-        qs = qs.annotate(siae_count=Count("siaes", distinct=True))
+        qs = qs.with_siae_stats()
         return qs
 
     def user_with_link(self, favorite_list):
@@ -53,9 +51,9 @@ class FavoriteListAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     user_with_link.short_description = "Utilisateur"
     user_with_link.admin_order_field = "user"
 
-    def nb_siaes(self, favorite_list):
+    def siae_count_annotated_with_link(self, favorite_list):
         url = reverse("admin:siaes_siae_changelist") + f"?favorite_lists__in={favorite_list.id}"
         return format_html(f'<a href="{url}">{favorite_list.siae_count}</a>')
 
-    nb_siaes.short_description = "Nombre de structures"
-    nb_siaes.admin_order_field = "siae_count"
+    siae_count_annotated_with_link.short_description = "Nombre de structures"
+    siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"

--- a/lemarche/favorites/factories.py
+++ b/lemarche/favorites/factories.py
@@ -10,3 +10,8 @@ class FavoriteListFactory(DjangoModelFactory):
 
     name = factory.Faker("company", locale="fr_FR")
     # slug: auto-generated
+
+    @factory.post_generation
+    def siaes(self, create, extracted, **kwargs):
+        if extracted:
+            self.siaes.add(*extracted)

--- a/lemarche/favorites/models.py
+++ b/lemarche/favorites/models.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models
+from django.db.models import Count
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.template.defaultfilters import slugify
@@ -11,6 +12,9 @@ from django.utils import timezone
 class FavoriteListQuerySet(models.QuerySet):
     def by_user(self, user):
         return self.filter(user=user)
+
+    def with_siae_stats(self):
+        return self.annotate(siae_count_annotated=Count("siaes", distinct=True))
 
 
 class FavoriteList(models.Model):

--- a/lemarche/favorites/tests.py
+++ b/lemarche/favorites/tests.py
@@ -50,17 +50,9 @@ class FavoriteListModelQuerysetTest(TestCase):
         self.assertEqual(favorite_list_queryset.get(id=favorite_list.id).siae_count_annotated, 0)
         self.assertEqual(favorite_list_queryset.get(id=favorite_list_with_siaes.id).siae_count_annotated, 2)
 
-    def test_siae_annotate_with_user_favorite_list_count(self):
+    def test_siae_with_in_user_favorite_list_stats(self):
         FavoriteListFactory(user=self.user, siaes=[self.siae_1])
         FavoriteListFactory(user=self.user, siaes=[self.siae_1])
-        siae_queryset = Siae.objects.annotate_with_user_favorite_list_count(self.user)
-        self.assertEqual(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_count, 2)
-        self.assertEqual(siae_queryset.get(id=self.siae_2.id).in_user_favorite_list_count, 0)
-
-    def test_siae_annotate_with_user_favorite_list_ids(self):
-        favorite_list_1 = FavoriteListFactory(user=self.user, siaes=[self.siae_1])
-        FavoriteListFactory(user=self.user, siaes=[self.siae_1])
-        siae_queryset = Siae.objects.annotate_with_user_favorite_list_ids(self.user)
-        self.assertEqual(len(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_ids), 2)
-        self.assertEqual(len(siae_queryset.get(id=self.siae_2.id).in_user_favorite_list_ids), 0)
-        self.assertEqual(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_ids[0], favorite_list_1.id)
+        siae_queryset = Siae.objects.with_in_user_favorite_list_stats(self.user)
+        self.assertEqual(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_count_annotated, 2)
+        self.assertEqual(siae_queryset.get(id=self.siae_2.id).in_user_favorite_list_count_annotated, 0)

--- a/lemarche/favorites/tests.py
+++ b/lemarche/favorites/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from lemarche.favorites.factories import FavoriteListFactory
+from lemarche.favorites.models import FavoriteList
 from lemarche.siaes.factories import SiaeFactory
 from lemarche.siaes.models import Siae
 from lemarche.users.factories import UserFactory
@@ -42,21 +43,24 @@ class FavoriteListModelQuerysetTest(TestCase):
         # -created_at ordering (added last shown first)
         self.assertEqual(favorite_list.favoriteitem_set.first().siae, self.siae_1)
 
+    def test_with_siae_stats(self):
+        favorite_list = FavoriteListFactory(user=self.user)
+        favorite_list_with_siaes = FavoriteListFactory(user=self.user, siaes=[self.siae_1, self.siae_2])
+        favorite_list_queryset = FavoriteList.objects.with_siae_stats()
+        self.assertEqual(favorite_list_queryset.get(id=favorite_list.id).siae_count_annotated, 0)
+        self.assertEqual(favorite_list_queryset.get(id=favorite_list_with_siaes.id).siae_count_annotated, 2)
+
     def test_siae_annotate_with_user_favorite_list_count(self):
-        favorite_list_1 = FavoriteListFactory(user=self.user)
-        favorite_list_1.siaes.add(self.siae_1)
-        favorite_list_2 = FavoriteListFactory(user=self.user)
-        favorite_list_2.siaes.add(self.siae_1)
-        qs = Siae.objects.annotate_with_user_favorite_list_count(self.user)
-        self.assertEqual(qs.get(id=self.siae_1.id).in_user_favorite_list_count, 2)
-        self.assertEqual(qs.get(id=self.siae_2.id).in_user_favorite_list_count, 0)
+        FavoriteListFactory(user=self.user, siaes=[self.siae_1])
+        FavoriteListFactory(user=self.user, siaes=[self.siae_1])
+        siae_queryset = Siae.objects.annotate_with_user_favorite_list_count(self.user)
+        self.assertEqual(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_count, 2)
+        self.assertEqual(siae_queryset.get(id=self.siae_2.id).in_user_favorite_list_count, 0)
 
     def test_siae_annotate_with_user_favorite_list_ids(self):
-        favorite_list_1 = FavoriteListFactory(user=self.user)
-        favorite_list_1.siaes.add(self.siae_1)
-        favorite_list_2 = FavoriteListFactory(user=self.user)
-        favorite_list_2.siaes.add(self.siae_1)
-        qs = Siae.objects.annotate_with_user_favorite_list_ids(self.user)
-        self.assertEqual(len(qs.get(id=self.siae_1.id).in_user_favorite_list_ids), 2)
-        self.assertEqual(len(qs.get(id=self.siae_2.id).in_user_favorite_list_ids), 0)
-        self.assertEqual(qs.get(id=self.siae_1.id).in_user_favorite_list_ids[0], favorite_list_1.id)
+        favorite_list_1 = FavoriteListFactory(user=self.user, siaes=[self.siae_1])
+        FavoriteListFactory(user=self.user, siaes=[self.siae_1])
+        siae_queryset = Siae.objects.annotate_with_user_favorite_list_ids(self.user)
+        self.assertEqual(len(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_ids), 2)
+        self.assertEqual(len(siae_queryset.get(id=self.siae_2.id).in_user_favorite_list_ids), 0)
+        self.assertEqual(siae_queryset.get(id=self.siae_1.id).in_user_favorite_list_ids[0], favorite_list_1.id)

--- a/lemarche/labels/factories.py
+++ b/lemarche/labels/factories.py
@@ -11,3 +11,9 @@ class LabelFactory(DjangoModelFactory):
     name = factory.Faker("company", locale="fr_FR")
     # slug: auto-generated
     website = "https://example.com"
+
+    @factory.post_generation
+    def siaes(self, create, extracted, **kwargs):
+        if extracted:
+            # Add the iterable of groups using bulk addition
+            self.siaes.add(*extracted)

--- a/lemarche/labels/models.py
+++ b/lemarche/labels/models.py
@@ -1,6 +1,12 @@
 from django.db import models
+from django.db.models import Count
 from django.template.defaultfilters import slugify
 from django.utils import timezone
+
+
+class LabelQuerySet(models.QuerySet):
+    def with_siae_stats(self):
+        return self.annotate(siae_count_annotated=Count("siaes", distinct=True))
 
 
 class Label(models.Model):
@@ -17,6 +23,8 @@ class Label(models.Model):
 
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
+
+    objects = models.Manager.from_queryset(LabelQuerySet)()
 
     class Meta:
         verbose_name = "Label & certification"

--- a/lemarche/labels/tests.py
+++ b/lemarche/labels/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
 from lemarche.labels.factories import LabelFactory
+from lemarche.labels.models import Label
+from lemarche.siaes.factories import SiaeFactory
 
 
 class LabelModelTest(TestCase):
@@ -13,3 +15,17 @@ class LabelModelTest(TestCase):
 
     def test_str(self):
         self.assertEqual(str(self.label), "Un label")
+
+
+class LabelQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.siae_1 = SiaeFactory()
+        cls.siae_2 = SiaeFactory()
+        cls.label = LabelFactory()
+        cls.label_with_siaes = LabelFactory(siaes=[cls.siae_1, cls.siae_2])
+
+    def test_with_siae_stats(self):
+        label_queryset = Label.objects.with_siae_stats()
+        self.assertEqual(label_queryset.get(id=self.label.id).siae_count_annotated, 0)
+        self.assertEqual(label_queryset.get(id=self.label_with_siaes.id).siae_count_annotated, 2)

--- a/lemarche/networks/factories.py
+++ b/lemarche/networks/factories.py
@@ -11,3 +11,8 @@ class NetworkFactory(DjangoModelFactory):
     name = factory.Faker("company", locale="fr_FR")
     # slug: auto-generated
     website = "https://example.com"
+
+    @factory.post_generation
+    def siaes(self, create, extracted, **kwargs):
+        if extracted:
+            self.siaes.add(*extracted)

--- a/lemarche/networks/models.py
+++ b/lemarche/networks/models.py
@@ -1,6 +1,15 @@
 from django.db import models
+from django.db.models import Count
 from django.template.defaultfilters import slugify
 from django.utils import timezone
+
+
+class NetworkQuerySet(models.QuerySet):
+    def with_siae_stats(self):
+        return self.annotate(siae_count_annotated=Count("siaes", distinct=True))
+
+    def with_user_partner_stats(self):
+        return self.annotate(user_partner_count_annotated=Count("user_partners", distinct=True))
 
 
 class Network(models.Model):
@@ -12,6 +21,8 @@ class Network(models.Model):
 
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
+
+    objects = models.Manager.from_queryset(NetworkQuerySet)()
 
     class Meta:
         verbose_name = "Réseau"

--- a/lemarche/networks/tests.py
+++ b/lemarche/networks/tests.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 
 from lemarche.networks.factories import NetworkFactory
+from lemarche.networks.models import Network
+from lemarche.siaes.factories import SiaeFactory
+from lemarche.users.factories import UserFactory
 
 
 class NetworkModelTest(TestCase):
@@ -13,3 +16,24 @@ class NetworkModelTest(TestCase):
 
     def test_str(self):
         self.assertEqual(str(self.network), "Mon réseau")
+
+
+class NetworkQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.siae_1 = SiaeFactory()
+        cls.siae_2 = SiaeFactory()
+        cls.network = NetworkFactory()
+        cls.network_with_user_partner = NetworkFactory()
+        cls.network_with_siaes = NetworkFactory(siaes=[cls.siae_1, cls.siae_2])
+        cls.user = UserFactory(partner_network=cls.network_with_user_partner)
+
+    def test_with_siae_stats(self):
+        network_queryset = Network.objects.with_siae_stats()
+        self.assertEqual(network_queryset.get(id=self.network.id).siae_count_annotated, 0)
+        self.assertEqual(network_queryset.get(id=self.network_with_siaes.id).siae_count_annotated, 2)
+
+    def test_with_user_partner_stats(self):
+        network_queryset = Network.objects.with_user_partner_stats()
+        self.assertEqual(network_queryset.get(id=self.network.id).user_partner_count_annotated, 0)
+        self.assertEqual(network_queryset.get(id=self.network_with_user_partner.id).user_partner_count_annotated, 1)

--- a/lemarche/networks/tests.py
+++ b/lemarche/networks/tests.py
@@ -23,8 +23,8 @@ class NetworkQuerySetTest(TestCase):
     def setUpTestData(cls):
         cls.siae_1 = SiaeFactory()
         cls.siae_2 = SiaeFactory()
-        cls.network = NetworkFactory()
-        cls.network_with_user_partner = NetworkFactory()
+        cls.network = NetworkFactory(name="Reseau")
+        cls.network_with_user_partner = NetworkFactory(name="Reseau avec utilisateur")
         cls.network_with_siaes = NetworkFactory(siaes=[cls.siae_1, cls.siae_2])
         cls.user = UserFactory(partner_network=cls.network_with_user_partner)
 

--- a/lemarche/sectors/admin.py
+++ b/lemarche/sectors/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.db.models import Count
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -9,7 +8,7 @@ from lemarche.utils.admin.admin_site import admin_site
 
 @admin.register(SectorGroup, site=admin_site)
 class SectorGroupAdmin(admin.ModelAdmin):
-    list_display = ["id", "name", "nb_sectors", "created_at"]
+    list_display = ["id", "name", "sector_count_annotated_with_link", "created_at"]
     search_fields = ["id", "name"]
     search_help_text = "Cherche sur les champs : ID, Nom"
 
@@ -18,20 +17,20 @@ class SectorGroupAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.annotate(sector_count=Count("sectors", distinct=True))
+        qs = qs.with_sector_stats()
         return qs
 
-    def nb_sectors(self, sector_group):
+    def sector_count_annotated_with_link(self, sector_group):
         url = reverse("admin:sectors_sector_changelist") + f"?group__id__exact={sector_group.id}"
-        return format_html(f'<a href="{url}">{sector_group.sector_count}</a>')
+        return format_html(f'<a href="{url}">{sector_group.sector_count_annotated}</a>')
 
-    nb_sectors.short_description = "Nombre de secteurs d'activité"
-    nb_sectors.admin_order_field = "sector_count"
+    sector_count_annotated_with_link.short_description = "Nombre de secteurs d'activité"
+    sector_count_annotated_with_link.admin_order_field = "sector_count_annotated"
 
 
 @admin.register(Sector, site=admin_site)
 class SectorAdmin(admin.ModelAdmin):
-    list_display = ["id", "name", "nb_siaes", "group", "created_at"]
+    list_display = ["id", "name", "siae_count_annotated_with_link", "group", "created_at"]
     list_filter = ["group"]
     search_fields = ["id", "name"]
     search_help_text = "Cherche sur les champs : ID, Nom"
@@ -41,12 +40,12 @@ class SectorAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.annotate(siae_count=Count("siaes", distinct=True))
+        qs = qs.with_siae_stats()
         return qs
 
-    def nb_siaes(self, sector):
+    def siae_count_annotated_with_link(self, sector):
         url = reverse("admin:siaes_siae_changelist") + f"?sectors__id__exact={sector.id}"
-        return format_html(f'<a href="{url}">{sector.siae_count}</a>')
+        return format_html(f'<a href="{url}">{sector.siae_count_annotated}</a>')
 
-    nb_siaes.short_description = "Nombre de structures rattachées"
-    nb_siaes.admin_order_field = "siae_count"
+    siae_count_annotated_with_link.short_description = "Nombre de structures rattachées"
+    siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"

--- a/lemarche/sectors/factories.py
+++ b/lemarche/sectors/factories.py
@@ -19,3 +19,8 @@ class SectorFactory(DjangoModelFactory):
     name = factory.Faker("name", locale="fr_FR")
     # slug auto-generated
     group = factory.SubFactory(SectorGroupFactory)
+
+    @factory.post_generation
+    def siaes(self, create, extracted, **kwargs):
+        if extracted:
+            self.siaes.add(*extracted)

--- a/lemarche/sectors/models.py
+++ b/lemarche/sectors/models.py
@@ -1,15 +1,23 @@
 from django.db import models
-from django.db.models import Value
+from django.db.models import Count, Value
 from django.db.models.functions import Left, NullIf
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 
 
+class SectorGroupQuerySet(models.QuerySet):
+    def with_sector_stats(self):
+        return self.annotate(sector_count_annotated=Count("sectors", distinct=True))
+
+
 class SectorGroup(models.Model):
     name = models.CharField(verbose_name="Nom", max_length=255)
     slug = models.SlugField(verbose_name="Slug", max_length=255, unique=True)
+
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
+
+    objects = models.Manager.from_queryset(SectorGroupQuerySet)()
 
     class Meta:
         verbose_name = "Groupe de secteurs d'activité"
@@ -44,6 +52,9 @@ class SectorQuerySet(models.QuerySet):
             .order_by("group__id", "sector_is_autre")
         )
 
+    def with_siae_stats(self):
+        return self.annotate(siae_count_annotated=Count("siaes", distinct=True))
+
 
 class Sector(models.Model):
     name = models.CharField(verbose_name="Nom", max_length=255)
@@ -56,6 +67,7 @@ class Sector(models.Model):
         null=True,
         blank=True,
     )
+
     created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
 

--- a/lemarche/sectors/tests.py
+++ b/lemarche/sectors/tests.py
@@ -1,7 +1,34 @@
 from django.test import TestCase
 
 from lemarche.sectors.factories import SectorFactory, SectorGroupFactory
-from lemarche.sectors.models import Sector
+from lemarche.sectors.models import Sector, SectorGroup
+from lemarche.siaes.factories import SiaeFactory
+
+
+class SectorGroupModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sector_group = SectorGroupFactory(name="Un groupe")
+
+    def test_slug_field(self):
+        self.assertEqual(self.sector_group.slug, "un-groupe")
+
+    def test_str(self):
+        self.assertEqual(str(self.sector_group), "Un groupe")
+
+
+class SectorGroupQuerysetModelTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sector_group = SectorGroupFactory(name="Informatique")
+        cls.sector_group_with_sectors = SectorGroupFactory(name="Bricolage")
+        SectorFactory(name="Développement de logiciel", group=cls.sector_group_1)
+        SectorFactory(name="Dépannage informatique", group=cls.sector_group_1)
+
+    def with_sector_stats(self):
+        sector_group_queryset = SectorGroup.objects.with_user_stats()
+        self.assertEqual(sector_group_queryset.get(id=self.sector_group.id).sector_count_annotated, 0)
+        self.assertEqual(sector_group_queryset.get(id=self.sector_group_with_sectors.id).sector_count_annotated, 2)
 
 
 class SectorModelTest(TestCase):
@@ -22,6 +49,8 @@ class SectorModelTest(TestCase):
 class SectorQuerysetModelTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.siae_1 = SiaeFactory()
+        cls.siae_2 = SiaeFactory()
         cls.sector_group_1 = SectorGroupFactory(name="Informatique")
         cls.sector_group_2 = SectorGroupFactory(name="Bricolage")
         cls.sector_1_1 = SectorFactory(name="Développement de logiciel", group=cls.sector_group_1)
@@ -29,7 +58,7 @@ class SectorQuerysetModelTest(TestCase):
         cls.sector_1_3 = SectorFactory(name="Autre", group=cls.sector_group_1)
         cls.sector_2_1 = SectorFactory(name="Plomberie", group=cls.sector_group_2)
         cls.sector_2_2 = SectorFactory(name="Autre (Bricolage)", group=cls.sector_group_2)
-        cls.sector_3 = SectorFactory(name="Un secteur seul", group=None)
+        cls.sector_3 = SectorFactory(name="Un secteur seul", group=None, siaes=[cls.siae_1, cls.siae_2])
 
     def test_form_filter_queryset(self):
         sectors = Sector.objects.form_filter_queryset()
@@ -41,3 +70,8 @@ class SectorQuerysetModelTest(TestCase):
         self.assertEqual(sectors[0], self.sector_1_2)
         self.assertEqual(sectors[2], self.sector_1_3)
         self.assertEqual(sectors[4], self.sector_2_2)
+
+    def test_with_siae_stats(self):
+        sector_queryset = Sector.objects.with_siae_stats()
+        self.assertEqual(sector_queryset.get(id=self.sector_1_1.id).siae_count_annotated, 0)
+        self.assertEqual(sector_queryset.get(id=self.sector_3.id).siae_count_annotated, 2)

--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -141,9 +141,9 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "label_count_with_link",
         "client_reference_count_with_link",
         "image_count_with_link",
-        "tender_email_send_count_with_link",
-        "tender_detail_display_count_with_link",
-        "tender_detail_contact_click_count_with_link",
+        "tender_email_send_count_annotated_with_link",
+        "tender_detail_display_count_annotated_with_link",
+        "tender_detail_contact_click_count_annotated_with_link",
         "created_at",
     ]
     list_filter = [
@@ -175,11 +175,11 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
         "coords_display",
         "logo_url",
         "logo_url_display",
-        "tender_count_with_link",
-        "tender_email_send_count_with_link",
-        "tender_email_link_click_count_with_link",
-        "tender_detail_display_count_with_link",
-        "tender_detail_contact_click_count_with_link",
+        "tender_count_annotated_with_link",
+        "tender_email_send_count_annotated_with_link",
+        "tender_email_link_click_count_annotated_with_link",
+        "tender_detail_display_count_annotated_with_link",
+        "tender_detail_contact_click_count_annotated_with_link",
         "logs_display",
         # "import_raw_object",
         "import_raw_object_display",
@@ -295,11 +295,11 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
             "Besoins des acheteurs",
             {
                 "fields": (
-                    "tender_count_with_link",
-                    "tender_email_send_count_with_link",
-                    "tender_email_link_click_count_with_link",
-                    "tender_detail_display_count_with_link",
-                    "tender_detail_contact_click_count_with_link",
+                    "tender_count_annotated_with_link",
+                    "tender_email_send_count_annotated_with_link",
+                    "tender_email_link_click_count_annotated_with_link",
+                    "tender_detail_display_count_annotated_with_link",
+                    "tender_detail_contact_click_count_annotated_with_link",
                 )
             },
         ),
@@ -531,52 +531,54 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.OSMGeoAdmin):
 
     import_raw_object_display.short_description = Siae._meta.get_field("import_raw_object").verbose_name
 
-    def tender_count_with_link(self, siae):
+    def tender_count_annotated_with_link(self, siae):
         url = reverse("admin:tenders_tender_changelist") + f"?siaes__in={siae.id}"
-        return format_html(f'<a href="{url}">{getattr(siae, "tender_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_count_annotated", 0)}</a>')
 
-    tender_count_with_link.short_description = "Besoins concernés"
-    tender_count_with_link.admin_order_field = "tender_count"
+    tender_count_annotated_with_link.short_description = "Besoins concernés"
+    tender_count_annotated_with_link.admin_order_field = "tender_count_annotated"
 
-    def tender_email_send_count_with_link(self, siae):
+    def tender_email_send_count_annotated_with_link(self, siae):
         url = (
             reverse("admin:tenders_tender_changelist")
             + f"?siaes__in={siae.id}&tendersiae__email_send_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(siae, "tender_email_send_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_email_send_count_annotated", 0)}</a>')
 
-    tender_email_send_count_with_link.short_description = "Besoins reçus"
-    tender_email_send_count_with_link.admin_order_field = "tender_email_send_count"
+    tender_email_send_count_annotated_with_link.short_description = "Besoins reçus"
+    tender_email_send_count_annotated_with_link.admin_order_field = "tender_email_send_count_annotated"
 
-    def tender_email_link_click_count_with_link(self, siae):
+    def tender_email_link_click_count_annotated_with_link(self, siae):
         url = (
             reverse("admin:tenders_tender_changelist")
             + f"?siaes__in={siae.id}&tendersiae__email_link_click_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(siae, "tender_email_link_click_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_email_link_click_count_annotated", 0)}</a>')
 
-    tender_email_link_click_count_with_link.short_description = "Besoins cliqués"
-    tender_email_link_click_count_with_link.admin_order_field = "tender_email_link_click_count"
+    tender_email_link_click_count_annotated_with_link.short_description = "Besoins cliqués"
+    tender_email_link_click_count_annotated_with_link.admin_order_field = "tender_email_link_click_count_annotated"
 
-    def tender_detail_display_count_with_link(self, siae):
+    def tender_detail_display_count_annotated_with_link(self, siae):
         url = (
             reverse("admin:tenders_tender_changelist")
             + f"?siaes__in={siae.id}&tendersiae__detail_display_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(siae, "tender_detail_display_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_detail_display_count_annotated", 0)}</a>')
 
-    tender_detail_display_count_with_link.short_description = "Besoins vues"
-    tender_detail_display_count_with_link.admin_order_field = "tender_detail_display_count"
+    tender_detail_display_count_annotated_with_link.short_description = "Besoins vues"
+    tender_detail_display_count_annotated_with_link.admin_order_field = "tender_detail_display_count_annotated"
 
-    def tender_detail_contact_click_count_with_link(self, siae):
+    def tender_detail_contact_click_count_annotated_with_link(self, siae):
         url = (
             reverse("admin:tenders_tender_changelist")
             + f"?siaes__in={siae.id}&tendersiae__detail_contact_click_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(siae, "tender_detail_contact_click_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(siae, "tender_detail_contact_click_count_annotated", 0)}</a>')
 
-    tender_detail_contact_click_count_with_link.short_description = "Besoins intéressés"
-    tender_detail_contact_click_count_with_link.admin_order_field = "tender_detail_contact_click_count"
+    tender_detail_contact_click_count_annotated_with_link.short_description = "Besoins intéressés"
+    tender_detail_contact_click_count_annotated_with_link.admin_order_field = (
+        "tender_detail_contact_click_count_annotated"
+    )
 
     def logs_display(self, siae=None):
         if siae:

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -14,6 +14,11 @@ class SiaeGroupFactory(DjangoModelFactory):
     name = factory.Faker("company", locale="fr_FR")
     # slug auto-generated
 
+    @factory.post_generation
+    def siaes(self, create, extracted, **kwargs):
+        if extracted:
+            self.siaes.add(*extracted)
+
 
 class SiaeFactory(DjangoModelFactory):
     class Meta:

--- a/lemarche/siaes/factories.py
+++ b/lemarche/siaes/factories.py
@@ -4,7 +4,7 @@ import factory.fuzzy
 from factory.django import DjangoModelFactory
 
 from lemarche.siaes import constants as siae_constants
-from lemarche.siaes.models import Siae, SiaeClientReference, SiaeGroup, SiaeLabelOld, SiaeOffer
+from lemarche.siaes.models import Siae, SiaeClientReference, SiaeGroup, SiaeImage, SiaeLabelOld, SiaeOffer
 
 
 class SiaeGroupFactory(DjangoModelFactory):
@@ -73,5 +73,12 @@ class SiaeClientReferenceFactory(DjangoModelFactory):
 class SiaeLabelOldFactory(DjangoModelFactory):
     class Meta:
         model = SiaeLabelOld
+
+    name = factory.Faker("name", locale="fr_FR")
+
+
+class SiaeImageFactory(DjangoModelFactory):
+    class Meta:
+        model = SiaeImage
 
     name = factory.Faker("name", locale="fr_FR")

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1116,9 +1116,10 @@ def siae_sectors_changed(sender, instance, action, **kwargs):
 
 @receiver(m2m_changed, sender=Siae.networks.through)
 def siae_networks_changed(sender, instance, action, **kwargs):
-    if action in ("post_add", "post_remove", "post_clear"):
-        instance.network_count = instance.networks.count()
-        instance.save()
+    if isinstance(instance, Siae):
+        if action in ("post_add", "post_remove", "post_clear"):
+            instance.network_count = instance.networks.count()
+            instance.save()
 
 
 @receiver(m2m_changed, sender=Siae.groups.through)

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -1108,9 +1108,10 @@ def siae_users_changed(sender, instance, action, **kwargs):
 
 @receiver(m2m_changed, sender=Siae.sectors.through)
 def siae_sectors_changed(sender, instance, action, **kwargs):
-    if action in ("post_add", "post_remove", "post_clear"):
-        instance.sector_count = instance.sectors.count()
-        instance.save()
+    if isinstance(instance, Siae):
+        if action in ("post_add", "post_remove", "post_clear"):
+            instance.sector_count = instance.sectors.count()
+            instance.save()
 
 
 @receiver(m2m_changed, sender=Siae.networks.through)

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -49,6 +49,20 @@ class SiaeGroupModelSaveTest(TestCase):
         self.assertNotEqual(siae_group.employees_insertion_count_last_updated, employees_insertion_count_last_updated)
 
 
+class SiaeGroupQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.siae_1 = SiaeFactory()
+        cls.siae_2 = SiaeFactory(is_active=False)
+        cls.siae_group = SiaeGroupFactory()
+        cls.siae_group_with_siaes = SiaeGroupFactory(siaes=[cls.siae_1, cls.siae_2])
+
+    def test_with_siae_stats(self):
+        siae_group_queryset = SiaeGroup.objects.with_siae_stats()
+        self.assertEqual(siae_group_queryset.get(id=self.siae_group.id).siae_count_annotated, 0)
+        self.assertEqual(siae_group_queryset.get(id=self.siae_group_with_siaes.id).siae_count_annotated, 2)
+
+
 class SiaeModelTest(TestCase):
     def setUp(self):
         pass

--- a/lemarche/siaes/tests.py
+++ b/lemarche/siaes/tests.py
@@ -6,7 +6,14 @@ from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.factories import SectorFactory
 from lemarche.siaes import constants as siae_constants, utils as siae_utils
-from lemarche.siaes.factories import SiaeFactory, SiaeGroupFactory, SiaeLabelOldFactory, SiaeOfferFactory
+from lemarche.siaes.factories import (
+    SiaeClientReferenceFactory,
+    SiaeFactory,
+    SiaeGroupFactory,
+    SiaeImageFactory,
+    SiaeLabelOldFactory,
+    SiaeOfferFactory,
+)
 from lemarche.siaes.models import Siae, SiaeGroup, SiaeLabel, SiaeUser
 from lemarche.users.factories import UserFactory
 
@@ -345,32 +352,43 @@ class SiaeModelQuerysetTest(TestCase):
         self.assertEqual(Siae.objects.count(), 2)
         self.assertEqual(Siae.objects.has_user().count(), 1)
 
-    # def test_annotate_with_user_favorite_list_ids(self):
+    # def test_with_in_user_favorite_list_stats(self):
     # see favorites > tests.py
 
     # def test_with_tender_stats(self):
     # see tenders > tests.py > TenderModelQuerysetStatsTest
 
-    def test_annotate_with_brand_or_name(self):
+    def test_with_brand_or_name(self):
         siae_1 = SiaeFactory(name="ZZZ", brand="ABC")
         siae_2 = SiaeFactory(name="Test", brand="")
-        siae_queryset = Siae.objects.annotate_with_brand_or_name()
-        self.assertEqual(siae_queryset.get(id=siae_1.id).brand_or_name, siae_1.brand)
-        self.assertEqual(siae_queryset.get(id=siae_2.id).brand_or_name, siae_2.name)
+        siae_queryset = Siae.objects.with_brand_or_name()
+        self.assertEqual(siae_queryset.get(id=siae_1.id).brand_or_name_annotated, siae_1.brand)
+        self.assertEqual(siae_queryset.get(id=siae_2.id).brand_or_name_annotated, siae_2.name)
         self.assertEqual(siae_queryset.first(), siae_2)  # default order is by "name"
-        siae_queryset_with_order_by = Siae.objects.annotate_with_brand_or_name().order_by("brand_or_name")
+        siae_queryset_with_order_by = Siae.objects.with_brand_or_name().order_by("brand_or_name_annotated")
         self.assertEqual(siae_queryset_with_order_by.first(), siae_1)
-        siae_queryset_with_order_by_parameter = Siae.objects.annotate_with_brand_or_name(with_order_by=True)
+        siae_queryset_with_order_by_parameter = Siae.objects.with_brand_or_name(with_order_by=True)
         self.assertEqual(siae_queryset_with_order_by_parameter.first(), siae_1)
 
     def test_with_content_filled_stats(self):
         siae_empty = SiaeFactory(name="Empty")
-        siae_filled_basic = SiaeFactory(name="Filled basic", user_count=1, sector_count=2, description="desc")
+        siae_filled_basic = SiaeFactory(name="Filled basic", user_count=1, sector_count=1, description="desc")
+        siae_filled_full = SiaeFactory(
+            name="Filled full", user_count=1, sector_count=1, description="desc", logo_url="https://logo.png"
+        )
+        SiaeClientReferenceFactory(siae=siae_filled_full)
+        SiaeImageFactory(siae=siae_filled_full)
+        SiaeLabelOldFactory(siae=siae_filled_full)
+        siae_filled_full.save()
         siae_queryset = Siae.objects.with_content_filled_stats()
-        self.assertEqual(siae_queryset.get(id=siae_empty.id).content_filled_basic, False)
-        self.assertEqual(siae_queryset.get(id=siae_filled_basic.id).content_filled_basic, True)
+        self.assertEqual(siae_queryset.get(id=siae_empty.id).content_filled_basic_annotated, False)
+        self.assertEqual(siae_queryset.get(id=siae_empty.id).content_filled_full_annotated, False)
+        self.assertEqual(siae_queryset.get(id=siae_filled_basic.id).content_filled_basic_annotated, True)
+        self.assertEqual(siae_queryset.get(id=siae_filled_basic.id).content_filled_full_annotated, False)
+        self.assertEqual(siae_queryset.get(id=siae_filled_full.id).content_filled_basic_annotated, True)
+        self.assertEqual(siae_queryset.get(id=siae_filled_full.id).content_filled_full_annotated, True)
 
-    def test_with_employees_count(self):
+    def test_with_employees_stats(self):
         siae_1 = SiaeFactory()
         siae_2 = SiaeFactory(employees_insertion_count=10)
         siae_3 = SiaeFactory(c2_etp_count=19.5)
@@ -380,30 +398,30 @@ class SiaeModelQuerysetTest(TestCase):
         siae_7 = SiaeFactory(c2_etp_count=2550, employees_permanent_count=1500)
         siae_8 = SiaeFactory(employees_insertion_count=125, c2_etp_count=158, employees_permanent_count=88)
 
-        siae_queryset = Siae.objects.with_employees_count()
-        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_insertion_count_with_c2_etp, None)
-        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_count, None)
+        siae_queryset = Siae.objects.with_employees_stats()
+        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_insertion_count_with_c2_etp_annotated, None)
+        self.assertEqual(siae_queryset.get(id=siae_1.id).employees_count_annotated, None)
 
-        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_insertion_count_with_c2_etp, 10)
-        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_count, 10)
+        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_insertion_count_with_c2_etp_annotated, 10)
+        self.assertEqual(siae_queryset.get(id=siae_2.id).employees_count_annotated, 10)
 
-        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_insertion_count_with_c2_etp, 20)
-        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_count, 20)
+        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_insertion_count_with_c2_etp_annotated, 20)
+        self.assertEqual(siae_queryset.get(id=siae_3.id).employees_count_annotated, 20)
 
-        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_insertion_count_with_c2_etp, None)
-        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_count, 155)
+        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_insertion_count_with_c2_etp_annotated, None)
+        self.assertEqual(siae_queryset.get(id=siae_4.id).employees_count_annotated, 155)
 
-        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_insertion_count_with_c2_etp, 22)
-        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_count, 22)
+        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_insertion_count_with_c2_etp_annotated, 22)
+        self.assertEqual(siae_queryset.get(id=siae_5.id).employees_count_annotated, 22)
 
-        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_insertion_count_with_c2_etp, 280)
-        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_count, 280 + 105)
+        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_insertion_count_with_c2_etp_annotated, 280)
+        self.assertEqual(siae_queryset.get(id=siae_6.id).employees_count_annotated, 280 + 105)
 
-        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_insertion_count_with_c2_etp, 2550)
-        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_count, 2550 + 1500)
+        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_insertion_count_with_c2_etp_annotated, 2550)
+        self.assertEqual(siae_queryset.get(id=siae_7.id).employees_count_annotated, 2550 + 1500)
 
-        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_insertion_count_with_c2_etp, 125)
-        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_count, 125 + 88)
+        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_insertion_count_with_c2_etp_annotated, 125)
+        self.assertEqual(siae_queryset.get(id=siae_8.id).employees_count_annotated, 125 + 88)
 
 
 class SiaeModelPerimeterQuerysetTest(TestCase):

--- a/lemarche/templates/dashboard/siae_edit_info.html
+++ b/lemarche/templates/dashboard/siae_edit_info.html
@@ -41,7 +41,7 @@
                 </fieldset>
             </div>
         </div>
-        {% if last_3_siae_content_filled_full %}
+        {% if last_3_siae_content_filled_full_annotated %}
             <div class="col-12 col-lg-4">
                 <div class="alert alert-info mt-3 mt-lg-0" role="alert">
                     <p class="mb-1">
@@ -50,8 +50,8 @@
                     </p>
                     <p class="mb-1">
                         Inspirez-vous des fiches commerciales des prestataires inclusifs
-                        <a href="{% url 'siae:detail' last_3_siae_content_filled_full.0.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.0.name_display }}</a>
-                        et <a href="{% url 'siae:detail' last_3_siae_content_filled_full.1.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full.1.name_display }}</a>.
+                        <a href="{% url 'siae:detail' last_3_siae_content_filled_full_annotated.0.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full_annotated.0.name_display }}</a>
+                        et <a href="{% url 'siae:detail' last_3_siae_content_filled_full_annotated.1.slug %}" target="_blank" style="white-space:nowrap;">{{ last_3_siae_content_filled_full_annotated.1.name_display }}</a>.
                     </p>
                     <p class="mb-0">
                         Une fiche commerciale bien complétée c'est davantage de chances d'être sollicité par des clients.

--- a/lemarche/templates/networks/dashboard_network_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_list.html
@@ -82,25 +82,25 @@
                         {% for siae in siaes %}
                             <tr>
                                 <td>
-                                    <a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.brand_or_name }}</a>
+                                    <a href="{% url 'siae:detail' siae.slug %}" target="_blank">{{ siae.brand_or_name_annotated }}</a>
                                 </td>
                                 <td>
-                                    {% if siae.tender_email_send_count > 0 %}
-                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues" id="dashboard-network-siae-show-tender-email-send-list-btn">{{ siae.tender_email_send_count }}</a>
+                                    {% if siae.tender_email_send_count_annotated > 0 %}
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug %}" title="Voir les demandes reçues" id="dashboard-network-siae-show-tender-email-send-list-btn">{{ siae.tender_email_send_count_annotated }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if siae.tender_detail_display_count > 0 %}
-                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues" id="dashboard-network-siae-show-tender-detail-display-list-btn">{{ siae.tender_detail_display_count }}</a>
+                                    {% if siae.tender_detail_display_count_annotated > 0 %}
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "DISPLAY" %}" title="Voir les demandes vues" id="dashboard-network-siae-show-tender-detail-display-list-btn">{{ siae.tender_detail_display_count_annotated }}</a>
                                     {% else %}
                                         0
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if siae.tender_detail_contact_click_count > 0 %}
-                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées" id="dashboard-network-siae-show-tender-detail-contact-click-list-btn">{{ siae.tender_detail_contact_click_count }}</a>
+                                    {% if siae.tender_detail_contact_click_count_annotated > 0 %}
+                                        <a href="{% url 'dashboard_networks:siae_tender_list' network.slug siae.slug "CONTACT-CLICK" %}" title="Voir les demandes intéressées" id="dashboard-network-siae-show-tender-detail-contact-click-list-btn">{{ siae.tender_detail_contact_click_count_annotated }}</a>
                                     {% else %}
                                         0
                                     {% endif %}

--- a/lemarche/templates/networks/dashboard_network_siae_tender_list.html
+++ b/lemarche/templates/networks/dashboard_network_siae_tender_list.html
@@ -45,7 +45,7 @@
                                 class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
                                 Demandes reçues
-                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_email_send_count }}</span>
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_email_send_count_annotated }}</span>
                             </a>
                         </li>
                         <li class="nav-item">
@@ -53,7 +53,7 @@
                                 class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_DISPLAY_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
                                 Demandes vues
-                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_display_count }}</span>
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_display_count_annotated }}</span>
                             </a>
                         </li>
                         <li class="nav-item">
@@ -61,7 +61,7 @@
                                 class="nav-link{% if request.get_full_path == NETWORK_SIAE_TENDER_CONTACT_CLICK_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
                                 Demandes intéressées
-                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_contact_click_count }}</span>
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ siae.tender_detail_contact_click_count_annotated }}</span>
                             </a>
                         </li>
                     </ul>

--- a/lemarche/templates/networks/dashboard_network_tender_detail.html
+++ b/lemarche/templates/networks/dashboard_network_tender_detail.html
@@ -34,11 +34,11 @@
             <div class="col-12 col-lg-4 order-1 order-lg-2">
                 <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug %}" id="show-tender-siae-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
                     <i class="ri-focus-2-line"></i>
-                    {{ tender.network_siae_email_send_count }} adhérent{{ tender.network_siae_email_send_count|pluralize }} notifié{{ tender.network_siae_email_send_count|pluralize }}
+                    {{ tender.network_siae_email_send_count_annotated }} adhérent{{ tender.network_siae_email_send_count_annotated|pluralize }} notifié{{ tender.network_siae_email_send_count_annotated|pluralize }}
                 </a>
                 <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug "CONTACT-CLICK" %}" id="show-tender-siae-interested-list-from-network-tender-detail-btn" class="btn btn-primary mb-3">
                     <i class="ri-thumb-up-line"></i>
-                    {{ tender.network_siae_detail_contact_click_count }} adhérent{{ tender.network_siae_detail_contact_click_count|pluralize }} intéressé{{ tender.network_siae_detail_contact_click_count|pluralize }}
+                    {{ tender.network_siae_detail_contact_click_count_annotated }} adhérent{{ tender.network_siae_detail_contact_click_count_annotated|pluralize }} intéressé{{ tender.network_siae_detail_contact_click_count_annotated|pluralize }}
                 </a>
             </div>
         </div>

--- a/lemarche/templates/networks/dashboard_network_tender_siae_list.html
+++ b/lemarche/templates/networks/dashboard_network_tender_siae_list.html
@@ -45,7 +45,7 @@
                                 class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
                                 Adhérents notifiés
-                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_email_send_count }}</span>
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_email_send_count_annotated }}</span>
                             </a>
                         </li>
                         <li class="nav-item">
@@ -53,7 +53,7 @@
                                 class="nav-link{% if request.get_full_path == NETWORK_TENDER_SIAE_CONTACT_CLICK_LIST_URL %} active{% endif %}"
                                 hx-target="#siaeTenderList" hx-swap="outerHTML">
                                 Adhérents intéressés
-                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_detail_contact_click_count }}</span>
+                                <span class="badge badge-pill badge-primary fs-xs" style="vertical-align:middle;">{{ tender.network_siae_detail_contact_click_count_annotated }}</span>
                             </a>
                         </li>
                     </ul>

--- a/lemarche/templates/siaes/_card_detail.html
+++ b/lemarche/templates/siaes/_card_detail.html
@@ -19,7 +19,7 @@
                             <small>(profil mis à jour il y a {{ siae.updated_at|timesince }})</small>
                         </h1>
                         {% if user.is_authenticated %}
-                            {% if siae.in_user_favorite_list_count %}
+                            {% if siae.in_user_favorite_list_count_annotated %}
                                 <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" title="Dans votre liste d'achat">
                                     <i class="ri-star-fill ri-xl"></i>
                                 </a>

--- a/lemarche/templates/siaes/_card_search_result.html
+++ b/lemarche/templates/siaes/_card_search_result.html
@@ -38,7 +38,7 @@
                 {% endif %}
             </ul>
             {% if user.is_authenticated %}
-                {% if from_profile or siae.in_user_favorite_list_count %}
+                {% if from_profile or siae.in_user_favorite_list_count_annotated %}
                     <a href="#" id="favorite-remove-modal-btn" class="btn btn-favorite" data-toggle="modal" data-target="#favorite_item_remove_modal" data-siae-id="{{ siae.id }}" data-siae-slug="{{ siae.slug }}" data-siae-name-display="{{ siae.name_display }}" title="Dans votre liste d'achat">
                         <i class="ri-star-fill ri-xl"></i>
                     </a>

--- a/lemarche/templates/tenders/_card_list_item.html
+++ b/lemarche/templates/tenders/_card_list_item.html
@@ -1,7 +1,7 @@
 <div>
     <time class="fs-sm d-block" aria-label="Date de clôture">
         <span>{{ tender.deadline_date|default:"" }}</span>
-        {% if tender.deadline_date_is_outdated %}
+        {% if tender.deadline_date_is_outdated_annotated %}
             <span class="badge badge-xs badge-base badge-pill badge-pilotage float-right">Clôturé</span>
         {% endif %}
         {% if tender.status == tender.STATUS_DRAFT %}

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -44,17 +44,17 @@
             <div class="col-md-4 text-center my-auto">
                 <hr class="d-md-none" />
                 {% if tender.status == tender.STATUS_VALIDATED %}
-                    {% if tender.siae_detail_contact_click_since_last_seen_date_count %}
+                    {% if tender.siae_detail_contact_click_since_last_seen_date_count_annotated %}
                         <span class="badge badge-base badge-pill badge-pilotage">
-                            <i class="ri-thumb-up-line ri-xl"></i>&nbsp;{{ tender.siae_detail_contact_click_since_last_seen_date_count }} nouveau{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize:"x" }} prestataire{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_since_last_seen_date_count|pluralize }}
+                            <i class="ri-thumb-up-line ri-xl"></i>&nbsp;{{ tender.siae_detail_contact_click_since_last_seen_date_count_annotated }} nouveau{{ tender.siae_detail_contact_click_since_last_seen_date_count_annotated|pluralize:"x" }} prestataire{{ tender.siae_detail_contact_click_since_last_seen_date_count_annotated|pluralize }} intéressé{{ tender.siae_detail_contact_click_since_last_seen_date_count_annotated|pluralize }}
                         </span>
                     {% endif %}
                     <div class="row">
                         <div class="col-6" style="border-right:1px solid;">
                             <p class="font-weight-bold mt-2">
-                                <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.siae_email_send_count|default:0 }} prestataire{{ tender.siae_email_send_count|pluralize }} ciblé{{ tender.siae_email_send_count|pluralize }}
+                                <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.siae_email_send_count_annotated|default:0 }} prestataire{{ tender.siae_email_send_count_annotated|pluralize }} ciblé{{ tender.siae_email_send_count_annotated|pluralize }}
                             </p>
-                            {% if tender.siae_email_send_count %}
+                            {% if tender.siae_email_send_count_annotated %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
                                     Voir
                                 </a>
@@ -62,9 +62,9 @@
                         </div>
                         <div class="col-6">
                             <p class="font-weight-bold mt-2">
-                                <i class="ri-thumb-up-line font-weight-light"></i>&nbsp;{{ tender.siae_detail_contact_click_count|default:0 }} prestataire{{ tender.siae_detail_contact_click_count|pluralize }} intéressé{{ tender.siae_detail_contact_click_count|pluralize }}
+                                <i class="ri-thumb-up-line font-weight-light"></i>&nbsp;{{ tender.siae_detail_contact_click_count_annotated|default:0 }} prestataire{{ tender.siae_detail_contact_click_count_annotated|pluralize }} intéressé{{ tender.siae_detail_contact_click_count_annotated|pluralize }}
                             </p>
-                            {% if tender.siae_detail_contact_click_count %}
+                            {% if tender.siae_detail_contact_click_count_annotated %}
                                 <a href="{% url 'tenders:detail-siae-list' tender.slug "INTERESTED" %}" id="show-tender-siae-list-btn" class="btn btn-sm btn-primary">
                                     Voir
                                 </a>

--- a/lemarche/templates/tenders/_list_item_buyer.html
+++ b/lemarche/templates/tenders/_list_item_buyer.html
@@ -6,7 +6,7 @@
             <div class="col-md-8" style="border-right:1px solid;">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_is_outdated %}
+                    {% if tender.deadline_date_is_outdated_annotated %}
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
                     {% if tender.status == tender.STATUS_DRAFT %}

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -8,7 +8,7 @@
                     <div class="col-md-12">
                         <p class="mb-1">
                             Date de clôture : {{ tender.deadline_date|default:"" }}
-                            {% if tender.deadline_date_is_outdated %}
+                            {% if tender.deadline_date_is_outdated_annotated %}
                                 <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                             {% endif %}
                             <span class="float-right badge badge-base badge-pill badge-emploi">

--- a/lemarche/templates/tenders/_list_item_network.html
+++ b/lemarche/templates/tenders/_list_item_network.html
@@ -34,9 +34,9 @@
                 <div class="row">
                     <div class="col-12">
                         <p class="font-weight-bold">
-                            <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count|default:0 }} adhérent{{ tender.network_siae_email_send_count|pluralize }} notifié{{ tender.network_siae_email_send_count|pluralize }}
+                            <i class="ri-focus-2-line font-weight-light"></i>&nbsp;{{ tender.network_siae_email_send_count_annotated|default:0 }} adhérent{{ tender.network_siae_email_send_count_annotated|pluralize }} notifié{{ tender.network_siae_email_send_count_annotated|pluralize }}
                         </p>
-                        {% if tender.network_siae_email_send_count %}
+                        {% if tender.network_siae_email_send_count_annotated %}
                             <a href="{% url 'dashboard_networks:tender_siae_list' network.slug tender.slug %}" id="dashboard-network-tender-show-siae-list-btn" class="btn btn-sm btn-primary">
                                 Voir la liste
                             </a>

--- a/lemarche/templates/tenders/_list_item_siae.html
+++ b/lemarche/templates/tenders/_list_item_siae.html
@@ -6,7 +6,7 @@
             <div class="col-md-12">
                 <p class="mb-1">
                     Date de clôture : {{ tender.deadline_date|default:"" }}
-                    {% if tender.deadline_date_is_outdated %}
+                    {% if tender.deadline_date_is_outdated_annotated %}
                         <span class="badge badge-sm badge-base badge-pill badge-pilotage">Clôturé</span>
                     {% endif %}
                     {% if not tender.tendersiae_set.first.detail_display_date %}

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -129,12 +129,12 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "kind",
         "deadline_date",
         "start_working_date",
-        "siae_count_with_link",
-        # "siae_email_send_count_with_link",
-        "siae_email_link_click_count_with_link",
-        "siae_detail_display_count_with_link",
-        # "siae_email_link_click_or_detail_display_count_with_link",
-        "siae_detail_contact_click_count_with_link",
+        "siae_count_annotated_with_link",
+        # "siae_email_send_count_annotated_with_link",
+        "siae_email_link_click_count_annotated_with_link",
+        "siae_detail_display_count_annotated_with_link",
+        # "siae_email_link_click_or_detail_display_count_annotated_with_link",
+        "siae_detail_contact_click_count_annotated_with_link",
         "siae_transactioned",
         "created_at",
         "validated_at",
@@ -172,13 +172,13 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         "survey_transactioned_answer",
         "survey_transactioned_answer_date",
         "validated_at",
-        "question_count_with_link",
-        "siae_count_with_link",
-        "siae_email_send_count_with_link",
-        "siae_email_link_click_count_with_link",
-        "siae_detail_display_count_with_link",
-        "siae_email_link_click_or_detail_display_count_with_link",
-        "siae_detail_contact_click_count_with_link",
+        "question_count_annotated_with_link",
+        "siae_count_annotated_with_link",
+        "siae_email_send_count_annotated_with_link",
+        "siae_email_link_click_count_annotated_with_link",
+        "siae_detail_display_count_annotated_with_link",
+        "siae_email_link_click_or_detail_display_count_annotated_with_link",
+        "siae_detail_contact_click_count_annotated_with_link",
         "logs_display",
         "extra_data_display",
         "source",
@@ -209,7 +209,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
                     "constraints",
                     "external_link",
                     "accept_cocontracting",
-                    "question_count_with_link",
+                    "question_count_annotated_with_link",
                 ),
             },
         ),
@@ -279,12 +279,12 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
             "Structures",
             {
                 "fields": (
-                    "siae_count_with_link",
-                    "siae_email_send_count_with_link",
-                    "siae_email_link_click_count_with_link",
-                    "siae_detail_display_count_with_link",
-                    "siae_email_link_click_or_detail_display_count_with_link",
-                    "siae_detail_contact_click_count_with_link",
+                    "siae_count_annotated_with_link",
+                    "siae_email_send_count_annotated_with_link",
+                    "siae_email_link_click_count_annotated_with_link",
+                    "siae_detail_display_count_annotated_with_link",
+                    "siae_email_link_click_or_detail_display_count_annotated_with_link",
+                    "siae_detail_contact_click_count_annotated_with_link",
                 )
             },
         ),
@@ -338,6 +338,7 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.with_siae_stats()
+        qs = qs.with_question_stats()
         return qs
 
     def get_changeform_initial_data(self, request):
@@ -405,73 +406,73 @@ class TenderAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
     user_with_link.short_description = "Auteur"
     user_with_link.admin_order_field = "author"
 
-    def question_count_with_link(self, tender):
+    def question_count_annotated_with_link(self, tender):
         url = reverse("admin:tenders_tenderquestion_changelist") + f"?tender__in={tender.id}"
-        return format_html(f'<a href="{url}">{getattr(tender, "questions_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "question_count_annotated", 0)}</a>')
 
-    question_count_with_link.short_description = TenderQuestion._meta.verbose_name_plural
-    question_count_with_link.admin_order_field = "questions_count"
+    question_count_annotated_with_link.short_description = TenderQuestion._meta.verbose_name_plural
+    question_count_annotated_with_link.admin_order_field = "question_count_annotated"
 
-    def siae_count_with_link(self, tender):
+    def siae_count_annotated_with_link(self, tender):
         url = reverse("admin:siaes_siae_changelist") + f"?tenders__in={tender.id}"
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "siae_count_annotated", 0)}</a>')
 
-    siae_count_with_link.short_description = "Structures concernées"
-    siae_count_with_link.admin_order_field = "siae_count"
+    siae_count_annotated_with_link.short_description = "Structures concernées"
+    siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"
 
-    def siae_email_send_count_with_link(self, tender):
+    def siae_email_send_count_annotated_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__email_send_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_email_send_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "siae_email_send_count_annotated", 0)}</a>')
 
-    siae_email_send_count_with_link.short_description = "S. contactées"
-    siae_email_send_count_with_link.admin_order_field = "siae_email_send_count"
+    siae_email_send_count_annotated_with_link.short_description = "S. contactées"
+    siae_email_send_count_annotated_with_link.admin_order_field = "siae_email_send_count_annotated"
 
-    def siae_email_link_click_count_with_link(self, tender):
+    def siae_email_link_click_count_annotated_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__email_link_click_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_email_link_click_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "siae_email_link_click_count_annotated", 0)}</a>')
 
-    siae_email_link_click_count_with_link.short_description = "S. cliquées"
-    siae_email_link_click_count_with_link.admin_order_field = "siae_email_link_click_count"
+    siae_email_link_click_count_annotated_with_link.short_description = "S. cliquées"
+    siae_email_link_click_count_annotated_with_link.admin_order_field = "siae_email_link_click_count_annotated"
 
-    def siae_detail_display_count_with_link(self, tender):
+    def siae_detail_display_count_annotated_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_display_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_display_count_annotated", 0)}</a>')
 
-    siae_detail_display_count_with_link.short_description = "S. vues"
-    siae_detail_display_count_with_link.admin_order_field = "siae_detail_display_count"
+    siae_detail_display_count_annotated_with_link.short_description = "S. vues"
+    siae_detail_display_count_annotated_with_link.admin_order_field = "siae_detail_display_count_annotated"
 
-    def siae_email_link_click_or_detail_display_count_with_link(self, tender):
+    def siae_email_link_click_or_detail_display_count_annotated_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__detail_display_date__isnull=False"
         )
         return format_html(
-            f'<a href="{url}">{getattr(tender, "siae_email_link_click_or_detail_display_count", 0)}</a>'
+            f'<a href="{url}">{getattr(tender, "siae_email_link_click_or_detail_display_count_annotated", 0)}</a>'
         )
 
-    siae_email_link_click_or_detail_display_count_with_link.short_description = "S. cliquées ou vues"
-    siae_email_link_click_or_detail_display_count_with_link.admin_order_field = (
-        "siae_email_link_click_or_detail_display_count"
+    siae_email_link_click_or_detail_display_count_annotated_with_link.short_description = "S. cliquées ou vues"
+    siae_email_link_click_or_detail_display_count_annotated_with_link.admin_order_field = (
+        "siae_email_link_click_or_detail_display_count_annotated"
     )
 
-    def siae_detail_contact_click_count_with_link(self, tender):
+    def siae_detail_contact_click_count_annotated_with_link(self, tender):
         url = (
             reverse("admin:siaes_siae_changelist")
             + f"?tenders__in={tender.id}&tendersiae__detail_contact_click_date__isnull=False"
         )
-        return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_contact_click_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(tender, "siae_detail_contact_click_count_annotated", 0)}</a>')
 
-    siae_detail_contact_click_count_with_link.short_description = "S. intéressées"
-    siae_detail_contact_click_count_with_link.admin_order_field = "siae_detail_contact_click_count"
+    siae_detail_contact_click_count_annotated_with_link.short_description = "S. intéressées"
+    siae_detail_contact_click_count_annotated_with_link.admin_order_field = "siae_detail_contact_click_count_annotated"
 
     def logs_display(self, tender=None):
         if tender:

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -83,12 +83,14 @@ class TenderQuerySet(models.QuerySet):
 
     def with_deadline_date_is_outdated(self, limit_date=datetime.today()):
         return self.annotate(
-            deadline_date_is_outdated=ExpressionWrapper(Q(deadline_date__lt=limit_date), output_field=BooleanField())
+            deadline_date_is_outdated_annotated=ExpressionWrapper(
+                Q(deadline_date__lt=limit_date), output_field=BooleanField()
+            )
         )
 
     def order_by_deadline_date(self, limit_date=datetime.today()):
         return self.with_deadline_date_is_outdated(limit_date=limit_date).order_by(
-            "deadline_date_is_outdated", "deadline_date", "-updated_at"
+            "deadline_date_is_outdated_annotated", "deadline_date", "-updated_at"
         )
 
     def with_question_stats(self):

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -94,30 +94,30 @@ class TenderQuerySet(models.QuerySet):
         )
 
     def with_question_stats(self):
-        return self.annotate(question_count=Count("questions", distinct=True))
+        return self.annotate(question_count_annotated=Count("questions", distinct=True))
 
     def with_siae_stats(self):
         """
         Enrich each Tender with stats on their linked Siae
         """
         return self.annotate(
-            siae_count=Count("siaes", distinct=True),
-            siae_email_send_count=Sum(
+            siae_count_annotated=Count("siaes", distinct=True),
+            siae_email_send_count_annotated=Sum(
                 Case(When(tendersiae__email_send_date__isnull=False, then=1), default=0, output_field=IntegerField())
             ),
-            siae_email_link_click_count=Sum(
+            siae_email_link_click_count_annotated=Sum(
                 Case(
                     When(tendersiae__email_link_click_date__isnull=False, then=1),
                     default=0,
                     output_field=IntegerField(),
                 )
             ),
-            siae_detail_display_count=Sum(
+            siae_detail_display_count_annotated=Sum(
                 Case(
                     When(tendersiae__detail_display_date__isnull=False, then=1), default=0, output_field=IntegerField()
                 )
             ),
-            siae_email_link_click_or_detail_display_count=Sum(
+            siae_email_link_click_or_detail_display_count_annotated=Sum(
                 Case(
                     When(
                         Q(tendersiae__detail_display_date__isnull=False)
@@ -128,14 +128,14 @@ class TenderQuerySet(models.QuerySet):
                     output_field=IntegerField(),
                 )
             ),
-            siae_detail_contact_click_count=Sum(
+            siae_detail_contact_click_count_annotated=Sum(
                 Case(
                     When(tendersiae__detail_contact_click_date__isnull=False, then=1),
                     default=0,
                     output_field=IntegerField(),
                 )
             ),
-            siae_detail_contact_click_since_last_seen_date_count=Sum(
+            siae_detail_contact_click_since_last_seen_date_count_annotated=Sum(
                 Case(
                     When(
                         tendersiae__detail_contact_click_date__gte=Greatest(
@@ -151,14 +151,14 @@ class TenderQuerySet(models.QuerySet):
 
     def with_network_siae_stats(self, network_siaes):
         return self.annotate(
-            network_siae_email_send_count=Sum(
+            network_siae_email_send_count_annotated=Sum(
                 Case(
                     When(Q(tendersiae__email_send_date__isnull=False) & Q(tendersiae__siae__in=network_siaes), then=1),
                     default=0,
                     output_field=IntegerField(),
                 ),
             ),
-            network_siae_detail_contact_click_count=Sum(
+            network_siae_detail_contact_click_count_annotated=Sum(
                 Case(
                     When(
                         Q(tendersiae__detail_contact_click_date__isnull=False) & Q(tendersiae__siae__in=network_siaes),
@@ -495,10 +495,6 @@ class Tender(models.Model):
 
     def questions_list(self):
         return list(self.questions.values("id", "text"))
-
-    @property
-    def questions_count(self):
-        return self.questions.count()
 
     @cached_property
     def external_link_title(self) -> str:

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -9,6 +9,7 @@ from django.forms.models import model_to_dict
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
+from lemarche.networks.factories import NetworkFactory
 from lemarche.perimeters.factories import PerimeterFactory
 from lemarche.perimeters.models import Perimeter
 from lemarche.sectors.factories import SectorFactory, SectorGroupFactory
@@ -316,50 +317,50 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(Tender.objects.count(), 2 + 1)
         tender_with_siae_1 = Tender.objects.with_siae_stats().filter(id=self.tender_with_siae_1.id).first()
         self.assertEqual(tender_with_siae_1.siaes.count(), 6)
-        self.assertEqual(tender_with_siae_1.siae_count, 6)
-        self.assertEqual(tender_with_siae_1.siae_email_send_count, 4)
-        self.assertEqual(tender_with_siae_1.siae_email_link_click_count, 3)
-        self.assertEqual(tender_with_siae_1.siae_detail_display_count, 2)
-        self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count, 2)
-        self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count, 1)
-        self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count, 1)
+        self.assertEqual(tender_with_siae_1.siae_count_annotated, 6)
+        self.assertEqual(tender_with_siae_1.siae_email_send_count_annotated, 4)
+        self.assertEqual(tender_with_siae_1.siae_email_link_click_count_annotated, 3)
+        self.assertEqual(tender_with_siae_1.siae_detail_display_count_annotated, 2)
+        self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count_annotated, 2)
+        self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count_annotated, 1)
+        self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count_annotated, 1)
         tender_with_siae_2 = Tender.objects.with_siae_stats().filter(id=self.tender_with_siae_2.id).first()
         self.assertEqual(tender_with_siae_2.siaes.count(), 1)
-        self.assertEqual(tender_with_siae_2.siae_count, 1)
-        self.assertEqual(tender_with_siae_2.siae_email_send_count, 1)
-        self.assertEqual(tender_with_siae_2.siae_detail_display_count, 1)
-        self.assertEqual(tender_with_siae_2.siae_email_link_click_or_detail_display_count, 1)
-        self.assertEqual(tender_with_siae_2.siae_detail_contact_click_count, 1)
-        self.assertEqual(tender_with_siae_2.siae_detail_contact_click_since_last_seen_date_count, 1)
+        self.assertEqual(tender_with_siae_2.siae_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.siae_email_send_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.siae_detail_display_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.siae_email_link_click_or_detail_display_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.siae_detail_contact_click_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.siae_detail_contact_click_since_last_seen_date_count_annotated, 1)
         tender_without_siae = Tender.objects.with_siae_stats().filter(id=self.tender_without_siae.id).first()
         self.assertEqual(tender_without_siae.siaes.count(), 0)
-        self.assertEqual(tender_without_siae.siae_count, 0)
-        self.assertEqual(tender_without_siae.siae_email_send_count, 0)
-        self.assertEqual(tender_without_siae.siae_detail_display_count, 0)
-        self.assertEqual(tender_without_siae.siae_email_link_click_or_detail_display_count, 0)
-        self.assertEqual(tender_without_siae.siae_detail_contact_click_count, 0)
-        self.assertEqual(tender_without_siae.siae_detail_contact_click_since_last_seen_date_count, 0)
+        self.assertEqual(tender_without_siae.siae_count_annotated, 0)
+        self.assertEqual(tender_without_siae.siae_email_send_count_annotated, 0)
+        self.assertEqual(tender_without_siae.siae_detail_display_count_annotated, 0)
+        self.assertEqual(tender_without_siae.siae_email_link_click_or_detail_display_count_annotated, 0)
+        self.assertEqual(tender_without_siae.siae_detail_contact_click_count_annotated, 0)
+        self.assertEqual(tender_without_siae.siae_detail_contact_click_since_last_seen_date_count_annotated, 0)
 
     def test_siae_with_tender_stats(self):
         self.assertEqual(Siae.objects.count(), 6 + 1)
         siae_with_tender_1 = Siae.objects.with_tender_stats().filter(id=self.siae_with_tender_1.id).first()
         # self.assertEqual(siae_with_tender_1.tenders.count(), 2)
-        self.assertEqual(siae_with_tender_1.tender_count, 2)
-        self.assertEqual(siae_with_tender_1.tender_email_send_count, 1)
-        self.assertEqual(siae_with_tender_1.tender_detail_display_count, 1)
-        self.assertEqual(siae_with_tender_1.tender_detail_contact_click_count, 1)
+        self.assertEqual(siae_with_tender_1.tender_count_annotated, 2)
+        self.assertEqual(siae_with_tender_1.tender_email_send_count_annotated, 1)
+        self.assertEqual(siae_with_tender_1.tender_detail_display_count_annotated, 1)
+        self.assertEqual(siae_with_tender_1.tender_detail_contact_click_count_annotated, 1)
         siae_without_tender = Siae.objects.with_tender_stats().filter(id=self.siae_without_tender.id).first()
         self.assertEqual(siae_without_tender.tenders.count(), 0)
-        self.assertEqual(siae_without_tender.tender_count, 0)
-        self.assertEqual(siae_without_tender.tender_email_send_count, 0)
-        self.assertEqual(siae_without_tender.tender_detail_display_count, 0)
-        self.assertEqual(siae_without_tender.tender_detail_contact_click_count, 0)
+        self.assertEqual(siae_without_tender.tender_count_annotated, 0)
+        self.assertEqual(siae_without_tender.tender_email_send_count_annotated, 0)
+        self.assertEqual(siae_without_tender.tender_detail_display_count_annotated, 0)
+        self.assertEqual(siae_without_tender.tender_detail_contact_click_count_annotated, 0)
 
     def test_with_question_stats(self):
         self.assertEqual(TenderQuestion.objects.count(), 2)
         tender_with_siae_1 = Tender.objects.with_question_stats().filter(id=self.tender_with_siae_1.id).first()
         self.assertEqual(tender_with_siae_1.questions.count(), 2)
-        self.assertEqual(tender_with_siae_1.question_count, 2)
+        self.assertEqual(tender_with_siae_1.question_count_annotated, 2)
 
     def test_with_deadline_date_is_outdated(self):
         TenderFactory(deadline_date=date_last_week)
@@ -370,19 +371,29 @@ class TenderModelQuerysetStatsTest(TestCase):
         self.assertEqual(tender_with_siae_1.id, self.tender_with_siae_1.id)
         self.assertFalse(tender_with_siae_1.deadline_date_is_outdated_annotated)
 
+    def test_with_network_siae_stats(self):
+        network_with_siaes = NetworkFactory(siaes=[self.siae_with_tender_1, self.siae_without_tender])
+        tender_with_siae_2 = (
+            Tender.objects.with_network_siae_stats(network_with_siaes.siaes.all())
+            .filter(id=self.tender_with_siae_2.id)
+            .first()
+        )
+        self.assertEqual(tender_with_siae_2.network_siae_email_send_count_annotated, 1)
+        self.assertEqual(tender_with_siae_2.network_siae_detail_contact_click_count_annotated, 1)
+
     # doesn't work when chaining these 2 querysets: adds duplicates...
     # def test_chain_querysets(self):
     #     tender_with_siae_1 = (
     #         Tender.objects.with_question_stats().with_siae_stats().filter(id=self.tender_with_siae_1.id).first()
     #     )
     #     self.assertEqual(tender_with_siae_1.siaes.count(), 6)
-    #     self.assertEqual(tender_with_siae_1.siae_count, 6)
-    #     self.assertEqual(tender_with_siae_1.siae_email_send_count, 4)
-    #     self.assertEqual(tender_with_siae_1.siae_email_link_click_count, 3)
-    #     self.assertEqual(tender_with_siae_1.siae_detail_display_count, 2)
-    #     self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count, 2)
-    #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count, 1)
-    #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count, 1)
+    #     self.assertEqual(tender_with_siae_1.siae_count_annotated, 6)
+    #     self.assertEqual(tender_with_siae_1.siae_email_send_count_annotated, 4)
+    #     self.assertEqual(tender_with_siae_1.siae_email_link_click_count_annotated, 3)
+    #     self.assertEqual(tender_with_siae_1.siae_detail_display_count_annotated, 2)
+    #     self.assertEqual(tender_with_siae_1.siae_email_link_click_or_detail_display_count_annotated, 2)
+    #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_count_annotated, 1)
+    #     self.assertEqual(tender_with_siae_1.siae_detail_contact_click_since_last_seen_date_count_annotated, 1)
 
 
 class TenderMigrationToSelectTest(TestCase):
@@ -652,9 +663,9 @@ class TenderAdminTest(TestCase):
         )
         tender_response = response.context_data["adminform"].form.instance
         self.assertEqual(tender_response.id, self.tender.id)
-        self.assertEqual(hasattr(tender_response, "siae_count"), True)
-        self.assertEqual(tender_response.siae_count, 2)
-        self.assertEqual(tender_response.siae_count, self.tender.tendersiae_set.count())
+        self.assertEqual(hasattr(tender_response, "siae_count_annotated"), True)
+        self.assertEqual(tender_response.siae_count_annotated, 2)
+        self.assertEqual(tender_response.siae_count_annotated, self.tender.tendersiae_set.count())
         # update sectors to have only one match for siaes
         response = self.client.post(
             tender_update_post_url,
@@ -666,7 +677,7 @@ class TenderAdminTest(TestCase):
             follow=True,
         )
         tender_response = response.context_data["adminform"].form.instance
-        self.assertEqual(tender_response.siae_count, 1)
+        self.assertEqual(tender_response.siae_count_annotated, 1)
         tender_siae_matched = tender_response.tendersiae_set.first()  # only one siae
         # update for another sectors and check if siaes are not the same
         response = self.client.post(
@@ -678,6 +689,6 @@ class TenderAdminTest(TestCase):
             follow=True,
         )
         tender_response = response.context_data["adminform"].form.instance
-        self.assertEqual(tender_response.siae_count, 1)
+        self.assertEqual(tender_response.siae_count_annotated, 1)
         tender_siae_matched_2 = tender_response.tendersiae_set.first()  # only one siae
         self.assertNotEqual(tender_siae_matched.pk, tender_siae_matched_2.pk)

--- a/lemarche/users/admin.py
+++ b/lemarche/users/admin.py
@@ -159,8 +159,8 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         "last_name",
         "kind",
         "company_name",
-        "siae_count_with_link",
-        "tender_count_with_link",
+        "siae_count_annotated_with_link",
+        "tender_count_annotated_with_link",
         "last_login",
         "created_at",
     ]
@@ -188,8 +188,8 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
         + [f"{field}_last_updated" for field in User.TRACK_UPDATE_FIELDS]
         + [field.name for field in User._meta.fields if field.name.endswith("_last_seen_date")]
         + [
-            "siae_count_with_link",
-            "tender_count_with_link",
+            "siae_count_annotated_with_link",
+            "tender_count_annotated_with_link",
             "favorite_list_count_with_link",
             "last_login",
             "image_url",
@@ -234,7 +234,7 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
             "Dépôt de besoin",
             {
                 "fields": (
-                    "tender_count_with_link",
+                    "tender_count_annotated_with_link",
                     "can_display_tender_contact_details",
                 ),
             },
@@ -330,19 +330,19 @@ class UserAdmin(FieldsetsInlineMixin, UserAdmin):
                     form.instance.author = request.user
         super().save_formset(request, form, formset, change)
 
-    def siae_count_with_link(self, user):
+    def siae_count_annotated_with_link(self, user):
         url = reverse("admin:siaes_siae_changelist") + f"?users__in={user.id}"
-        return format_html(f'<a href="{url}">{getattr(user, "siae_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(user, "siae_count_annotated", 0)}</a>')
 
-    siae_count_with_link.short_description = "Nombre de structures"
-    siae_count_with_link.admin_order_field = "siae_count"
+    siae_count_annotated_with_link.short_description = "Nombre de structures"
+    siae_count_annotated_with_link.admin_order_field = "siae_count_annotated"
 
-    def tender_count_with_link(self, user):
+    def tender_count_annotated_with_link(self, user):
         url = reverse("admin:tenders_tender_changelist") + f"?author__id__exact={user.id}"
-        return format_html(f'<a href="{url}">{getattr(user, "tender_count", 0)}</a>')
+        return format_html(f'<a href="{url}">{getattr(user, "tender_count_annotated", 0)}</a>')
 
-    tender_count_with_link.short_description = "Nombre de besoins déposés"
-    tender_count_with_link.admin_order_field = "tender_count"
+    tender_count_annotated_with_link.short_description = "Nombre de besoins déposés"
+    tender_count_annotated_with_link.admin_order_field = "tender_count_annotated"
 
     def favorite_list_count_with_link(self, user):
         url = reverse("admin:favorites_favoritelist_changelist") + f"?users__in={user.id}"

--- a/lemarche/users/models.py
+++ b/lemarche/users/models.py
@@ -39,10 +39,10 @@ class UserQueryset(models.QuerySet):
         return self.filter(api_key__isnull=False)
 
     def with_siae_stats(self):
-        return self.prefetch_related("siaes").annotate(siae_count=Count("siaes", distinct=True))
+        return self.prefetch_related("siaes").annotate(siae_count_annotated=Count("siaes", distinct=True))
 
     def with_tender_stats(self):
-        return self.prefetch_related("tenders").annotate(tender_count=Count("tenders", distinct=True))
+        return self.prefetch_related("tenders").annotate(tender_count_annotated=Count("tenders", distinct=True))
 
 
 class UserManager(BaseUserManager):

--- a/lemarche/users/tests.py
+++ b/lemarche/users/tests.py
@@ -49,50 +49,52 @@ class UserModelQuerysetTest(TestCase):
     def setUpTestData(cls):
         cls.user = UserFactory()
 
-    def test_has_siae_queryset(self):
+    def test_has_siae(self):
         user_2 = UserFactory()
         siae = SiaeFactory()
         siae.users.add(user_2)
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_siae().count(), 1)
 
-    def test_has_tender_queryset(self):
+    def test_has_tender(self):
         user_2 = UserFactory()
         TenderFactory(author=user_2)
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_tender().count(), 1)
 
-    def test_has_favorite_list_queryset(self):
+    def test_has_favorite_list(self):
         user_2 = UserFactory()
         FavoriteListFactory(user=user_2)
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_favorite_list().count(), 1)
 
-    def test_has_api_key_queryset(self):
+    def test_has_api_key(self):
         UserFactory(api_key="coucou")
         self.assertEqual(User.objects.count(), 1 + 1)
         self.assertEqual(User.objects.has_api_key().count(), 1)
 
-    def test_with_siae_stats_queryset(self):
+    def test_with_siae_stats(self):
         user_2 = UserFactory()
         siae = SiaeFactory()
         siae.users.add(user_2)
         self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.with_siae_stats().filter(id=self.user.id).first().siae_count, 0)
-        self.assertEqual(User.objects.with_siae_stats().filter(id=user_2.id).first().siae_count, 1)
+        self.assertEqual(User.objects.with_siae_stats().filter(id=self.user.id).first().siae_count_annotated, 0)
+        self.assertEqual(User.objects.with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1)
 
-    def test_with_tender_stats_queryset(self):
+    def test_with_tender_stats(self):
         user_2 = UserFactory()
         TenderFactory(author=user_2)
         self.assertEqual(User.objects.count(), 1 + 1)
-        self.assertEqual(User.objects.with_tender_stats().filter(id=self.user.id).first().tender_count, 0)
-        self.assertEqual(User.objects.with_tender_stats().filter(id=user_2.id).first().tender_count, 1)
+        self.assertEqual(User.objects.with_tender_stats().filter(id=self.user.id).first().tender_count_annotated, 0)
+        self.assertEqual(User.objects.with_tender_stats().filter(id=user_2.id).first().tender_count_annotated, 1)
 
     def test_chain_querysets(self):
         user_2 = UserFactory(api_key="chain")
         siae = SiaeFactory()
         siae.users.add(user_2)
-        self.assertEqual(User.objects.has_api_key().with_siae_stats().filter(id=user_2.id).first().siae_count, 1)
+        self.assertEqual(
+            User.objects.has_api_key().with_siae_stats().filter(id=user_2.id).first().siae_count_annotated, 1
+        )
 
 
 class UserModelSaveTest(TestCase):

--- a/lemarche/www/dashboard_networks/tests.py
+++ b/lemarche/www/dashboard_networks/tests.py
@@ -23,8 +23,8 @@ class DashboardNetworkViewTest(TestCase):
             # "dashboard_networks:tender_detail"
             # "dashboard_networks:siae_tender_list"
         ]
-        cls.network_1 = NetworkFactory(name="Liste 1")
-        cls.network_2 = NetworkFactory(name="Liste 2")
+        cls.network_1 = NetworkFactory(name="Reseau 1")
+        cls.network_2 = NetworkFactory(name="Reseau 2")
         cls.user_network_1 = UserFactory(kind=User.KIND_PARTNER, partner_network=cls.network_1)
         cls.user_network_2 = UserFactory(kind=User.KIND_PARTNER, partner_network=cls.network_2)
         cls.user_buyer = UserFactory(kind=User.KIND_BUYER, company_name="Entreprise Buyer")

--- a/lemarche/www/dashboard_networks/views.py
+++ b/lemarche/www/dashboard_networks/views.py
@@ -26,7 +26,7 @@ class DashboardNetworkSiaeListView(NetworkMemberRequiredMixin, FormMixin, ListVi
         qs = super().get_queryset()
         # first get the network's siaes
         self.network = Network.objects.get(slug=self.kwargs.get("slug"))
-        qs = qs.filter(networks__in=[self.network]).with_tender_stats().annotate_with_brand_or_name(with_order_by=True)
+        qs = qs.filter(networks__in=[self.network]).with_tender_stats().with_brand_or_name(with_order_by=True)
         # then filter with the form
         self.filter_form = NetworkSiaeFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)

--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -143,9 +143,9 @@ class SiaeEditInfoView(SiaeMemberRequiredMixin, SuccessMessageMixin, UpdateView)
             context["label_formset"] = SiaeLabelOldFormSet(self.request.POST, instance=self.object)
         else:
             context["label_formset"] = SiaeLabelOldFormSet(instance=self.object)
-        context["last_3_siae_content_filled_full"] = (
+        context["last_3_siae_content_filled_full_annotated"] = (
             Siae.objects.with_content_filled_stats()
-            .filter(content_filled_full=True)
+            .filter(content_filled_full_annotated=True)
             .exclude(id=self.object.id)
             .order_by("-updated_at")[:3]
         )

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -276,10 +276,10 @@ class SiaeFilterForm(forms.Form):
             lower_limit, upper_limit = employees.split("-")
 
             # Check lower limitation, it always exists when employees filter is used
-            qs = qs.with_employees_count().filter(
-                (Q(employees_count__isnull=False) & Q(employees_count__gte=int(lower_limit)))
+            qs = qs.with_employees_stats().filter(
+                (Q(employees_count_annotated__isnull=False) & Q(employees_count_annotated__gte=int(lower_limit)))
                 | (
-                    Q(employees_count=None)
+                    Q(employees_count_annotated=None)
                     & Q(api_entreprise_employees__in=EMPLOYEES_API_ENTREPRISE_MAPPING[employees])
                 )
             )
@@ -287,9 +287,9 @@ class SiaeFilterForm(forms.Form):
             # Upper limitation
             if upper_limit:
                 qs = qs.filter(
-                    (Q(employees_count__isnull=False) & Q(employees_count__lte=int(upper_limit)))
+                    (Q(employees_count_annotated__isnull=False) & Q(employees_count_annotated__lte=int(upper_limit)))
                     | (
-                        Q(employees_count=None)
+                        Q(employees_count_annotated=None)
                         & Q(api_entreprise_employees__in=EMPLOYEES_API_ENTREPRISE_MAPPING[employees])
                     )
                 )

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -68,7 +68,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
         results = filter_form.filter_queryset()
         results_ordered = filter_form.order_queryset(results)
         if user.is_authenticated:
-            results_ordered = results_ordered.annotate_with_user_favorite_list_count(user)
+            results_ordered = results_ordered.with_in_user_favorite_list_stats(user)
         return results_ordered
 
     def get_mailto_share_url(self):
@@ -262,7 +262,7 @@ class SiaeDetailView(FormMixin, DetailView):
         """
         qs = super().get_queryset()
         if self.request.user.is_authenticated:
-            qs = qs.annotate_with_user_favorite_list_count(self.request.user)
+            qs = qs.with_in_user_favorite_list_stats(self.request.user)
         return qs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
### Quoi ?

Modifications apportées : 
- mis les `annotate` dans des queryset
- les renommé avec un suffix `_annotated` pour les distinguer des champs `_count` éventuels sur les modèles
- ajout des tests

### Pourquoi ?

Pour pouvoir plus facilement rajouter des champs `*_count` sans que cela rentre en conflit avec tous nos count annotated existants :) cc #939