### PR TITLE
fix(Admin): Correction sur l'ajout d'une structure

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -411,7 +411,6 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.GISModelAdmin, SimpleHistoryAdmi
             {
                 "fields": (
                     "description",
-                    "sector",
                     "networks",
                 )
             },


### PR DESCRIPTION
### Quoi ?

Correction sur l'ajout d'une structure dans l'admin

### Pourquoi ?

Produit une erreur 500 car le champs secteur n'est plus au niveau de Siae.

### Comment ?

Suppression du champs du formulaire.