### PR TITLE
feat(dashboard): export CSV, Excel et PDF des achats inclusifs

### DIFF
--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -34,7 +34,7 @@
                         <span class="fr-icon-download-line" aria-hidden="true"></span> CSV
                     </a>
                     <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
-                       style="display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none;color:inherit;font-size:14px;">
+                       style="display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none;color:inherit;font-size:14px;border:none;">
                         <span class="fr-icon-download-line" aria-hidden="true"></span> Excel (.xls)
                     </a>
                 </div>

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -17,6 +17,25 @@
         </div>
         {% if user.kind == "BUYER" and user.company %}
             {% if unfiltered_qs_count > 0 %}
+                <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w no-print">
+                    <div class="fr-col-12 fr-col-md-auto">
+                        <button onclick="window.print()" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-pdf-line">
+                            Exporter en PDF
+                        </button>
+                    </div>
+                    <div class="fr-col-12 fr-col-md-auto">
+                        <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=csv&{{ request.GET.urlencode }}"
+                           class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line">
+                            Exporter en CSV
+                        </a>
+                    </div>
+                    <div class="fr-col-12 fr-col-md-auto">
+                        <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
+                           class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line">
+                            Exporter en Excel
+                        </a>
+                    </div>
+                </div>
                 <section class="fr-accordion fr-mb-2w">
                     <h3 class="fr-accordion__title">
                         <button type="button"
@@ -396,6 +415,20 @@
         {% endif %}
     </div>
 {% endblock content %}
+{% block extra_css %}
+    <style>
+        @media print {
+            .no-print,
+            .fr-accordion,
+            .fr-header,
+            .fr-footer,
+            .fr-breadcrumb,
+            nav { display: none !important; }
+            .fr-card { break-inside: avoid; }
+            canvas { max-height: 250px !important; }
+        }
+    </style>
+{% endblock extra_css %}
 {% block extra_js %}
     {% if chart_data_inclusive %}
         <script type="text/javascript"

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -10,43 +10,39 @@
 {% block content %}
     <div class="fr-container">
         <div class="fr-grid-row">
-            <div class="fr-col-12">
+            <div class="fr-col">
                 <h1>Ma part d'achat inclusif</h1>
                 <p class="fr-text--lead">Pilotez l'intégration des achats inclusifs dans votre politique achat.</p>
             </div>
+            {% if user.kind == "BUYER" and user.company %}
+            <div class="fr-col-auto no-print" style="position:relative;" id="export-menu">
+                <button id="export-btn"
+                        style="display:flex;align-items:center;gap:8px;padding:8px 16px;border:1px solid #000091;border-radius:4px;background:#fff;color:#000091;font-weight:600;cursor:pointer;font-size:14px;"
+                        onclick="toggleExportMenu()">
+                    <span class="fr-icon-download-line" aria-hidden="true"></span>
+                    Exporter
+                    <span id="export-chevron" style="font-size:10px;transition:transform .2s;">▼</span>
+                </button>
+                <div id="export-menu-list"
+                     style="display:none;position:absolute;right:0;top:calc(100% + 4px);background:#fff;border:1px solid #ddd;border-radius:4px;min-width:180px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:200;">
+                    <button onclick="window.print();closeExportMenu()"
+                            style="width:100%;text-align:left;background:none;border:none;border-bottom:1px solid #eee;padding:12px 16px;cursor:pointer;display:flex;align-items:center;gap:10px;font-size:14px;">
+                        <span class="fr-icon-file-pdf-line" aria-hidden="true"></span> PDF
+                    </button>
+                    <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=csv&{{ request.GET.urlencode }}"
+                       style="display:flex;align-items:center;gap:10px;padding:12px 16px;border-bottom:1px solid #eee;text-decoration:none;color:inherit;font-size:14px;">
+                        <span class="fr-icon-download-line" aria-hidden="true"></span> CSV
+                    </a>
+                    <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
+                       style="display:flex;align-items:center;gap:10px;padding:12px 16px;text-decoration:none;color:inherit;font-size:14px;">
+                        <span class="fr-icon-download-line" aria-hidden="true"></span> Excel (.xls)
+                    </a>
+                </div>
+            </div>
+            {% endif %}
         </div>
         {% if user.kind == "BUYER" and user.company %}
             {% if unfiltered_qs_count > 0 %}
-                <div class="fr-mb-2w no-print" id="export-dropdown-container">
-                    <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
-                            aria-expanded="false"
-                            aria-controls="export-dropdown"
-                            data-fr-js-collapse-button="true">
-                        Exporter
-                    </button>
-                    <div class="fr-collapse" id="export-dropdown">
-                        <ul style="list-style:none;padding:8px 0;margin:0;border:1px solid #ddd;border-radius:4px;background:#fff;min-width:200px;box-shadow:0 4px 12px rgba(0,0,0,.1);">
-                            <li>
-                                <button onclick="window.print()"
-                                        style="width:100%;text-align:left;background:none;border:none;padding:10px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;">
-                                    <span class="fr-icon-file-pdf-line" aria-hidden="true"></span> PDF
-                                </button>
-                            </li>
-                            <li>
-                                <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=csv&{{ request.GET.urlencode }}"
-                                   style="display:flex;align-items:center;gap:8px;padding:10px 16px;text-decoration:none;color:inherit;">
-                                    <span class="fr-icon-download-line" aria-hidden="true"></span> CSV
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
-                                   style="display:flex;align-items:center;gap:8px;padding:10px 16px;text-decoration:none;color:inherit;">
-                                    <span class="fr-icon-download-line" aria-hidden="true"></span> Excel (.xls)
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
                 <section class="fr-accordion fr-mb-2w">
                     <h3 class="fr-accordion__title">
                         <button type="button"
@@ -787,5 +783,30 @@
         });
         </script>
     {% endif %}
+    <script>
+    function toggleExportMenu() {
+        const list = document.getElementById('export-menu-list');
+        const chevron = document.getElementById('export-chevron');
+        const open = list.style.display === 'block';
+        list.style.display = open ? 'none' : 'block';
+        chevron.style.transform = open ? '' : 'rotate(180deg)';
+        if (!open) {
+            setTimeout(() => {
+                document.addEventListener('click', function handler(e) {
+                    if (!document.getElementById('export-menu').contains(e.target)) {
+                        closeExportMenu();
+                        document.removeEventListener('click', handler);
+                    }
+                });
+            }, 0);
+        }
+    }
+    function closeExportMenu() {
+        const list = document.getElementById('export-menu-list');
+        if (list) list.style.display = 'none';
+        const chevron = document.getElementById('export-chevron');
+        if (chevron) chevron.style.transform = '';
+    }
+    </script>
     <script type="text/javascript" src="{% static 'js/multiselect.js' %}"></script>
 {% endblock extra_js %}

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -17,23 +17,34 @@
         </div>
         {% if user.kind == "BUYER" and user.company %}
             {% if unfiltered_qs_count > 0 %}
-                <div class="fr-grid-row fr-grid-row--gutters fr-mb-2w no-print">
-                    <div class="fr-col-12 fr-col-md-auto">
-                        <button onclick="window.print()" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-pdf-line">
-                            Exporter en PDF
-                        </button>
-                    </div>
-                    <div class="fr-col-12 fr-col-md-auto">
-                        <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=csv&{{ request.GET.urlencode }}"
-                           class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line">
-                            Exporter en CSV
-                        </a>
-                    </div>
-                    <div class="fr-col-12 fr-col-md-auto">
-                        <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
-                           class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line">
-                            Exporter en Excel
-                        </a>
+                <div class="fr-mb-2w no-print" id="export-dropdown-container">
+                    <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
+                            aria-expanded="false"
+                            aria-controls="export-dropdown"
+                            data-fr-js-collapse-button="true">
+                        Exporter
+                    </button>
+                    <div class="fr-collapse" id="export-dropdown">
+                        <ul style="list-style:none;padding:8px 0;margin:0;border:1px solid #ddd;border-radius:4px;background:#fff;min-width:200px;box-shadow:0 4px 12px rgba(0,0,0,.1);">
+                            <li>
+                                <button onclick="window.print()"
+                                        style="width:100%;text-align:left;background:none;border:none;padding:10px 16px;cursor:pointer;display:flex;align-items:center;gap:8px;">
+                                    <span class="fr-icon-file-pdf-line" aria-hidden="true"></span> PDF
+                                </button>
+                            </li>
+                            <li>
+                                <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=csv&{{ request.GET.urlencode }}"
+                                   style="display:flex;align-items:center;gap:8px;padding:10px 16px;text-decoration:none;color:inherit;">
+                                    <span class="fr-icon-download-line" aria-hidden="true"></span> CSV
+                                </a>
+                            </li>
+                            <li>
+                                <a href="{% url 'dashboard:inclusive_purchase_export' %}?format=excel&{{ request.GET.urlencode }}"
+                                   style="display:flex;align-items:center;gap:8px;padding:10px 16px;text-decoration:none;color:inherit;">
+                                    <span class="fr-icon-download-line" aria-hidden="true"></span> Excel (.xls)
+                                </a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
                 <section class="fr-accordion fr-mb-2w">

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -15,7 +15,7 @@
                 <p class="fr-text--lead">Pilotez l'intégration des achats inclusifs dans votre politique achat.</p>
             </div>
             {% if user.kind == "BUYER" and user.company %}
-            <div class="fr-col-auto no-print" style="position:relative;" id="export-menu">
+            <div class="fr-col-auto no-print" style="position:relative;align-self:flex-start;" id="export-menu">
                 <button id="export-btn"
                         style="display:flex;align-items:center;gap:8px;padding:8px 16px;border:1px solid #000091;border-radius:4px;background:#fff;color:#000091;font-weight:600;cursor:pointer;font-size:14px;"
                         onclick="toggleExportMenu()">

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -5,6 +5,7 @@ from lemarche.www.dashboard.views import (
     DisabledEmailEditView,
     InclusivePotentialAnalysisView,
     InclusivePotentialProjectDetailView,
+    InclusivePurchaseExportView,
     InclusivePurchaseStatsDashboardView,
     ProfileEditView,
     SlugMappingValidationView,
@@ -20,6 +21,7 @@ urlpatterns = [
     path("modifier/", ProfileEditView.as_view(), name="profile_edit"),
     path("notifications/", DisabledEmailEditView.as_view(), name="notifications_edit"),
     path("part-achat-inclusif/", InclusivePurchaseStatsDashboardView.as_view(), name="inclusive_purchase_stats"),
+    path("part-achat-inclusif/export/", InclusivePurchaseExportView.as_view(), name="inclusive_purchase_export"),
     path("analyse-potentiel-inclusif/", InclusivePotentialAnalysisView.as_view(), name="inclusive_potential_analysis"),
     path(
         "analyse-potentiel-inclusif/modele-excel/",

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -1,9 +1,11 @@
+import csv
 import io
 import json
 import logging
 from urllib.parse import urlencode
 
 import openpyxl
+import xlwt
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
@@ -299,6 +301,110 @@ class InclusivePurchaseStatsDashboardView(LoginRequiredMixin, FilterView):
                 }
             )
         return context
+
+
+class InclusivePurchaseExportView(LoginRequiredMixin, View):
+    """
+    Export filtered purchase data as CSV or Excel (.xls).
+    Accepts the same query params as InclusivePurchaseStatsDashboardView.
+    Usage: ?format=csv  or  ?format=excel
+    """
+
+    LEGAL_FORM_LABELS = dict(LEGAL_FORM_CHOICES)
+
+    EXPORT_HEADERS = [
+        "Fournisseur",
+        "SIRET",
+        "Montant (€)",
+        "Année",
+        "Catégorie d'achat",
+        "Entité acheteuse",
+        "Structure inclusive",
+        "Type de structure",
+        "Statut juridique",
+        "Région",
+        "Taille",
+        "QPV",
+        "ZRR",
+    ]
+
+    def _get_size_label(self, siae):
+        if siae is None:
+            return ""
+        insertion = siae.employees_insertion_count
+        if insertion is None and siae.c2_etp_count is not None:
+            insertion = round(siae.c2_etp_count)
+        permanent = siae.employees_permanent_count or 0
+        if insertion is None and siae.employees_permanent_count is None:
+            return "Non renseigné"
+        total = (insertion or 0) + permanent
+        return "TPE (< 10 salariés)" if total < 10 else "PME (≥ 10 salariés)"
+
+    def _build_rows(self, purchases):
+        rows = []
+        for purchase in purchases.select_related("siae"):
+            siae = purchase.siae
+            rows.append(
+                [
+                    purchase.supplier_name,
+                    purchase.supplier_siret,
+                    float(purchase.purchase_amount),
+                    purchase.purchase_year,
+                    purchase.purchase_category or "",
+                    purchase.buying_entity or "",
+                    siae.name if siae else "",
+                    siae.kind if siae else "",
+                    self.LEGAL_FORM_LABELS.get(siae.legal_form, siae.legal_form or "") if siae else "",
+                    siae.region if siae else "",
+                    self._get_size_label(siae),
+                    "Oui" if siae and siae.is_qpv else ("Non" if siae else ""),
+                    "Oui" if siae and siae.is_zrr else ("Non" if siae else ""),
+                ]
+            )
+        return rows
+
+    def get(self, request):
+        filterset = PurchaseFilterSet(
+            data=request.GET,
+            queryset=Purchase.objects.get_purchase_for_user(request.user),
+        )
+        purchases = filterset.qs
+        export_format = request.GET.get("format", "csv")
+
+        if export_format == "excel":
+            return self._export_excel(purchases)
+        return self._export_csv(purchases)
+
+    def _export_csv(self, purchases):
+        response = HttpResponse(content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = 'attachment; filename="achats_inclusifs.csv"'
+        response.write("\ufeff")  # BOM for Excel UTF-8 compatibility
+        writer = csv.writer(response, delimiter=";")
+        writer.writerow(self.EXPORT_HEADERS)
+        for row in self._build_rows(purchases):
+            writer.writerow(row)
+        return response
+
+    def _export_excel(self, purchases):
+        wb = xlwt.Workbook(encoding="utf-8")
+        ws = wb.add_sheet("Achats inclusifs")
+
+        bold = xlwt.XFStyle()
+        bold.font.bold = True
+        normal = xlwt.XFStyle()
+        normal.alignment.wrap = 1
+
+        for col, header in enumerate(self.EXPORT_HEADERS):
+            ws.write(0, col, header, bold)
+
+        for row_idx, row in enumerate(self._build_rows(purchases), start=1):
+            for col_idx, value in enumerate(row):
+                ws.write(row_idx, col_idx, value, normal)
+
+        response = HttpResponse(content_type="application/vnd.ms-excel")
+        response["Content-Disposition"] = 'attachment; filename="achats_inclusifs.xls"'
+        wb.save(response)
+        return response
 
 
 class ProfileEditView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):


### PR DESCRIPTION
Description :

  Ajoute un menu déroulant "Exporter" en haut à droite du tableau de bord part des achats inclusifs, avec trois formats disponibles.

  ## Ce qui change

  - **PDF** - déclenche l'impression navigateur ; les filtres et la navigation
    sont masqués, seuls les graphiques et tableaux sont conservés
  - **CSV** - télécharge les achats filtrés au format `.csv` (séparateur `;`,
    encodage UTF-8 avec BOM pour compatibilité Excel)
  - **Excel** - télécharge les achats filtrés au format `.xls`

  Les exports respectent les filtres actifs du dashboard (type de structure,
  QPV, ZRR, catégorie d'achat, entité acheteuse).

  Chaque ligne exportée contient : fournisseur, SIRET, montant, année,
  catégorie d'achat, entité acheteuse, nom de la structure inclusive, type,
  statut juridique, région, taille (TPE/PME/Non renseigné), QPV, ZRR.
