### PR TITLE
fix(cms):  Correction de l'erreur dans l'admin Wagtail au niveau des fragments

### DIFF
--- a/lemarche/cms/__init__.py
+++ b/lemarche/cms/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "lemarche.cms.apps.CmsConfig"

--- a/lemarche/cms/apps.py
+++ b/lemarche/cms/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class CmsConfig(AppConfig):
+    name = "lemarche.cms"
+
+    def ready(self):
+        import lemarche.cms.snippets  # noqa


### PR DESCRIPTION
### Quoi ?

Chargement des snippets dans Wagtail. 

### Pourquoi ?

Dans l'admin Wagtail, il n'était plus possible d'accéder aux fragments à cause de l'erreur : 

NoReverseMatch at /cms/snippets/

'wagtailsnippets_cms_paragraph' is not a registered namespace 


### Comment ?

Parfois, Wagtail ne détecte pas les snippets si le module n’est pas importé lors du chargement de l’app.