### PR TITLE
feat: filtrage par mode de prestation dans l'analyse du potentiel inclusif

### DIFF
--- a/lemarche/api/inclusive_potential/constants.py
+++ b/lemarche/api/inclusive_potential/constants.py
@@ -1,3 +1,30 @@
+from lemarche.siaes import constants as siae_constants
+
+
+PRESTA_MODE_SERVICE = "service"
+PRESTA_MODE_MISE_A_DISPO = "mise_a_disposition"
+PRESTA_MODE_DEFAULT = PRESTA_MODE_SERVICE
+
+PRESTA_MODE_CHOICES = [
+    (PRESTA_MODE_SERVICE, "Services et fournitures"),
+    (PRESTA_MODE_MISE_A_DISPO, "Mise à disposition de personnel (intérim d'insertion)"),
+]
+
+PRESTA_MODE_TO_SIAE_KINDS = {
+    PRESTA_MODE_SERVICE: [
+        siae_constants.KIND_EI,
+        siae_constants.KIND_ACI,
+        siae_constants.KIND_EA,
+        siae_constants.KIND_ESAT,
+    ],
+    PRESTA_MODE_MISE_A_DISPO: [
+        siae_constants.KIND_ETTI,
+        siae_constants.KIND_AI,
+        siae_constants.KIND_EATT,
+        siae_constants.KIND_GEIQ,
+    ],
+}
+
 LIMIT_FOR_RESERVATION = 30
 LIMIT_FOR_LOT = 10
 LIMIT_FOR_CLAUSE = 1

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -5,6 +5,8 @@ from lemarche.api.inclusive_potential.constants import (
     LIMIT_FOR_ECO_DEPENDENCY,
     LIMIT_FOR_LOT,
     LIMIT_FOR_RESERVATION,
+    PRESTA_MODE_DEFAULT,
+    PRESTA_MODE_TO_SIAE_KINDS,
     RECOMMENDATIONS,
 )
 from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST
@@ -55,14 +57,22 @@ def set_analysis_data(siaes, siaes_count, budget, analysis_data):
     analysis_data["recommendation"] = recommendation
 
 
-def get_inclusive_potential_data(sector: str, perimeter: str, budget: int) -> tuple[PotentialData, dict]:
+def get_inclusive_potential_data(
+    sector: str, perimeter: str, budget: int, presta_mode: str = PRESTA_MODE_DEFAULT
+) -> tuple[PotentialData, dict]:
     """
     Get the potential data for a given sector and perimeter.
     Budget is optional and is used to calculate the eco-dependency.
+    presta_mode filters structures by their economic model (service vs. mise à disposition).
     """
+    allowed_kinds = PRESTA_MODE_TO_SIAE_KINDS.get(presta_mode, PRESTA_MODE_TO_SIAE_KINDS[PRESTA_MODE_DEFAULT])
 
-    # Get all siaes with potential through activities
-    siaes = Siae.objects.filter_with_potential_through_activities(sector, perimeter).with_is_local(perimeter)
+    # Get all siaes with potential through activities, filtered by presta_mode
+    siaes = (
+        Siae.objects.filter_with_potential_through_activities(sector, perimeter)
+        .filter(kind__in=allowed_kinds)
+        .with_is_local(perimeter)
+    )
 
     # Calculate the number of siaes by kind and the number of employees
     # Prefer to loop over siaes rather than using querysets to avoid lots of big queries

--- a/lemarche/api/inclusive_potential/utils.py
+++ b/lemarche/api/inclusive_potential/utils.py
@@ -5,7 +5,6 @@ from lemarche.api.inclusive_potential.constants import (
     LIMIT_FOR_ECO_DEPENDENCY,
     LIMIT_FOR_LOT,
     LIMIT_FOR_RESERVATION,
-    PRESTA_MODE_DEFAULT,
     PRESTA_MODE_TO_SIAE_KINDS,
     RECOMMENDATIONS,
 )
@@ -58,21 +57,21 @@ def set_analysis_data(siaes, siaes_count, budget, analysis_data):
 
 
 def get_inclusive_potential_data(
-    sector: str, perimeter: str, budget: int, presta_mode: str = PRESTA_MODE_DEFAULT
+    sector: str, perimeter: str, budget: int, presta_mode: str | None = None
 ) -> tuple[PotentialData, dict]:
     """
     Get the potential data for a given sector and perimeter.
     Budget is optional and is used to calculate the eco-dependency.
     presta_mode filters structures by their economic model (service vs. mise à disposition).
+    When None (API default), all structure kinds are included.
     """
-    allowed_kinds = PRESTA_MODE_TO_SIAE_KINDS.get(presta_mode, PRESTA_MODE_TO_SIAE_KINDS[PRESTA_MODE_DEFAULT])
+    qs = Siae.objects.filter_with_potential_through_activities(sector, perimeter)
+
+    if presta_mode and presta_mode in PRESTA_MODE_TO_SIAE_KINDS:
+        qs = qs.filter(kind__in=PRESTA_MODE_TO_SIAE_KINDS[presta_mode])
 
     # Get all siaes with potential through activities, filtered by presta_mode
-    siaes = (
-        Siae.objects.filter_with_potential_through_activities(sector, perimeter)
-        .filter(kind__in=allowed_kinds)
-        .with_is_local(perimeter)
-    )
+    siaes = qs.with_is_local(perimeter)
 
     # Calculate the number of siaes by kind and the number of employees
     # Prefer to loop over siaes rather than using querysets to avoid lots of big queries

--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -301,6 +301,42 @@
             </p>
         </div>
 
+        {# ── Segmented control : mode de prestation ── #}
+        <div class="fr-mb-3w">
+            <form method="post" action="" id="presta-mode-form">
+                {% csrf_token %}
+                <input type="hidden" name="mode" value="reanalyze">
+                <fieldset class="fr-segmented fr-segmented--sm">
+                    <legend class="fr-segmented__legend fr-text--sm fr-mb-1w" style="font-weight:600;">
+                        Type de prestation analysé
+                        <span class="fr-hint-text">Le mode sélectionné modifie la base de structures et tous les indicateurs.</span>
+                    </legend>
+                    <div class="fr-segmented__elements">
+                        <div class="fr-segmented__element">
+                            <input type="radio" name="presta_mode"
+                                   id="presta-mode-service"
+                                   value="service"
+                                   {% if presta_mode == "service" %}checked{% endif %}
+                                   onchange="document.getElementById('presta-mode-form').submit()">
+                            <label class="fr-label" for="presta-mode-service">
+                                Services et fournitures
+                            </label>
+                        </div>
+                        <div class="fr-segmented__element">
+                            <input type="radio" name="presta_mode"
+                                   id="presta-mode-mise-a-dispo"
+                                   value="mise_a_disposition"
+                                   {% if presta_mode == "mise_a_disposition" %}checked{% endif %}
+                                   onchange="document.getElementById('presta-mode-form').submit()">
+                            <label class="fr-label" for="presta-mode-mise-a-dispo">
+                                Mise à disposition de personnel (intérim d'insertion)
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
+        </div>
+
     {# ══ Résultats Excel : tableau Alpine.js ══ #}
     {% if mode == "excel" %}
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -16,6 +16,7 @@ from django.views.generic import DetailView, FormView, UpdateView
 from django_filters.views import FilterView
 
 from content_manager.models import ContentPage, Tag
+from lemarche.api.inclusive_potential.constants import PRESTA_MODE_DEFAULT, PRESTA_MODE_TO_SIAE_KINDS
 from lemarche.api.inclusive_potential.utils import get_inclusive_potential_data
 from lemarche.cms.models import ArticleList
 from lemarche.perimeters.models import Perimeter
@@ -331,10 +332,12 @@ def _build_search_urls(sector: Sector, perimeter: Perimeter | None) -> dict:
     }
 
 
-def _analyze_purchase_project(titre: str, sector: Sector, perimeter: Perimeter | None, budget: int | None) -> dict:
+def _analyze_purchase_project(
+    titre: str, sector: Sector, perimeter: Perimeter | None, budget: int | None, presta_mode: str = PRESTA_MODE_DEFAULT
+) -> dict:
     """Run the inclusive potential analysis for a single purchase project."""
     try:
-        potential_data, analysis_data = get_inclusive_potential_data(sector, perimeter, budget)
+        potential_data, analysis_data = get_inclusive_potential_data(sector, perimeter, budget, presta_mode)
     except Exception:
         logger.exception("Erreur lors de l'analyse du potentiel inclusif pour '%s'", titre)
         return {
@@ -476,6 +479,7 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
         results_by_perimeter=None,
         import_errors=None,
         mode="manual",
+        presta_mode=PRESTA_MODE_DEFAULT,
     ):
         return {
             "sectors": list(Sector.objects.form_filter_queryset()),
@@ -485,6 +489,8 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
             "results_by_perimeter": results_by_perimeter,
             "import_errors": import_errors,
             "mode": mode,
+            "presta_mode": presta_mode,
+            "presta_mode_choices": list(PRESTA_MODE_TO_SIAE_KINDS.keys()),
         }
 
     def get(self, request):
@@ -492,6 +498,8 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
 
     def post(self, request):
         mode = request.POST.get("mode", "manual")
+        if mode == "reanalyze":
+            return self._handle_reanalyze(request)
         if mode == "excel":
             return self._handle_excel_import(request)
         return self._handle_manual_form(request)
@@ -505,6 +513,11 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
                 self._get_context(formset=formset, mode="manual"),
             )
 
+        presta_mode = request.POST.get("presta_mode", PRESTA_MODE_DEFAULT)
+        if presta_mode not in PRESTA_MODE_TO_SIAE_KINDS:
+            presta_mode = PRESTA_MODE_DEFAULT
+
+        raw_projects = []
         results = []
         for form in formset:
             if not form.cleaned_data:
@@ -523,13 +536,25 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
                     results.append({"titre": titre, "error": f"Périmètre '{perimeter_slug}' introuvable."})
                     continue
 
-            result = _analyze_purchase_project(titre, sector, perimeter, montant)
+            raw_projects.append(
+                {
+                    "titre": titre,
+                    "secteur_slug": sector.slug,
+                    "perimeter_slug": perimeter.slug if perimeter else None,
+                    "france_entiere": france_entiere,
+                    "montant": montant,
+                    "input_mode": "manual",
+                }
+            )
+            result = _analyze_purchase_project(titre, sector, perimeter, montant, presta_mode)
             results.append(result)
+
+        request.session["ipa_raw_projects"] = raw_projects
 
         return render(
             request,
             self.template_name,
-            self._get_context(formset=formset, results=results, mode="manual"),
+            self._get_context(formset=formset, results=results, mode="manual", presta_mode=presta_mode),
         )
 
     def _handle_excel_import(self, request):
@@ -550,6 +575,11 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
                 self._get_context(import_errors=[str(e)], mode="excel"),
             )
 
+        presta_mode = request.POST.get("presta_mode", PRESTA_MODE_DEFAULT)
+        if presta_mode not in PRESTA_MODE_TO_SIAE_KINDS:
+            presta_mode = PRESTA_MODE_DEFAULT
+
+        raw_projects = []
         results = []
         import_errors = []
 
@@ -578,7 +608,17 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
                     import_errors.append(f"Ligne {row_num} — « {titre} » : périmètre « {perimetre} » introuvable.")
                     continue
 
-            result = _analyze_purchase_project(titre, sector, perimeter, montant)
+            raw_projects.append(
+                {
+                    "titre": titre,
+                    "secteur_slug": sector.slug,
+                    "perimeter_slug": perimeter.slug if perimeter else None,
+                    "france_entiere": perimetre.lower() == "france_entiere",
+                    "montant": montant,
+                    "input_mode": "excel",
+                }
+            )
+            result = _analyze_purchase_project(titre, sector, perimeter, montant, presta_mode)
             results.append(result)
 
         if not results:
@@ -590,6 +630,7 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
 
         by_sector, by_perimeter = _aggregate_results(results)
 
+        request.session["ipa_raw_projects"] = raw_projects
         request.session["ipa_excel_results"] = [{k: v for k, v in r.items() if k != "search_urls"} for r in results]
 
         return render(
@@ -601,7 +642,68 @@ class InclusivePotentialAnalysisView(LoginRequiredMixin, View):
                 results_by_perimeter=by_perimeter,
                 import_errors=import_errors or None,
                 mode="excel",
+                presta_mode=presta_mode,
             ),
+        )
+
+    def _handle_reanalyze(self, request):
+        """Re-run the analysis from session data with a new presta_mode."""
+        raw_projects = request.session.get("ipa_raw_projects")
+        if not raw_projects:
+            return HttpResponseRedirect(reverse("dashboard:inclusive_potential_analysis"))
+
+        presta_mode = request.POST.get("presta_mode", PRESTA_MODE_DEFAULT)
+        if presta_mode not in PRESTA_MODE_TO_SIAE_KINDS:
+            presta_mode = PRESTA_MODE_DEFAULT
+
+        input_mode = raw_projects[0].get("input_mode", "manual") if raw_projects else "manual"
+
+        results = []
+        for project in raw_projects:
+            titre = project["titre"]
+            montant = project["montant"]
+            france_entiere = project.get("france_entiere", False)
+
+            try:
+                sector = Sector.objects.get(slug=project["secteur_slug"])
+            except Sector.DoesNotExist:
+                results.append({"titre": titre, "error": f"Secteur '{project['secteur_slug']}' introuvable."})
+                continue
+
+            perimeter = None
+            if project.get("perimeter_slug") and not france_entiere:
+                try:
+                    perimeter = Perimeter.objects.get(slug=project["perimeter_slug"])
+                except Perimeter.DoesNotExist:
+                    results.append({"titre": titre, "error": f"Périmètre '{project['perimeter_slug']}' introuvable."})
+                    continue
+
+            result = _analyze_purchase_project(titre, sector, perimeter, montant, presta_mode)
+            results.append(result)
+
+        request.session["ipa_raw_projects"] = raw_projects
+
+        if input_mode == "excel":
+            request.session["ipa_excel_results"] = [
+                {k: v for k, v in r.items() if k != "search_urls"} for r in results
+            ]
+            by_sector, by_perimeter = _aggregate_results(results)
+            return render(
+                request,
+                self.template_name,
+                self._get_context(
+                    results=results,
+                    results_by_sector=by_sector,
+                    results_by_perimeter=by_perimeter,
+                    mode="excel",
+                    presta_mode=presta_mode,
+                ),
+            )
+
+        return render(
+            request,
+            self.template_name,
+            self._get_context(results=results, mode="manual", presta_mode=presta_mode),
         )
 
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -312,23 +312,35 @@ class DisabledEmailEditView(LoginRequiredMixin, SuccessMessageMixin, FormView):
         return super().form_valid(form)
 
 
-def _build_search_urls(sector: Sector, perimeter: Perimeter | None) -> dict:
+def _build_search_urls(sector: Sector, perimeter: Perimeter | None, presta_mode: str | None = None) -> dict:
     """Build search URLs for each indicator, pointing to the Marché search page."""
     base_params = [("sectors", sector.slug)]
     if perimeter:
         base_params.append(("perimeters", perimeter.slug))
 
-    def url(extra_params=None):
-        params = base_params + (extra_params or [])
+    presta_kinds = PRESTA_MODE_TO_SIAE_KINDS.get(presta_mode) if presta_mode else None
+
+    def kind_params(base_kinds=None):
+        """Return kind URL params, intersected with active presta_mode if any."""
+        if base_kinds is None:
+            kinds = presta_kinds or []
+        elif presta_kinds is not None:
+            kinds = [k for k in base_kinds if k in presta_kinds]
+        else:
+            kinds = base_kinds
+        return [("kind", k) for k in kinds]
+
+    def url(kind_filter=None, extra_params=None):
+        params = base_params + kind_params(kind_filter) + (extra_params or [])
         return f"/prestataires/?{urlencode(params)}"
 
     return {
         "all": url(),
-        "insertion": url([("kind", k) for k in KIND_INSERTION_LIST]),
-        "handicap": url([("kind", k) for k in KIND_HANDICAP_LIST]),
-        "local": url([("local", "True")]),
-        "super_badge": url([("super_badge", "True")]),
-        "won_contract": url([("has_won_contract", "True")]),
+        "insertion": url(KIND_INSERTION_LIST),
+        "handicap": url(KIND_HANDICAP_LIST),
+        "local": url(extra_params=[("local", "True")]),
+        "super_badge": url(extra_params=[("super_badge", "True")]),
+        "won_contract": url(extra_params=[("has_won_contract", "True")]),
     }
 
 
@@ -345,7 +357,7 @@ def _analyze_purchase_project(
             "error": "Une erreur technique s'est produite lors de l'analyse. Veuillez réessayer.",
         }
 
-    search_urls = _build_search_urls(sector, perimeter)
+    search_urls = _build_search_urls(sector, perimeter, presta_mode)
     result = {
         "titre": titre,
         "secteur_name": sector.name,

--- a/tests/www/dashboard/test_inclusive_potential_analysis.py
+++ b/tests/www/dashboard/test_inclusive_potential_analysis.py
@@ -252,3 +252,86 @@ class InclusivePotentialExcelTemplateTest(TestCase):
         self.assertIn("secteur", headers)
         self.assertIn("montant", headers)
         self.assertIn("perimetre_geographique", headers)
+
+
+class InclusivePotentialPrestaModeTest(TestCase):
+    """Tests du filtrage par mode de prestation (service vs mise à disposition)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse(ANALYSIS_URL)
+        cls.user = UserFactory(kind=User.KIND_BUYER)
+        cls.sector = SectorFactory()
+        cls.perimeter = PerimeterFactory(name="Paris", slug="paris")
+
+    def _post_manual(self, extra_data=None):
+        self.client.force_login(self.user)
+        data = {
+            "mode": "manual",
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-titre": "Projet test",
+            "form-0-secteur": self.sector.slug,
+            "form-0-montant": "80000",
+            "form-0-perimeter_slug": "paris",
+            "form-0-france_entiere": "",
+        }
+        if extra_data:
+            data.update(extra_data)
+        return self.client.post(self.url, data)
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_default_presta_mode_is_service(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        response = self._post_manual()
+        self.assertEqual(response.context["presta_mode"], "service")
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_presta_mode_service_passed_to_analysis(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        self._post_manual({"presta_mode": "service"})
+        call_kwargs = mock_analysis.call_args[1]
+        self.assertEqual(call_kwargs.get("presta_mode") or mock_analysis.call_args[0][3], "service")
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_presta_mode_mise_a_dispo_passed_to_analysis(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, {})
+        response = self._post_manual({"presta_mode": "mise_a_disposition"})
+        self.assertEqual(response.context["presta_mode"], "mise_a_disposition")
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_invalid_presta_mode_falls_back_to_default(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, {})
+        response = self._post_manual({"presta_mode": "mode_invalide"})
+        self.assertEqual(response.context["presta_mode"], "service")
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_raw_projects_stored_in_session_after_manual(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        self._post_manual()
+        raw = self.client.session.get("ipa_raw_projects")
+        self.assertIsNotNone(raw)
+        self.assertEqual(len(raw), 1)
+        self.assertEqual(raw[0]["titre"], "Projet test")
+        self.assertEqual(raw[0]["secteur_slug"], self.sector.slug)
+        self.assertEqual(raw[0]["input_mode"], "manual")
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_reanalyze_from_session_changes_mode(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        # Première analyse en mode service
+        self._post_manual({"presta_mode": "service"})
+        # Re-analyse en mode mise à disposition depuis la session
+        self.client.force_login(self.user)
+        response = self.client.post(self.url, {"mode": "reanalyze", "presta_mode": "mise_a_disposition"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["presta_mode"], "mise_a_disposition")
+        self.assertIsNotNone(response.context["results"])
+
+    def test_reanalyze_without_session_redirects(self):
+        self.client.force_login(self.user)
+        response = self.client.post(self.url, {"mode": "reanalyze", "presta_mode": "service"})
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("analyse-potentiel-inclusif", response.url)

--- a/tests/www/dashboard/test_inclusive_potential_analysis.py
+++ b/tests/www/dashboard/test_inclusive_potential_analysis.py
@@ -308,6 +308,22 @@ class InclusivePotentialPrestaModeTest(TestCase):
         self.assertEqual(response.context["presta_mode"], "service")
 
     @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_search_urls_filtered_by_presta_mode_service(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        response = self._post_manual({"presta_mode": "service"})
+        search_urls = response.context["results"][0]["search_urls"]
+        self.assertIn("kind=EI", search_urls["all"])
+        self.assertNotIn("kind=ETTI", search_urls["all"])
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
+    def test_search_urls_filtered_by_presta_mode_mise_a_dispo(self, mock_analysis):
+        mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
+        response = self._post_manual({"presta_mode": "mise_a_disposition"})
+        search_urls = response.context["results"][0]["search_urls"]
+        self.assertIn("kind=ETTI", search_urls["all"])
+        self.assertNotIn("kind=EI", search_urls["all"])
+
+    @patch("lemarche.www.dashboard.views.get_inclusive_potential_data")
     def test_raw_projects_stored_in_session_after_manual(self, mock_analysis):
         mock_analysis.return_value = (MOCK_POTENTIAL_DATA, MOCK_ANALYSIS_DATA)
         self._post_manual()


### PR DESCRIPTION
## Pourquoi ce changement

L'IPA agrégait toutes les structures inclusives sans distinction de modèle économique. Or, les prestataires de services (EI, ACI, EA, ESAT) et les structures de mise à disposition de personnel (ETTI, AI, EATT, GEIQ) ne répondent pas aux mêmes besoins acheteur et ne doivent pas être mélangés dans les indicateurs.

## Ce qui change

### Segmented control dans les résultats

Un sélecteur apparaît dans la page de résultats (saisie manuelle et import Excel) :
- **Services et fournitures** (défaut) → EI, ACI, EA, ESAT
- **Mise à disposition de personnel (intérim d'insertion)** → ETTI, AI, EATT, GEIQ

Changer de mode re-lance l'analyse **sans re-saisir ni re-uploader** : les projets bruts sont stockés en session après la première analyse.

### Architecture

- `constants.py` — mapping `presta_mode` → kinds de structures
- `utils.py` — paramètre `presta_mode` sur `get_inclusive_potential_data()`, filtre `kind__in` sur le queryset
- `views.py` — propagation de `presta_mode`, stockage session `ipa_raw_projects`, nouveau handler `_handle_reanalyze()`
- Template — `fr-segmented` DSFR dans la section résultats

## Comment tester

1. Aller sur `/profil/analyse-potentiel-inclusif/`
2. Saisir un projet et lancer l'analyse → vérifier que le segmented control "Services et fournitures" est sélectionné par défaut
3. Basculer sur "Mise à disposition de personnel" → vérifier que les indicateurs changent et que la page ne redemande pas de re-saisir
4. Même test avec l'import Excel
5. Vérifier que le mode actif reste visible après changement