### PR TITLE
feat(dashboard): add size, legal form and region breakdowns to inclusive purchase stats

### DIFF
--- a/lemarche/purchases/models.py
+++ b/lemarche/purchases/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.models import Count, ExpressionWrapper, IntegerField, Q, Sum
+from django.db.models import Case, CharField, Count, ExpressionWrapper, F, IntegerField, Q, Sum, Value, When
 from django.db.models.functions import Coalesce, Round
 from django.utils import timezone
 from django.utils.text import slugify
@@ -127,6 +127,110 @@ class PurchaseQuerySet(models.QuerySet):
             )
 
         return self.aggregate(**aggregates)
+
+    def with_size_stats(self):
+        """
+        Purchase amounts and supplier counts grouped by size category.
+
+        TPE: total employees < 10
+        PME: total employees >= 10
+        Non renseigné: insertion count, c2_etp_count and permanent count all null
+
+        Effective insertion = employees_insertion_count ?? round(c2_etp_count)
+        Total employees = effective_insertion + permanent_count (nulls treated as 0)
+        """
+        SIZE_NON_RENSEIGNE = "Non renseigné"
+        SIZE_TPE = "TPE (< 10 salariés)"
+        SIZE_PME = "PME (≥ 10 salariés)"
+
+        qs = (
+            self.filter(siae__isnull=False)
+            .annotate(
+                _eff_insertion=Case(
+                    When(
+                        siae__employees_insertion_count__isnull=False,
+                        then=F("siae__employees_insertion_count"),
+                    ),
+                    When(
+                        siae__c2_etp_count__isnull=False,
+                        then=Round(F("siae__c2_etp_count")),
+                    ),
+                    default=Value(None, output_field=IntegerField()),
+                    output_field=IntegerField(),
+                )
+            )
+            .annotate(
+                _total_employees=Case(
+                    When(
+                        _eff_insertion__isnull=True,
+                        siae__employees_permanent_count__isnull=True,
+                        then=Value(None, output_field=IntegerField()),
+                    ),
+                    default=ExpressionWrapper(
+                        Coalesce(F("_eff_insertion"), Value(0))
+                        + Coalesce(F("siae__employees_permanent_count"), Value(0)),
+                        output_field=IntegerField(),
+                    ),
+                    output_field=IntegerField(),
+                )
+            )
+            .annotate(
+                size_category=Case(
+                    When(_total_employees__isnull=True, then=Value(SIZE_NON_RENSEIGNE)),
+                    When(_total_employees__lt=10, then=Value(SIZE_TPE)),
+                    default=Value(SIZE_PME),
+                    output_field=CharField(),
+                )
+            )
+        )
+
+        return (
+            qs.values("size_category")
+            .annotate(
+                total_amount=ExpressionWrapper(
+                    Coalesce(Round(Sum("purchase_amount"), 0), Value(0)),
+                    output_field=IntegerField(),
+                ),
+                supplier_count=Count("supplier_siret", distinct=True),
+            )
+            .order_by("size_category")
+        )
+
+    def with_legal_form_stats(self):
+        """
+        Purchase amounts and supplier counts grouped by siae legal form.
+        Results ordered by total amount descending.
+        """
+        return (
+            self.filter(siae__isnull=False)
+            .values("siae__legal_form")
+            .annotate(
+                total_amount=ExpressionWrapper(
+                    Coalesce(Round(Sum("purchase_amount"), 0), Value(0)),
+                    output_field=IntegerField(),
+                ),
+                supplier_count=Count("supplier_siret", distinct=True),
+            )
+            .order_by("-total_amount")
+        )
+
+    def with_region_stats(self):
+        """
+        Purchase amounts and supplier counts grouped by siae region.
+        Results ordered by total amount descending.
+        """
+        return (
+            self.filter(siae__isnull=False)
+            .values("siae__region")
+            .annotate(
+                total_amount=ExpressionWrapper(
+                    Coalesce(Round(Sum("purchase_amount"), 0), Value(0)),
+                    output_field=IntegerField(),
+                ),
+                supplier_count=Count("supplier_siret", distinct=True),
+            )
+            .order_by("-total_amount")
+        )
 
 
 class Purchase(models.Model):

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -143,6 +143,126 @@
                             </div>
                         </div>
                     </div>
+                    {# Bloc 2 — Taille de structure #}
+                    {% if chart_data_size %}
+                        <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+                            <div class="fr-col-12">
+                                <h2 class="fr-h3">Répartition par taille de structure</h2>
+                            </div>
+                            <div class="fr-col-12 fr-col-lg-6">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Montant d'achats inclusifs par taille</h3>
+                                            <div class="fr-card__desc">
+                                                <canvas id="sizeAmountChart" width="400" height="300"></canvas>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="fr-col-12 fr-col-lg-6">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Nombre de fournisseurs inclusifs par taille</h3>
+                                            <div class="fr-card__desc">
+                                                <canvas id="sizeSupplierChart" width="400" height="300"></canvas>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    {# Bloc 3 — Statut juridique #}
+                    {% if chart_data_legal_form.labels %}
+                        <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+                            <div class="fr-col-12">
+                                <h2 class="fr-h3">Répartition par statut juridique</h2>
+                            </div>
+                            <div class="fr-col-12 fr-col-lg-6">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Montant d'achats inclusifs par statut juridique</h3>
+                                            <div class="fr-card__desc">
+                                                <canvas id="legalFormAmountChart" width="400" height="300"></canvas>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="fr-col-12 fr-col-lg-6">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Nombre de fournisseurs inclusifs par statut juridique</h3>
+                                            <div class="fr-card__desc">
+                                                <canvas id="legalFormSupplierChart" width="400" height="300"></canvas>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    {# Bloc 4 — Cartographie régionale #}
+                    {% if chart_data_region.labels %}
+                        <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+                            <div class="fr-col-12">
+                                <h2 class="fr-h3">Répartition géographique par région</h2>
+                            </div>
+                            <div class="fr-col-12">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Montant d'achats inclusifs par région</h3>
+                                            <div class="fr-card__desc">
+                                                <canvas id="regionChart" width="400" height="400"></canvas>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="fr-col-12">
+                                <div class="fr-card">
+                                    <div class="fr-card__body">
+                                        <div class="fr-card__content">
+                                            <h3 class="fr-card__title">Détail par région</h3>
+                                            <div class="fr-card__desc">
+                                                <div class="fr-table fr-table--no-scroll" id="region-table">
+                                                    <table>
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Région</th>
+                                                                <th>Montant achats inclusifs</th>
+                                                                <th>Part du total</th>
+                                                                <th>Nb fournisseurs</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            {% for label, amount, pct, count in chart_data_region.rows %}
+                                                                <tr>
+                                                                    <td>{{ label }}</td>
+                                                                    <td>{{ amount|floatformat:0 }} €</td>
+                                                                    <td>{{ pct|floatformat:1 }} %</td>
+                                                                    <td>{{ count }}</td>
+                                                                </tr>
+                                                            {% endfor %}
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+
                     <div class="fr-grid-row fr-grid-row--gutters fr-mb-6w">
                         {% if chart_data_purchases_by_category.dataset %}
                             <div class="fr-col-12">
@@ -456,6 +576,142 @@
                    }
                }
             });
+
+            // --- Taille de structure ---
+            {% if chart_data_size %}
+            const sizeLabels = {{ chart_data_size.labels | safe }};
+            const sizeAmounts = {{ chart_data_size.amounts | safe }};
+            const sizeSupplierCounts = {{ chart_data_size.supplier_counts | safe }};
+            const sizeColors = ['#1a92ec', '#ff9f31', '#c8c9ce'];
+
+            if (sizeAmounts.some(v => v > 0)) {
+                new Chart(document.getElementById('sizeAmountChart'), {
+                    type: 'doughnut',
+                    data: {
+                        labels: sizeLabels,
+                        datasets: [{
+                            data: sizeAmounts,
+                            backgroundColor: sizeColors,
+                            borderColor: '#ffffff',
+                            borderWidth: 2
+                        }]
+                    },
+                    options: { ...commonOptions, cutout: '50%' },
+                    plugins: [ChartDataLabels]
+                });
+            }
+
+            if (sizeSupplierCounts.some(v => v > 0)) {
+                new Chart(document.getElementById('sizeSupplierChart'), {
+                    type: 'doughnut',
+                    data: {
+                        labels: sizeLabels,
+                        datasets: [{
+                            data: sizeSupplierCounts,
+                            backgroundColor: sizeColors,
+                            borderColor: '#ffffff',
+                            borderWidth: 2
+                        }]
+                    },
+                    options: {
+                        ...commonOptions,
+                        cutout: '50%',
+                        plugins: {
+                            ...commonOptions.plugins,
+                            tooltip: {
+                                callbacks: {
+                                    label: function(context) {
+                                        return ' ' + context.parsed + ' fournisseur(s)';
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    plugins: [ChartDataLabels]
+                });
+            }
+            {% endif %}
+
+            // --- Statut juridique ---
+            {% if chart_data_legal_form.labels %}
+            const legalFormLabels = {{ chart_data_legal_form.labels | safe }};
+            const legalFormAmounts = {{ chart_data_legal_form.amounts | safe }};
+            const legalFormSupplierCounts = {{ chart_data_legal_form.supplier_counts | safe }};
+            const barColors = ['#1a92ec','#ff3479','#00c5c2','#ff9f31','#b200fe','#ffd651','#c8c9ce','#a8e600','#0b1e3d','#f4b6c2','#6b4423'];
+
+            new Chart(document.getElementById('legalFormAmountChart'), {
+                type: 'bar',
+                data: {
+                    labels: legalFormLabels,
+                    datasets: [{
+                        data: legalFormAmounts,
+                        backgroundColor: barColors,
+                        borderColor: '#ffffff',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    plugins: { legend: { display: false } },
+                    scales: { x: { ticks: { callback: v => v.toLocaleString() + ' €' } } }
+                }
+            });
+
+            new Chart(document.getElementById('legalFormSupplierChart'), {
+                type: 'bar',
+                data: {
+                    labels: legalFormLabels,
+                    datasets: [{
+                        data: legalFormSupplierCounts,
+                        backgroundColor: barColors,
+                        borderColor: '#ffffff',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    plugins: { legend: { display: false } },
+                    scales: { x: { ticks: { stepSize: 1 } } }
+                }
+            });
+            {% endif %}
+
+            // --- Cartographie régionale ---
+            {% if chart_data_region.labels %}
+            const regionLabels = {{ chart_data_region.labels | safe }};
+            const regionAmounts = {{ chart_data_region.amounts | safe }};
+            const regionSupplierCounts = {{ chart_data_region.supplier_counts | safe }};
+
+            new Chart(document.getElementById('regionChart'), {
+                type: 'bar',
+                data: {
+                    labels: regionLabels,
+                    datasets: [{
+                        data: regionAmounts,
+                        backgroundColor: '#000091',
+                        borderColor: '#ffffff',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: function(context) {
+                                    const idx = context.dataIndex;
+                                    const amount = context.parsed.x.toLocaleString();
+                                    const nb = regionSupplierCounts[idx];
+                                    return [' ' + amount + ' €', ' ' + nb + ' fournisseur(s)'];
+                                }
+                            }
+                        }
+                    },
+                    scales: { x: { ticks: { callback: v => v.toLocaleString() + ' €' } } }
+                }
+            });
+            {% endif %}
 
         });
         </script>

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -9,7 +9,7 @@ from django_filters.views import FilterView
 from content_manager.models import ContentPage, Tag
 from lemarche.cms.models import ArticleList
 from lemarche.purchases.models import Purchase
-from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
+from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST, LEGAL_FORM_CHOICES
 from lemarche.siaes.models import Siae
 from lemarche.tenders.models import Tender
 from lemarche.users.models import User
@@ -189,6 +189,53 @@ class InclusivePurchaseStatsDashboardView(LoginRequiredMixin, FilterView):
                 "dataset": [purchases_stats[key] for key in qpv_zrr_keys if purchases_stats[key] > 0],
             }
 
+            # --- Taille de structure ---
+            SIZE_ORDER = ["TPE (< 10 salariés)", "PME (≥ 10 salariés)", "Non renseigné"]
+            size_rows = {row["size_category"]: row for row in self.filterset.qs.with_size_stats()}
+            chart_data_size = {
+                "labels": SIZE_ORDER,
+                "amounts": [size_rows.get(cat, {}).get("total_amount", 0) for cat in SIZE_ORDER],
+                "supplier_counts": [size_rows.get(cat, {}).get("supplier_count", 0) for cat in SIZE_ORDER],
+            }
+
+            # --- Statut juridique ---
+            legal_form_label_map = dict(LEGAL_FORM_CHOICES)
+            legal_form_rows = list(self.filterset.qs.with_legal_form_stats())
+            TOP_N = 10
+            top_rows = legal_form_rows[:TOP_N]
+            other_rows = legal_form_rows[TOP_N:]
+            lf_labels = [
+                legal_form_label_map.get(r["siae__legal_form"], r["siae__legal_form"] or "Non renseigné")
+                for r in top_rows
+            ]
+            lf_amounts = [r["total_amount"] for r in top_rows]
+            lf_supplier_counts = [r["supplier_count"] for r in top_rows]
+            if other_rows:
+                lf_labels.append("Autres")
+                lf_amounts.append(sum(r["total_amount"] for r in other_rows))
+                lf_supplier_counts.append(sum(r["supplier_count"] for r in other_rows))
+            chart_data_legal_form = {
+                "labels": lf_labels,
+                "amounts": lf_amounts,
+                "supplier_counts": lf_supplier_counts,
+            }
+
+            # --- Cartographie régionale ---
+            region_rows = list(self.filterset.qs.with_region_stats())
+            total_inclusive = purchases_stats["total_inclusive_amount_annotated"]
+            region_table_rows = []
+            for r in region_rows:
+                label = r["siae__region"] or "Non renseigné"
+                amount = r["total_amount"]
+                pct = round(amount * 100 / total_inclusive, 1) if total_inclusive else 0
+                region_table_rows.append((label, amount, pct, r["supplier_count"]))
+            chart_data_region = {
+                "labels": [row[0] for row in region_table_rows],
+                "amounts": [row[1] for row in region_table_rows],
+                "supplier_counts": [row[3] for row in region_table_rows],
+                "rows": region_table_rows,
+            }
+
             context.update(
                 {
                     "total_purchases": purchases_stats["total_amount_annotated"],
@@ -215,6 +262,9 @@ class InclusivePurchaseStatsDashboardView(LoginRequiredMixin, FilterView):
                     "chart_data_purchases_by_category": chart_data_purchases_by_category,
                     "chart_data_purchases_by_buying_entity": chart_data_purchases_by_buying_entity,
                     "chart_data_qpv_zrr": chart_data_qpv_zrr,
+                    "chart_data_size": chart_data_size,
+                    "chart_data_legal_form": chart_data_legal_form,
+                    "chart_data_region": chart_data_region,
                 }
             )
         return context

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -232,6 +232,143 @@ class InclusivePurchaseStatsDashboardViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["total_purchases"], 15000)
 
+    def test_size_stats_tpe_pme_and_non_renseigne(self):
+        """chart_data_size correctly splits TPE, PME and Non renseigné."""
+        self.client.force_login(self.user)
+        # TPE: 3 insertion + 2 permanent = 5 → < 10
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__employees_insertion_count=3,
+            siae__employees_permanent_count=2,
+            purchase_amount=10000,
+        )
+        # PME: 8 + 7 = 15 → >= 10
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__employees_insertion_count=8,
+            siae__employees_permanent_count=7,
+            purchase_amount=20000,
+        )
+        # Non renseigné: all null
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__employees_insertion_count=None,
+            siae__employees_permanent_count=None,
+            siae__c2_etp_count=None,
+            purchase_amount=5000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        chart = response.context["chart_data_size"]
+        tpe_idx = chart["labels"].index("TPE (< 10 salariés)")
+        pme_idx = chart["labels"].index("PME (≥ 10 salariés)")
+        nr_idx = chart["labels"].index("Non renseigné")
+        self.assertEqual(chart["amounts"][tpe_idx], 10000)
+        self.assertEqual(chart["amounts"][pme_idx], 20000)
+        self.assertEqual(chart["amounts"][nr_idx], 5000)
+        self.assertEqual(chart["supplier_counts"][tpe_idx], 1)
+        self.assertEqual(chart["supplier_counts"][pme_idx], 1)
+
+    def test_size_stats_uses_c2_etp_count_as_fallback(self):
+        """When employees_insertion_count is null, c2_etp_count is used for size classification."""
+        self.client.force_login(self.user)
+        # c2_etp_count=5.7 → round=6, permanent=2 → total=8 → TPE
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__employees_insertion_count=None,
+            siae__c2_etp_count=5.7,
+            siae__employees_permanent_count=2,
+            purchase_amount=12000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        chart = response.context["chart_data_size"]
+        tpe_idx = chart["labels"].index("TPE (< 10 salariés)")
+        self.assertEqual(chart["amounts"][tpe_idx], 12000)
+
+    def test_legal_form_stats_groups_by_legal_form(self):
+        """chart_data_legal_form returns labels and amounts grouped by legal form."""
+        self.client.force_login(self.user)
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__legal_form="ASSOCIATION",
+            purchase_amount=30000,
+        )
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__legal_form="SAS",
+            purchase_amount=15000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        chart = response.context["chart_data_legal_form"]
+        # Association has highest amount → should be first
+        self.assertIn("Association", chart["labels"])
+        self.assertIn("SAS (Société par actions simplifiée)", chart["labels"])
+        assoc_idx = chart["labels"].index("Association")
+        self.assertEqual(chart["amounts"][assoc_idx], 30000)
+
+    def test_legal_form_stats_blank_shows_non_renseigne(self):
+        """A siae with blank legal_form is shown as 'Non renseigné'."""
+        self.client.force_login(self.user)
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__legal_form="",
+            purchase_amount=8000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        chart = response.context["chart_data_legal_form"]
+        self.assertIn("Non renseigné", chart["labels"])
+
+    def test_region_stats_groups_by_region(self):
+        """chart_data_region returns labels and amounts grouped by region, descending."""
+        self.client.force_login(self.user)
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__region="Île-de-France",
+            purchase_amount=50000,
+        )
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__region="Bretagne",
+            purchase_amount=20000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        chart = response.context["chart_data_region"]
+        self.assertEqual(chart["labels"][0], "Île-de-France")
+        self.assertEqual(chart["amounts"][0], 50000)
+        self.assertIn("Bretagne", chart["labels"])
+
+    def test_region_stats_table_rows_include_percentage(self):
+        """chart_data_region.rows contains (label, amount, pct, supplier_count) tuples."""
+        self.client.force_login(self.user)
+        PurchaseFactory(
+            company=self.user.company,
+            siae__kind=KIND_INSERTION_LIST[0],
+            siae__region="Bretagne",
+            purchase_amount=40000,
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        rows = response.context["chart_data_region"]["rows"]
+        self.assertEqual(len(rows), 1)
+        label, amount, pct, count = rows[0]
+        self.assertEqual(label, "Bretagne")
+        self.assertEqual(amount, 40000)
+        self.assertEqual(pct, 100.0)
+        self.assertEqual(count, 1)
+
 
 class DisabledEmailEditViewTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
- Add with_size_stats(), with_legal_form_stats(), with_region_stats() to PurchaseQuerySet
- Size classification: TPE (< 10 employees) / PME (≥ 10), with c2_etp_count as fallback for employees_insertion_count; non-renseigné when all three fields are null
- Legal form: top 10 + "Autres" grouping, display labels from LEGAL_FORM_CHOICES
- Region: horizontal bar chart + detail table with percentage of inclusive total
- 7 new tests covering all three breakdowns

Description :

  Enrichit le tableau de bord "part des achats inclusifs" avec trois nouveaux axes d'analyse.

  ## Ce qui change

  - **Taille de structure** - répartition TPE (< 10 salariés) / PME (≥ 10) / Non renseigné,
    avec montant et nombre de fournisseurs par catégorie
  - **Statut juridique** - top 10 statuts les plus représentés + regroupement "Autres"
  - **Cartographie régionale** - graphique par région trié par montant décroissant
    + tableau détaillé (montant, part du total, nb fournisseurs)

  Les trois analyses respectent les filtres existants (type de structure, QPV/ZRR, etc.).

  ## Tests

  7 nouveaux tests ajoutés : `tests/www/dashboard/tests.py`