### PR TITLE
feat: rendre les indicateurs du potentiel inclusif cliquables

### DIFF
--- a/lemarche/api/inclusive_potential/views.py
+++ b/lemarche/api/inclusive_potential/views.py
@@ -19,7 +19,9 @@ class InclusivePotentialView(APIView):
 
         data = {
             "sector_name": sector.name,
+            "sector_slug": sector.slug,
             "perimeter_name": perimeter.name if perimeter else None,
+            "perimeter_slug": perimeter.slug if perimeter else None,
             "perimeter_kind": perimeter.kind if perimeter else None,
             "potential_siaes": potential_data.potential_siaes,
             "insertion_siaes": potential_data.insertion_siaes,

--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -107,6 +107,7 @@
                                     <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">{% dsfr_form_field form.legal_form %}</div>
                                     <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">{% dsfr_form_field form.employees %}</div>
                                     <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">{% dsfr_form_field form.labels %}</div>
+                                    <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">{% dsfr_form_field form.super_badge %}</div>
                                 </div>
                             </div>
                             <div class="fr-grid-row fr-hidden-lg">

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -75,6 +75,7 @@ class SiaeFilterForm(forms.Form):
         "legal_form",
         "employees",
         "labels",
+        "super_badge",
     ]
 
     sectors = GroupedModelMultipleChoiceField(
@@ -168,6 +169,12 @@ class SiaeFilterForm(forms.Form):
         widget=CustomSelectMultiple(),
     )
 
+    super_badge = forms.ChoiceField(
+        label="Super prestataire inclusif",
+        choices=[("", ""), ("True", "Oui")],
+        required=False,
+    )
+
     company_client_reference = forms.CharField(
         label="Indiquez le nom de votre entreprise",
         required=False,
@@ -189,6 +196,7 @@ class SiaeFilterForm(forms.Form):
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
+    local = forms.CharField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, advanced_search=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -334,6 +342,16 @@ class SiaeFilterForm(forms.Form):
         favorite_list = self.cleaned_data.get("favorite_list", None)
         if favorite_list:
             qs = qs.filter(favorite_lists__in=[favorite_list])
+
+        super_badge = self.cleaned_data.get("super_badge", None)
+        if super_badge in (True, "True"):
+            qs = qs.filter(super_badge=True)
+
+        local = self.cleaned_data.get("local", None)
+        if local in (True, "True", "true", "1"):
+            perimeters = self.cleaned_data.get("perimeters", None)
+            if perimeters:
+                qs = qs.with_is_local(perimeters[0]).filter(is_local=True)
 
         # avoid duplicates
         qs = qs.distinct()

--- a/lemarche/www/siaes/forms.py
+++ b/lemarche/www/siaes/forms.py
@@ -196,7 +196,7 @@ class SiaeFilterForm(forms.Form):
     favorite_list = forms.ModelChoiceField(
         queryset=FavoriteList.objects.all(), to_field_name="slug", required=False, widget=forms.HiddenInput()
     )
-    local = forms.CharField(required=False, widget=forms.HiddenInput())
+    local = forms.BooleanField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, advanced_search=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -343,14 +343,11 @@ class SiaeFilterForm(forms.Form):
         if favorite_list:
             qs = qs.filter(favorite_lists__in=[favorite_list])
 
-        super_badge = self.cleaned_data.get("super_badge", None)
-        if super_badge in (True, "True"):
+        if self.cleaned_data.get("super_badge", None):
             qs = qs.filter(super_badge=True)
 
-        local = self.cleaned_data.get("local", None)
-        if local in (True, "True", "true", "1"):
-            perimeters = self.cleaned_data.get("perimeters", None)
-            if perimeters:
+        if self.cleaned_data.get("local"):
+            if perimeters := self.cleaned_data.get("perimeters", None):
                 qs = qs.with_is_local(perimeters[0]).filter(is_local=True)
 
         # avoid duplicates


### PR DESCRIPTION
- API : ajout de sector_slug et perimeter_slug dans la réponse de /api/inclusive-potential/
- Moteur de recherche : ajout du filtre super_badge (visible) dans la recherche avancée
- Moteur de recherche : ajout du filtre local (masqué) pour filtrer les fournisseurs locaux

### Quoi ?

Permettre à l'utilisateur d'accéder à la liste des structures potentielles dans l'analyse du potentiel inclusif

@tonial 
