### PR TITLE
feat(ipa): contexte projet et avertissement multi-projets dans la modal de validation

### DIFF
--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -603,8 +603,6 @@
                             <span class="ipa-group-hd__name" x-text="group.name"></span>
                             <span class="ipa-group-hd__meta">
                                 <span x-text="group.projects.length + ' projet' + (group.projects.length > 1 ? 's' : '')"></span>
-                                &nbsp;·&nbsp;
-                                <strong x-text="group.total + ' structure' + (group.total > 1 ? 's' : '') + ' potentielle' + (group.total > 1 ? 's' : '')"></strong>
                             </span>
                             <span class="ipa-group-hd__chevron" x-text="expandedGroups[group.name] ? '▲' : '▼'"></span>
                         </div>
@@ -1323,11 +1321,10 @@
             _groupBy(key) {
                 const groups = {};
                 for (const p of this.filteredProjects) {
-                    if (!groups[p[key]]) groups[p[key]] = { name: p[key], projects: [], total: 0 };
+                    if (!groups[p[key]]) groups[p[key]] = { name: p[key], projects: [] };
                     groups[p[key]].projects.push(p);
-                    groups[p[key]].total += p.potential_siaes;
                 }
-                return Object.values(groups).sort((a, b) => b.total - a.total);
+                return Object.values(groups).sort((a, b) => b.projects.length - a.projects.length);
             },
 
             get uniqueSectors() {

--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -602,7 +602,7 @@
                         <div class="ipa-group-hd" @click="toggleGroup(group.name)">
                             <span class="ipa-group-hd__name" x-text="group.name"></span>
                             <span class="ipa-group-hd__meta">
-                                <span x-text="group.projects.length + ' projet' + (group.projects.length > 1 ? 's' : '')"></span>
+                                <span x-text="group.withPotential + ' / ' + group.projects.length + ' projet' + (group.projects.length > 1 ? 's' : '') + ' avec potentiel inclusif'"></span>
                             </span>
                             <span class="ipa-group-hd__chevron" x-text="expandedGroups[group.name] ? '▲' : '▼'"></span>
                         </div>
@@ -1324,7 +1324,13 @@
                     if (!groups[p[key]]) groups[p[key]] = { name: p[key], projects: [] };
                     groups[p[key]].projects.push(p);
                 }
-                return Object.values(groups).sort((a, b) => b.projects.length - a.projects.length);
+                return Object.values(groups).sort((a, b) => b.projects.length - a.projects.length).map(g => ({
+                    ...g,
+                    withPotential: g.projects.filter(p =>
+                        p.recommendation_title === 'Réservation totale' ||
+                        p.recommendation_title === 'Clause sociale'
+                    ).length,
+                }));
             },
 
             get uniqueSectors() {

--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -1327,9 +1327,9 @@
                 return Object.values(groups).sort((a, b) => b.projects.length - a.projects.length).map(g => ({
                     ...g,
                     withPotential: g.projects.filter(p =>
-                        p.recommendation_title === 'Réservation totale' ||
-                        p.recommendation_title === 'Lot réservé' ||
-                        p.recommendation_title === 'Clause sociale d\'exécution'
+                        p.recommendation_key === 'reservation' ||
+                        p.recommendation_key === 'lot' ||
+                        p.recommendation_key === 'clause'
                     ).length,
                 }));
             },

--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -578,9 +578,13 @@
                                     <td style="text-align:right;">
                                         <a :href="p.search_urls.won_contract" target="_blank" rel="noopener" x-text="p.siaes_with_won_contract"></a>
                                     </td>
-                                    <td style="text-align:right;"
-                                        :style="p.eco_dependency !== null && p.eco_dependency > 30 ? 'color:#ce0500; font-weight:700;' : ''">
-                                        <span x-text="p.eco_dependency !== null ? p.eco_dependency + ' %' : '—'"></span>
+                                    <td style="text-align:right;">
+                                        <template x-if="p.eco_dependency !== null">
+                                            <span class="fr-badge fr-badge--sm"
+                                                  :class="ecoDepBadgeClass(p.eco_dependency)"
+                                                  x-text="p.eco_dependency + ' %'"></span>
+                                        </template>
+                                        <template x-if="p.eco_dependency === null"><span>—</span></template>
                                     </td>
                                     <td>
                                         <span class="ipa-reco"
@@ -657,9 +661,14 @@
                                                 <td style="text-align:right;">
                                                     <a :href="p.search_urls.won_contract" target="_blank" rel="noopener" x-text="p.siaes_with_won_contract"></a>
                                                 </td>
-                                                <td style="text-align:right;"
-                                                    :style="p.eco_dependency !== null && p.eco_dependency > 30 ? 'color:#ce0500; font-weight:700;' : ''"
-                                                    x-text="p.eco_dependency !== null ? p.eco_dependency + ' %' : '—'"></td>
+                                                <td style="text-align:right;">
+                                                    <template x-if="p.eco_dependency !== null">
+                                                        <span class="fr-badge fr-badge--sm"
+                                                              :class="ecoDepBadgeClass(p.eco_dependency)"
+                                                              x-text="p.eco_dependency + ' %'"></span>
+                                                    </template>
+                                                    <template x-if="p.eco_dependency === null"><span>—</span></template>
+                                                </td>
                                                 <td>
                                                     <span class="ipa-reco"
                                                           :class="recoClass(p.recommendation_title)"
@@ -829,6 +838,17 @@
                                     Dépendance économique
                                     <span class="ipa-tip" data-tip="Part que représente votre marché dans le CA moyen des structures potentielles. Au-delà de 30 %, le risque de dépendance économique est considéré comme élevé."><i class="ri-information-line" aria-hidden="true"></i></span>
                                 </div>
+                                {% if result.eco_dependency is not None %}
+                                <div class="fr-mt-1v">
+                                    {% if result.eco_dependency <= 30 %}
+                                        <span class="fr-badge fr-badge--sm fr-badge--success">Limitée</span>
+                                    {% elif result.eco_dependency <= 50 %}
+                                        <span class="fr-badge fr-badge--sm fr-badge--warning">Point de vigilance</span>
+                                    {% else %}
+                                        <span class="fr-badge fr-badge--sm fr-badge--error">Risque élevé</span>
+                                    {% endif %}
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
                         <div class="fr-col-6 fr-col-md-3">
@@ -1374,6 +1394,12 @@
 
             toggleGroup(name) {
                 this.expandedGroups[name] = !this.expandedGroups[name];
+            },
+
+            ecoDepBadgeClass(value) {
+                if (value <= 30) return 'fr-badge--success';
+                if (value <= 50) return 'fr-badge--warning';
+                return 'fr-badge--error';
             },
 
             recoClass(title) {

--- a/lemarche/templates/dashboard/inclusive_potential_analysis.html
+++ b/lemarche/templates/dashboard/inclusive_potential_analysis.html
@@ -1328,7 +1328,8 @@
                     ...g,
                     withPotential: g.projects.filter(p =>
                         p.recommendation_title === 'Réservation totale' ||
-                        p.recommendation_title === 'Clause sociale'
+                        p.recommendation_title === 'Lot réservé' ||
+                        p.recommendation_title === 'Clause sociale d\'exécution'
                     ).length,
                 }));
             },

--- a/lemarche/templates/dashboard/inclusive_potential_mapping_validation.html
+++ b/lemarche/templates/dashboard/inclusive_potential_mapping_validation.html
@@ -82,6 +82,13 @@
         text-transform: uppercase; letter-spacing: .04em;
         color: #3a3a3a; margin-bottom: .5rem;
     }
+    .ipa-context-block {
+        background: #f0f0fb;
+        border-left: 3px solid #000091;
+        border-radius: 0 4px 4px 0;
+        padding: .625rem .875rem;
+        margin-bottom: 1rem;
+    }
 </style>
 
 <div x-data="ipaValidationWizard()" x-init="init()">
@@ -112,10 +119,6 @@
                 <div class="ipa-progress fr-mt-1w">
                     <div class="ipa-progress__fill" :style="`width:${progress}%`"></div>
                 </div>
-                <p class="fr-text--xs fr-mb-0 fr-mt-1w" style="color:#777;">
-                    Projet en cours :
-                    <strong x-text="currentItem.titre"></strong>
-                </p>
                 {% if unresolvable_count %}
                 <p class="fr-text--xs fr-mb-0 fr-mt-1w" style="color:#b34000;">
                     ⚠ {{ unresolvable_count }} projet(s) déjà ignoré(s) — correspondance introuvable.
@@ -130,10 +133,20 @@
                 <template x-if="needsSectorValidation">
                     <div class="fr-mb-3w">
                         <p class="ipa-section-label">Secteur d'achat</p>
-                        <p class="fr-text--sm fr-mb-2w">
-                            Votre fichier indique <span class="ipa-raw-value" x-text="currentItem.sector_raw || '(vide)'"></span>.
-                            À quel secteur d'activité cela correspond-il ?
-                        </p>
+                        <div class="ipa-context-block">
+                            <p class="fr-text--xs fr-mb-1v" style="color:#555; text-transform:uppercase; letter-spacing:.03em;">Valeur dans votre fichier</p>
+                            <p class="fr-mb-1v" style="font-weight:700; font-size:1rem;">
+                                <span class="ipa-raw-value" x-text="currentItem.sector_raw || '(vide)'"></span>
+                            </p>
+                            <p class="fr-text--sm fr-mb-0" style="font-weight:600;" x-text="currentItem.titre"></p>
+                            <template x-if="sameRawSectorCount > 0">
+                                <p class="fr-text--sm fr-mb-0 fr-mt-1v" style="color:#000091;">
+                                    <span class="fr-icon-information-line" aria-hidden="true"></span>
+                                    <span x-text="sameRawSectorWarning"></span>
+                                </p>
+                            </template>
+                        </div>
+                        <p class="fr-text--sm fr-mb-2w">À quel secteur d'activité cela correspond-il ?</p>
 
                         {# Candidats radio #}
                         <template x-if="currentItem.sector_result.candidates.length > 0">
@@ -186,10 +199,20 @@
                 <template x-if="needsPerimeterValidation">
                     <div>
                         <p class="ipa-section-label">Périmètre géographique</p>
-                        <p class="fr-text--sm fr-mb-2w">
-                            Votre fichier indique <span class="ipa-raw-value" x-text="currentItem.perimeter_raw || '(vide)'"></span>.
-                            À quelle zone géographique cela correspond-il ?
-                        </p>
+                        <div class="ipa-context-block">
+                            <p class="fr-text--xs fr-mb-1v" style="color:#555; text-transform:uppercase; letter-spacing:.03em;">Valeur dans votre fichier</p>
+                            <p class="fr-mb-1v" style="font-weight:700; font-size:1rem;">
+                                <span class="ipa-raw-value" x-text="currentItem.perimeter_raw || '(vide)'"></span>
+                            </p>
+                            <p class="fr-text--sm fr-mb-0" style="font-weight:600;" x-text="currentItem.titre"></p>
+                            <template x-if="sameRawPerimeterCount > 0">
+                                <p class="fr-text--sm fr-mb-0 fr-mt-1v" style="color:#000091;">
+                                    <span class="fr-icon-information-line" aria-hidden="true"></span>
+                                    <span x-text="sameRawPerimeterWarning"></span>
+                                </p>
+                            </template>
+                        </div>
+                        <p class="fr-text--sm fr-mb-2w">À quelle zone géographique cela correspond-il ?</p>
 
                         {# Candidats radio #}
                         <template x-if="currentItem.perimeter_result.candidates && currentItem.perimeter_result.candidates.length > 0">
@@ -325,6 +348,28 @@ function ipaValidationWizard() {
         get needsPerimeterValidation() {
             const p = this.currentItem?.perimeter_result;
             return p?.status === 'ambiguous' || p?.status === 'error';
+        },
+
+        get sameRawSectorCount() {
+            const raw = this.currentItem?.sector_raw;
+            if (!raw) return 0;
+            return this.items.filter(i => i.sector_raw === raw && i.row !== this.currentItem.row).length;
+        },
+
+        get sameRawPerimeterCount() {
+            const raw = this.currentItem?.perimeter_raw;
+            if (!raw) return 0;
+            return this.items.filter(i => i.perimeter_raw === raw && i.row !== this.currentItem.row).length;
+        },
+
+        get sameRawSectorWarning() {
+            const n = this.sameRawSectorCount;
+            return `Cette valeur apparaît dans ${n} autre${n > 1 ? 's' : ''} projet${n > 1 ? 's' : ''} de votre fichier.`;
+        },
+
+        get sameRawPerimeterWarning() {
+            const n = this.sameRawPerimeterCount;
+            return `Cette valeur apparaît dans ${n} autre${n > 1 ? 's' : ''} projet${n > 1 ? 's' : ''} de votre fichier.`;
         },
 
         initItem() {

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -17,7 +17,7 @@ from django.views.generic import DetailView, FormView, UpdateView
 from django_filters.views import FilterView
 
 from content_manager.models import ContentPage, Tag
-from lemarche.api.inclusive_potential.constants import PRESTA_MODE_DEFAULT, PRESTA_MODE_TO_SIAE_KINDS
+from lemarche.api.inclusive_potential.constants import PRESTA_MODE_DEFAULT, PRESTA_MODE_TO_SIAE_KINDS, RECOMMENDATIONS
 from lemarche.api.inclusive_potential.utils import get_inclusive_potential_data
 from lemarche.cms.models import ArticleList
 from lemarche.perimeters.models import Perimeter
@@ -396,9 +396,12 @@ def _analyze_purchase_project(
         recommendation = analysis_data["recommendation"]
         result["recommendation_title"] = recommendation.get("title")
         result["recommendation_response"] = recommendation.get("response")
+        result["recommendation_key"] = _RECOMMENDATION_TITLE_TO_KEY.get(result["recommendation_title"])
 
     return result
 
+
+_RECOMMENDATION_TITLE_TO_KEY = {rec["title"]: key for key, rec in RECOMMENDATIONS.items()}
 
 INCLUSIVE_POTENTIAL_ANALYSIS_TEMPLATE = "dashboard/inclusive_potential_analysis.html"
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -343,7 +343,7 @@ def _build_search_urls(sector: Sector, perimeter: Perimeter | None, presta_mode:
 
     def url(kind_filter=None, extra_params=None):
         params = base_params + kind_params(kind_filter) + (extra_params or [])
-        return f"/prestataires/?{urlencode(params)}"
+        return f"/prestataires/?{urlencode(params)}#searchResults"
 
     return {
         "all": url(),


### PR DESCRIPTION
## Pourquoi ce changement

Dans la modal de validation des correspondances (import Excel IPA), le contexte projet était affiché discrètement en `xs` dans l'en-tête. L'utilisateur ne comprenait pas immédiatement quelle valeur de son fichier posait problème, ni pour quel projet.

De plus, si une même valeur brute ("Services", "IDF"…) était présente dans plusieurs lignes du fichier, rien n'indiquait que la correction allait concerner plusieurs projets.

## Ce qui change

- **Bloc contexte** dans le corps de la modal (secteur et périmètre) : valeur brute mise en évidence + titre du projet en-dessous — bien visible, pas dans l'en-tête
- **Avertissement multi-projets** : si la même valeur apparaît dans N autres lignes du fichier, affiche _"Cette valeur apparaît dans N autre(s) projet(s) de votre fichier."_
- **Suppression** de la ligne "Projet en cours : xxx" dans l'en-tête (redondant avec le nouveau bloc)

## Fichier modifié

`lemarche/templates/dashboard/inclusive_potential_mapping_validation.html` — template uniquement, zéro Python.

## Comment tester

1. Importer un Excel avec des valeurs de secteur ou périmètre non reconnues, dont certaines répétées sur plusieurs lignes
2. Vérifier que la modal affiche bien la valeur brute + le titre du projet dans un encart visible
3. Si la valeur est répétée sur N autres lignes : vérifier le message d'avertissement
4. Si la valeur est unique : vérifier que le message n'apparaît pas

## Ordre de merge

#2048 → #2049 → cette PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)