### PR TITLE
Refactoring : remplacer datetime par timezone

### DIFF
--- a/lemarche/siaes/management/commands/sync_c1_c4.py
+++ b/lemarche/siaes/management/commands/sync_c1_c4.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import psycopg2
 import psycopg2.extras
@@ -360,8 +360,8 @@ class Command(BaseCommand):
         - all the ones who have is_active as False
         """
         if not dry_run:
-            date_yesterday = datetime.now() - timedelta(days=1)
-            Siae.objects.exclude(c1_sync_skip=True).filter(
-                c1_last_sync_date__lt=timezone.make_aware(date_yesterday)
-            ).update(is_delisted=True)
+            date_yesterday = timezone.now() - timedelta(days=1)
+            Siae.objects.exclude(c1_sync_skip=True).filter(c1_last_sync_date__lt=date_yesterday).update(
+                is_delisted=True
+            )
             Siae.objects.filter(is_active=False).update(is_delisted=True)

--- a/lemarche/siaes/management/commands/sync_c2_c4.py
+++ b/lemarche/siaes/management/commands/sync_c2_c4.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import psycopg2
 import psycopg2.extras
@@ -64,10 +64,10 @@ class Command(BaseCommand):
 
             # count after
             siae_etp_count_after = Siae.objects.filter(c2_etp_count__isnull=False).count()
-            date_yesterday = datetime.now() - timedelta(days=1)
+            date_yesterday = timezone.now() - timedelta(days=1)
             siae_etp_updated = (
                 Siae.objects.filter(c2_etp_count__isnull=False)
-                .filter(c2_etp_count_last_sync_date__gte=timezone.make_aware(date_yesterday))
+                .filter(c2_etp_count_last_sync_date__gte=date_yesterday)
                 .count()
             )
 

--- a/lemarche/stats/models.py
+++ b/lemarche/stats/models.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.db import models
+from django.utils import timezone
 
 from lemarche.siaes import constants as siae_constants
 from lemarche.utils import constants
@@ -17,7 +18,7 @@ class TrackerQuerySet(models.QuerySet):
         return self.env_prod().filter(
             action="load",
             page=f"/prestataires/{siae_slug}/",
-            date_created__gte=datetime.now() - timedelta(days=90),
+            date_created__gte=timezone.now() - timedelta(days=90),
         )
 
     def siae_buyer_views_last_3_months(self, siae_slug):

--- a/lemarche/tenders/admin.py
+++ b/lemarche/tenders/admin.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from ckeditor.widgets import CKEditorWidget
 from django import forms
 from django.contrib import admin
@@ -7,6 +5,7 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from django.db import models
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.html import format_html
 from django_admin_filters import MultiChoice
 from django_better_admin_arrayfield.admin.mixins import DynamicArrayMixin
@@ -109,7 +108,7 @@ def restart_send_tender_task(tender: Tender):
     # 1) log the tender send restart
     log_item = {
         "action": "restart_send",
-        "date": str(datetime.now()),
+        "date": timezone.now().isoformat(),
     }
     tender.logs.append(log_item)
     tender.save()

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -603,7 +603,7 @@ class Tender(models.Model):
         return self.validated_at and self.status == self.STATUS_VALIDATED
 
     def set_validated(self, with_save=True):
-        self.validated_at = datetime.now()
+        self.validated_at = timezone.now()
         self.status = tender_constants.STATUS_VALIDATED
         log_item = {
             "action": "validate",

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -607,7 +607,7 @@ class Tender(models.Model):
         self.status = tender_constants.STATUS_VALIDATED
         log_item = {
             "action": "validate",
-            "date": str(self.validated_at),
+            "date": self.validated_at.isoformat(),
         }
         self.logs.append(log_item)
         if with_save:


### PR DESCRIPTION
### Quoi ?

Il restait quelques endroits où l'on utilisait des dates sans TZ.

Cela provoque des warning dans nos logs
```
RuntimeWarning: DateTimeField Tracker.date_created received a naive datetime (2023-07-25 08:59:46.973584) while time zone support is active.
RuntimeWarning: DateTimeField Tender.validated_at received a naive datetime (2023-10-23 09:09:50.640033) while time zone support is active.
```