### PR TITLE
chore(wagtail): Mise en silence des warnings wagtails

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -48,6 +48,9 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", False)
 
+# Silence annoying warnings
+SILENCED_SYSTEM_CHECKS = ["wagtailadmin.W002"]
+
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=["http://localhost:8000", "http://127.0.0.1:8000"])
 


### PR DESCRIPTION
### Quoi ?

Au moment des checks de Django, des dizaines de warnings sont affichés à cause de la dépendance https://github.com/jazzband/wagtailmenus. 
Dans issue, les développeurs indiquent qu'ils ne compte rien faire par rapport à ces warnings.
Même s'il n'est pas idéal de les mettre sous silence, c'est circonscrit à seulement une sous partie de wagtail admin, les risque de passer à coté d'une information importante sont a priori moins grands que lorsque l'on est noyés de dizaines de warnings à chaque démarrage de Django, et que l'on finit par ne plus y faire attention.