### PR TITLE
chore: Set cooldown period in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,16 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "chore(deps): "
       prefix-development: "chore(dev-deps): "


### PR DESCRIPTION
With this cooldown period, Dependabot waits for 5 days before suggesting non-security updates. It reduces the risk of installing a malware-infected new version (which are usually detected and yanked from PyPI within hours or a couple of days).

Cooldown does not apply for security updates, which are suggested as soon as they are available.

Because the cooldown introduces a delay before updates, we now run Dependabot more frequently (daily instead of weekly) to avoid waiting too long (up to 6 days instead of 12 days if run weekly).

See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-