### PR TITLE
chore: Mise à jour du gestion de consentement et désactivation de Crisp et Matomo selon les variables d'environnement

### DIFF
--- a/lemarche/templates/includes/_tracker_tarteaucitron.html
+++ b/lemarche/templates/includes/_tracker_tarteaucitron.html
@@ -1,5 +1,7 @@
 <script type="text/javascript"
-        src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.11.0/tarteaucitron.min.js"></script>
+        src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.26.0/tarteaucitron.min.js"
+        integrity="sha384-7jFwdx+LzATjPAX6eCSpQy9IFevP6qNjbYPGhZWHVvWgAF/n8Qao4WJuUGDwbnE2"
+        crossorigin="anonymous"></script>
 <script type="text/javascript">
 // Tarteaucitron's language is set according to the browser configuration
 // but a lot of users don't know how to change it.
@@ -40,12 +42,10 @@ tarteaucitron.init({
 tarteaucitron.user.googletagmanagerId = "{{ GOOGLE_TAG_MANAGER_ID }}";
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');
 
-// Crisp (voir plus bas)
-tarteaucitron.user.cripsWebsiteId = "{{ CRISP_ID }}";
-tarteaucitron.user.cripsMore = function () {
-    // Ajouter ici les $crisp.push()
-};
-(tarteaucitron.job = tarteaucitron.job || []).push('crips');
+{% if CRISP_ID %}
+    tarteaucitron.user.crispID = "{{ CRISP_ID }}";
+    (tarteaucitron.job = tarteaucitron.job || []).push('crisp');    
+{% endif %}
 
 {% if MATOMO_HOST %}
     // Matomo
@@ -70,50 +70,4 @@ tarteaucitron.user.cripsMore = function () {
         g.async=true; g.src='{{ MATOMO_HOST }}js/container_{{ MATOMO_TAG_MANAGER_CONTAINER_ID }}.js'; s.parentNode.insertBefore(g,s);
     {% endif %}
 {% endif %}
-
-</script>
-<!-- Ajouter manuellement Crisp à tarteaucitron : https://github.com/AmauriC/tarteaucitron.js/pull/281 -->
-<script type="text/javascript">
-tarteaucitron.services.crips = {
-"key": "crips",
-"type": "support",
-"name": "Crisp",
-"uri": "https://crisp.chat/fr/privacy/",
-"needConsent": true,
-"cookies": [],
-"js": function () {
-    "use strict";
-    if (tarteaucitron.user.cripsWebsiteId === undefined) {
-        return;
-    }
-    window.$crisp = [];
-
-    window.CRISP_WEBSITE_ID = tarteaucitron.user.cripsWebsiteId;
-
-    tarteaucitron.addScript('https://client.crisp.chat/l.js');
-
-    // waiting for crips to be ready to check first party cookies
-    var interval = setInterval(function () {
-        if (typeof $crisp === 'undefined') return
-
-        clearInterval(interval);
-
-        // looping throught cookies
-        var theCookies = document.cookie.split(';');
-        for (var i = 1 ; i <= theCookies.length; i++) {
-            var cookie = theCookies[i - 1].split('=');
-            var cookieName = cookie[0].trim();
-
-            // if cookie starts like a piwik one, register it
-            if (cookieName.indexOf('crisp-client') === 0) {
-                tarteaucitron.services.crips.cookies.push(cookieName);
-            }
-        }
-    }, 100)
-
-    if (typeof tarteaucitron.user.cripsMore === 'function') {
-        tarteaucitron.user.cripsMore();
-    }
-}
-};
 </script>


### PR DESCRIPTION
### Quoi ?

Désactivation de Matomo si la variable d'environnement `MATOMO_HOST` n'est pas définie.
Pareil pour Crisp avec le variable `CRISP_ID`.

### Pourquoi ?

Pour éviter les erreurs sur staging.

### Comment ?

Modification du javascript de bas de page.

### Autre

J'en ai profité pour mettre à jour Tarte au citron pour inclure nativement Crisp.
