### PR TITLE
[Structures] Rattachement : répare le lien vers les contact à la fin du workflow

### DIFF
--- a/lemarche/www/dashboard_siaes/views.py
+++ b/lemarche/www/dashboard_siaes/views.py
@@ -88,7 +88,7 @@ class SiaeSearchAdoptConfirmView(SiaeUserAndNotMemberRequiredMixin, SuccessMessa
             send_siae_user_request_email_to_assignee(siae_user_request)
             success_message = (
                 f"La demande a été envoyée à {self.object.users.first().full_name}.<br />"
-                f"<i>Cet utilisateur ne fait plus partie de la structure ? <a href=\"{reverse_lazy('dashboard_siaes:siae_search_by_siret')}?siret={self.object.siret}\">Contactez le support</a></i>"  # noqa
+                f"<i>Cet utilisateur ne fait plus partie de la structure ? <a href=\"{reverse_lazy('pages:contact')}?siret={self.object.siret}\">Contactez le support</a></i>"  # noqa
             )
             messages.add_message(self.request, messages.SUCCESS, success_message)
             return HttpResponseRedirect(reverse_lazy("dashboard:home"))


### PR DESCRIPTION
### Quoi ?

A la fin d'un rattachement, on propose à l'utilisateur de contacter le support si il y a un soucis.
Mais ce n'était pas le bon lien..