### PR TITLE
feat: recherche avancée accessible aux visiteurs non connectés

### DIFF
--- a/lemarche/templates/siaes/search_results.html
+++ b/lemarche/templates/siaes/search_results.html
@@ -80,8 +80,7 @@
                                     <div class="fr-col-12 fr-btns-group--center fr-mt-4v fr-mb-0">
                                         <button type="button"
                                                 class="fr-btn fr-btn--tertiary-no-outline"
-                                                @click="toggle()"
-                                                {% if not user.is_authenticated %} data-fr-opened="false" aria-controls="modal_login_to_access_advanced_search"{% endif %}>
+                                                @click="toggle()">
                                             Recherche avancée
                                             <br />
                                             <span :class="open ? 'fr-icon-arrow-up-s-line' : 'fr-icon-arrow-down-s-line'"
@@ -226,7 +225,6 @@
 {% endblock content %}
 {% block modals %}
     {% include "auth/_login_or_signup_modal.html" %}
-    {% include "auth/_login_or_signup_search_advanced_modal.html" %}
     {% include "favorites/_favorite_item_add_modal.html" %}
     {% include "favorites/_favorite_item_remove_modal.html" %}
 {% endblock modals %}

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -59,8 +59,7 @@ class SiaeSearchResultsView(FormMixin, ListView):
 
     def get_filter_form(self):
         if not self.filter_form:
-            user = self.request.user
-            self.filter_form = SiaeFilterForm(data=self.request.GET, advanced_search=user.is_authenticated)
+            self.filter_form = SiaeFilterForm(data=self.request.GET)
         return self.filter_form
 
     def get_queryset(self):

--- a/tests/www/siaes/tests.py
+++ b/tests/www/siaes/tests.py
@@ -103,6 +103,27 @@ class SiaeSearchNumQueriesTest(TestCase):
             self.assertEqual(len(siaes), 20)
 
 
+class SiaeAdvancedSearchAnonymousTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        SiaeFactory(kind=siae_constants.KIND_EI)
+        SiaeFactory(kind=siae_constants.KIND_AI)
+        cls.url = reverse("siae:search_results")
+
+    def test_anonymous_can_use_advanced_search_filter(self):
+        """Un visiteur non connecté peut filtrer par type de structure (recherche avancée)."""
+        response = self.client.get(self.url + f"?kind={siae_constants.KIND_EI}")
+        self.assertEqual(response.status_code, 200)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 1)
+
+    def test_anonymous_can_use_multiple_advanced_filters(self):
+        response = self.client.get(self.url + f"?kind={siae_constants.KIND_EI}&kind={siae_constants.KIND_AI}")
+        self.assertEqual(response.status_code, 200)
+        siaes = list(response.context["siaes"])
+        self.assertEqual(len(siaes), 2)
+
+
 class SiaeKindSearchFilterTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
## Quoi ?

Suppression de la restriction d'accès à la recherche avancée / multicritères pour les visiteurs non connectés.

## Pourquoi ?

La recherche avancée était réservée aux utilisateurs connectés, ce qui forçait les visiteurs anonymes à créer un compte pour filtrer les résultats par type de structure, type de prestation, territoire, labels, etc. Cette restriction n'est pas justifiée fonctionnellement : les données affichées sont publiques.

## Comment tester ?

1. Ouvrir `/prestataires/` **sans être connecté**
2. Vérifier que le bouton **"Recherche avancée"** est visible
3. Cliquer dessus → les filtres s'ouvrent (sans redirection ni modale de connexion)
4. Sélectionner un type de structure (ex : EI) → lancer la recherche
5. Vérifier que les résultats sont bien filtrés
6. Tester avec une URL préfiltrée (ex : `/prestataires/?kind=EI`) → fonctionne sans connexion
7. Se connecter → vérifier que le comportement est identique à avant

## Comment ?

**3 changements :**

- `lemarche/www/siaes/views.py` — `get_filter_form()` : suppression de `advanced_search=user.is_authenticated`, le formulaire utilise désormais toujours la valeur par défaut `advanced_search=True`
- `lemarche/templates/siaes/search_results.html` — suppression de la condition `{% if not user.is_authenticated %}` qui ajoutait les attributs `data-fr-opened` / `aria-controls` ouvrant la modale de login
- Suppression de l'include `auth/_login_or_signup_search_advanced_modal.html` (devenu dead code)

**Tests :**
- Ajout de `SiaeAdvancedSearchAnonymousTest` : vérifie qu'un visiteur anonyme peut filtrer par `kind` et obtenir les résultats corrects

## Autre

- Aucune donnée sensible exposée : tous les filtres avancés portent sur des critères de recherche publics (type de structure, prestation, territoire, labels…)
- Les fonctionnalités réservées aux connectés (contacter une structure, sauvegarder une recherche, publier un besoin) ne sont pas affectées