### PR TITLE
Suppression du message de log sur l'enregistrement du traqueur

### DIFF
--- a/lemarche/utils/tracker.py
+++ b/lemarche/utils/tracker.py
@@ -83,7 +83,6 @@ def track(page: str = "", action: str = "load", meta: dict = {}):  # noqa B006
 
         try:
             Tracker.objects.create(**payload)
-            logger.info("Tracker saved")
         except Exception as e:
             logger.exception(e)
             logger.warning("Failed to save tracker")


### PR DESCRIPTION
### Quoi ?

Suppression du message de log

### Pourquoi ?

Le message sans intérêt pollue les logs 
