### PR TITLE
feat: Ajout de la page FAQ dans le footer

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -933,6 +933,7 @@ CGU_API = env.str("CGU_API", "/cgu-api/")
 LEGAL_INFO = env.str("LEGAL_INFO", "/mentions-legales/")
 PRIVACY_POLICY = env.str("PRIVACY_POLICY", "/confidentialite/")
 RESSOURCES = env.str("RESSOURCES", "/ressources/")
+FAQ = env.str("FAQ", "/la-faq-dune-consultation/")
 
 # Increase throttling to avoid Bad request errors when saving large pages
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-number-fields

--- a/lemarche/templates/layouts/_footer.html
+++ b/lemarche/templates/layouts/_footer.html
@@ -27,6 +27,7 @@
                         <li><a class="fr-footer__top-link" href="{{ ABOUT }}">Qui sommes-nous&nbsp;?</a></li>
                         <li><a class="fr-footer__top-link" href="{% url 'pages:decouvrir_inclusion' %}">C'est quoi l'inclusion&nbsp;?</a></li>
                         <li><a class="fr-footer__top-link" href="{{ RESSOURCES }}">Nos ressources</a></li>
+                        <li><a class="fr-footer__top-link" href="{{ FAQ }}">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">

--- a/lemarche/utils/settings_context_processors.py
+++ b/lemarche/utils/settings_context_processors.py
@@ -34,6 +34,7 @@ def expose_settings(request):
         "LEGAL_INFO": settings.LEGAL_INFO,
         "PRIVACY_POLICY": settings.PRIVACY_POLICY,
         "RESSOURCES": settings.RESSOURCES,
+        "FAQ": settings.FAQ,
         "DASHBOARD_TITLE": settings.DASHBOARD_TITLE,
         "DASHBOARD_NETWORK_DETAIL_TITLE": settings.DASHBOARD_NETWORK_DETAIL_TITLE,
         "DASHBOARD_NETWORK_SIAE_LIST_TITLE": settings.DASHBOARD_NETWORK_SIAE_LIST_TITLE,


### PR DESCRIPTION
### Quoi ?

Ajout de la page FAQ dans le footer

### Captures d'écran (optionnel)

Avant
<img width="1234" alt="Capture d’écran 2025-01-21 à 10 22 19" src="https://github.com/user-attachments/assets/5c6b501d-4087-4e06-baab-dcb2ad7533b2" />

Après
![Capture d’écran du 2025-02-04 17-41-09](https://github.com/user-attachments/assets/eb4d9c10-66d2-4226-9cf9-205960d959c2)
