### PR TITLE
[Dépôt de besoin] Dans les e-mails aux prestataires, envoyer aussi le montant

### DIFF
--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -519,6 +519,17 @@ class Tender(models.Model):
             # maintain legacy perimeters display
             return self.perimeters_list_string
 
+    @cached_property
+    def amount_display(self) -> str:
+        if not self.accept_share_amount:
+            return "Non renseigné"
+        elif self.amount_exact:
+            return f"{self.amount_exact} €"
+        elif self.amount:
+            return self.get_amount_display()
+        else:
+            return "Non renseigné"
+
     def questions_list(self):
         return list(self.questions.values("id", "text"))
 
@@ -546,7 +557,7 @@ class Tender(models.Model):
         elif self.kind == tender_constants.KIND_QUOTE:
             return "Accéder aux coordonnées du client afin de lui envoyer un devis."
         elif self.kind == tender_constants.KIND_PROJECT and self.response_is_anonymous:
-            return "Manifestez votre intérêt au client. S’il est intéressé, le client vous recontactera via les coordonnées présentes sur votre fiche commerciale."  # noqa
+            return "Manifestez votre intérêt au client. S'il est intéressé, le client vous recontactera via les coordonnées présentes sur votre fiche commerciale."  # noqa
         elif self.kind == tender_constants.KIND_PROJECT:
             return "Accéder aux coordonnées du client afin de lui présenter vos services et produits."
         # just in case

--- a/lemarche/tenders/tests.py
+++ b/lemarche/tenders/tests.py
@@ -114,6 +114,22 @@ class TenderModelPropertyTest(TestCase):
         self.assertTrue(tender_validated_half.is_validated, False)
         self.assertTrue(tender_validated_full.is_validated, True)
 
+    def test_amount_display(self):
+        tender_with_amount = TenderFactory(amount=tender_constants.AMOUNT_RANGE_0_1, accept_share_amount=True)
+        tender_with_amount_2 = TenderFactory(amount=tender_constants.AMOUNT_RANGE_10_15, accept_share_amount=True)
+        tender_with_amount_exact = TenderFactory(
+            amount=tender_constants.AMOUNT_RANGE_10_15, amount_exact=10000, accept_share_amount=True
+        )
+        tender_dont_share_amount = TenderFactory(
+            amount=tender_constants.AMOUNT_RANGE_10_15, amount_exact=10000, accept_share_amount=False
+        )
+        tender_no_amount = TenderFactory(amount=None, amount_exact=None, accept_share_amount=True)
+        self.assertEqual(tender_with_amount.amount_display, "0-1000 €")
+        self.assertEqual(tender_with_amount_2.amount_display, "10-15 K€")
+        self.assertEqual(tender_with_amount_exact.amount_display, "10000 €")
+        self.assertEqual(tender_dont_share_amount.amount_display, "Non renseigné")
+        self.assertEqual(tender_no_amount.amount_display, "Non renseigné")
+
 
 class TenderModelSaveTest(TestCase):
     def test_set_slug(self):

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -136,6 +136,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_AMOUNT": tender.amount,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tender)}?siae_id={siae.id}",
         }
@@ -213,6 +214,7 @@ def send_tender_contacted_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
+            "TENDER_AMOUNT": tendersiae.tender.amount,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
         }
@@ -286,6 +288,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
+            "TENDER_AMOUNT": tendersiae.tender.amount,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
         }
@@ -329,6 +332,7 @@ def send_confirmation_published_email_to_author(tender: Tender, nb_matched_siaes
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
+            "TENDER_AMOUNT": tender.amount,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_NB_MATCH": nb_matched_siaes,
             "TENDER_URL": get_share_url_object(tender),

--- a/lemarche/www/tenders/tasks.py
+++ b/lemarche/www/tenders/tasks.py
@@ -136,7 +136,7 @@ def send_tender_email_to_siae(tender: Tender, siae: Siae, email_subject: str, em
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
-            "TENDER_AMOUNT": tender.amount,
+            "TENDER_AMOUNT": tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tender)}?siae_id={siae.id}",
         }
@@ -214,7 +214,7 @@ def send_tender_contacted_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
-            "TENDER_AMOUNT": tendersiae.tender.amount,
+            "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-contactees",  # noqa
         }
@@ -288,7 +288,7 @@ def send_tender_interested_reminder_email_to_siae(
             "TENDER_KIND": tendersiae.tender.get_kind_display(),
             "TENDER_SECTORS": tendersiae.tender.sectors_list_string(),
             "TENDER_PERIMETERS": tendersiae.tender.location_display,
-            "TENDER_AMOUNT": tendersiae.tender.amount,
+            "TENDER_AMOUNT": tendersiae.tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tendersiae.tender.deadline_date),
             "TENDER_URL": f"{get_share_url_object(tendersiae.tender)}?siae_id={tendersiae.siae.id}&mtm_campaign=relance-esi-interessees",  # noqa
         }
@@ -332,7 +332,7 @@ def send_confirmation_published_email_to_author(tender: Tender, nb_matched_siaes
             "TENDER_KIND": tender.get_kind_display(),
             "TENDER_SECTORS": tender.sectors_list_string(),
             "TENDER_PERIMETERS": tender.location_display,
-            "TENDER_AMOUNT": tender.amount,
+            "TENDER_AMOUNT": tender.amount_display,
             "TENDER_DEADLINE_DATE": date_to_string(tender.deadline_date),
             "TENDER_NB_MATCH": nb_matched_siaes,
             "TENDER_URL": get_share_url_object(tender),


### PR DESCRIPTION
### Quoi ?

Dans certains mails transactionnels, indiquer le montant du besoin : 
- nouvelle property `amount_display` + ajout de tests
- passer cette info via la variable `TENDER_AMOUNT`

### Reste à faire

Modifier les templates d'e-mails correspondants pour faire apparaître le montant