### PR TITLE
[Dépôt de besoin] Renvoyer une erreur 404 si le besoin n'est pas trouvé

### DIFF
--- a/lemarche/utils/mixins.py
+++ b/lemarche/utils/mixins.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.views import redirect_to_login
 from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from sesame.utils import get_user as sesame_get_user
 
@@ -161,7 +162,7 @@ class TenderAuthorOrAdminRequiredIfNotValidatedMixin(UserPassesTestMixin):
     def test_func(self):
         # user = self.request.user
         tender_slug = self.kwargs.get("slug")
-        tender = Tender.objects.get(slug=tender_slug)
+        tender = get_object_or_404(Tender.objects.all(), slug=tender_slug)
         if tender.status != tender_constants.STATUS_VALIDATED:
             return TenderAuthorOrAdminRequiredMixin.test_func(self)
         return True

--- a/lemarche/www/tenders/tests.py
+++ b/lemarche/www/tenders/tests.py
@@ -540,6 +540,11 @@ class TenderDetailViewTest(TestCase):
                 self.assertEqual(response.status_code, 302)
                 self.assertEqual(response.url, "/")
 
+    def test_tender_unknown_should_return_404(self):
+        url = reverse("tenders:detail", kwargs={"slug": f"{self.tender_1.slug}-bug"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
     def test_tender_basic_fields_display(self):
         url = reverse("tenders:detail", kwargs={"slug": self.tender_1.slug})
         response = self.client.get(url)


### PR DESCRIPTION
### Quoi ?

Si l'url du besoin n'est pas trouvé, on renvoie actuellement une erreur... 500 :warning: 
J'ai corrigé pour renvoyer une erreur 404.