### PR TITLE
feat: super badge — taux d'engagement (contact + pas intéressé)

### DIFF
--- a/lemarche/siaes/management/commands/update_siae_count_fields.py
+++ b/lemarche/siaes/management/commands/update_siae_count_fields.py
@@ -74,6 +74,7 @@ class Command(BaseCommand):
                 siae.tender_email_link_click_count = siae.tender_email_link_click_count_annotated
                 siae.tender_detail_display_count = siae.tender_detail_display_count_annotated
                 siae.tender_detail_contact_click_count = siae.tender_detail_contact_click_count_annotated
+                siae.tender_detail_not_interested_count = siae.tender_detail_not_interested_count_annotated
 
             Siae.objects.bulk_update(siaes, update_fields)
             batch_count += 1

--- a/lemarche/siaes/migrations/0007_siae_tender_detail_not_interested_count.py
+++ b/lemarche/siaes/migrations/0007_siae_tender_detail_not_interested_count.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("siaes", "0006_siae_decp_details_last_sync_date"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="siae",
+            name="tender_detail_not_interested_count",
+            field=models.IntegerField(
+                default=0,
+                help_text="Champ recalculé automatiquement.",
+                verbose_name="Nombre de besoins refusés",
+            ),
+        ),
+    ]

--- a/lemarche/siaes/migrations/0007_siae_tender_detail_not_interested_count.py
+++ b/lemarche/siaes/migrations/0007_siae_tender_detail_not_interested_count.py
@@ -8,11 +8,20 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
+            model_name="historicalsiae",
+            name="tender_detail_not_interested_count",
+            field=models.IntegerField(
+                default=0,
+                help_text="Champ recalculé à intervalles réguliers",
+                verbose_name="Nombre de besoins refusés",
+            ),
+        ),
+        migrations.AddField(
             model_name="siae",
             name="tender_detail_not_interested_count",
             field=models.IntegerField(
                 default=0,
-                help_text="Champ recalculé automatiquement.",
+                help_text="Champ recalculé à intervalles réguliers",
                 verbose_name="Nombre de besoins refusés",
             ),
         ),

--- a/lemarche/siaes/models.py
+++ b/lemarche/siaes/models.py
@@ -636,6 +636,7 @@ class Siae(NexusModelMixin, models.Model):
         "tender_email_link_click_count",
         "tender_detail_display_count",
         "tender_detail_contact_click_count",
+        "tender_detail_not_interested_count",
     ]
     FIELDS_STATS_TIMESTAMPS = ["signup_date", "content_filled_basic_date", "created_at", "updated_at"]
     FIELDS_STATS = FIELDS_STATS_COUNT + FIELDS_STATS_TIMESTAMPS + ["super_badge", "completion_rate"]
@@ -901,6 +902,9 @@ class Siae(NexusModelMixin, models.Model):
     )
     tender_detail_contact_click_count = models.IntegerField(
         "Nombre de besoins intéressés", help_text=RECALCULATED_FIELD_HELP_TEXT, default=0
+    )
+    tender_detail_not_interested_count = models.IntegerField(
+        "Nombre de besoins refusés", help_text=RECALCULATED_FIELD_HELP_TEXT, default=0
     )
     logs = models.JSONField(verbose_name="Logs historiques", editable=False, default=list)
     recipient_transactional_send_logs = GenericRelation(
@@ -1180,8 +1184,13 @@ class Siae(NexusModelMixin, models.Model):
             and (self.tender_email_send_count >= 1)
         ):
             tender_view_rate = round(100 * self.tender_email_link_click_count / self.tender_email_send_count)
-            tender_interested_rate = round(100 * self.tender_detail_contact_click_count / self.tender_email_send_count)
-            if (tender_view_rate >= 40) or (tender_interested_rate >= 20):
+            # Engagement = prise de contact OU refus explicite (les deux montrent que la structure est active)
+            tender_engagement_rate = round(
+                100
+                * (self.tender_detail_contact_click_count + self.tender_detail_not_interested_count)
+                / self.tender_email_send_count
+            )
+            if (tender_view_rate >= 40) or (tender_engagement_rate >= 20):
                 return True
         return False
 

--- a/lemarche/templates/includes/_super_badge.html
+++ b/lemarche/templates/includes/_super_badge.html
@@ -8,9 +8,15 @@
     {% endif %}
     {% if siae.super_badge %}
         <span class="fr-tag lemarche-super-badge"
-              title="Les Super prestataires sont des structures particulièrement actives sur le Marché de l'inclusion : leur fiche commerciale est complète, et elles répondent régulièrement aux besoins d'achat, que ce soit en prenant contact avec l'acheteur ou en signalant leur indisponibilité.">
+              aria-describedby="tooltip-super-badge-{{ siae.pk }}">
             <span class="fr-icon-award-fill" aria-hidden="true"></span>
             Super prestataire
+        </span>
+        <span class="fr-tooltip fr-placement"
+              id="tooltip-super-badge-{{ siae.pk }}"
+              role="tooltip"
+              aria-hidden="true">
+            Les Super prestataires sont des structures particulièrement actives sur le Marché de l'inclusion : leur fiche commerciale est complète, et elles répondent régulièrement aux besoins d'achat, que ce soit en prenant contact avec l'acheteur ou en signalant leur indisponibilité.
         </span>
     {% endif %}
 </span>

--- a/lemarche/templates/includes/_super_badge.html
+++ b/lemarche/templates/includes/_super_badge.html
@@ -7,7 +7,8 @@
         </span>
     {% endif %}
     {% if siae.super_badge %}
-        <span class="fr-tag lemarche-super-badge">
+        <span class="fr-tag lemarche-super-badge"
+              title="Les Super prestataires sont des structures particulièrement actives sur le Marché de l'inclusion : leur fiche commerciale est complète, et elles répondent régulièrement aux besoins d'achat, que ce soit en prenant contact avec l'acheteur ou en signalant leur indisponibilité.">
             <span class="fr-icon-award-fill" aria-hidden="true"></span>
             Super prestataire
         </span>

--- a/tests/nexus/__snapshots__/tests_management_commands.ambr
+++ b/tests/nexus/__snapshots__/tests_management_commands.ambr
@@ -101,6 +101,7 @@
                  "siaes_siae"."tender_email_link_click_count",
                  "siaes_siae"."tender_detail_display_count",
                  "siaes_siae"."tender_detail_contact_click_count",
+                 "siaes_siae"."tender_detail_not_interested_count",
                  "siaes_siae"."logs",
                  "siaes_siae"."source",
                  "siaes_siae"."extra_data",

--- a/tests/siaes/test_models.py
+++ b/tests/siaes/test_models.py
@@ -207,9 +207,27 @@ class SiaeModelTest(TestCase):
             tender_email_link_click_count=3,
             tender_detail_contact_click_count=3,
         )
+        # Engagement via "pas intéressé" uniquement (2 refus / 10 = 20%)
+        siae_super_badge_3 = SiaeFactory(
+            user_count=1,
+            completion_rate=80,
+            tender_email_send_count=10,
+            tender_email_link_click_count=0,
+            tender_detail_contact_click_count=0,
+            tender_detail_not_interested_count=2,
+        )
+        # Engagement mixte : 1 contact + 1 refus = 20%
+        siae_super_badge_4 = SiaeFactory(
+            user_count=1,
+            completion_rate=80,
+            tender_email_send_count=10,
+            tender_email_link_click_count=0,
+            tender_detail_contact_click_count=1,
+            tender_detail_not_interested_count=1,
+        )
         for siae in [siae_1, siae_2, siae_3, siae_4]:
             self.assertFalse(siae.super_badge_calculated)
-        for siae in [siae_super_badge_1, siae_super_badge_2]:
+        for siae in [siae_super_badge_1, siae_super_badge_2, siae_super_badge_3, siae_super_badge_4]:
             self.assertTrue(siae.super_badge_calculated)
 
 


### PR DESCRIPTION
## Quoi ?

Évolution du calcul du badge "Super prestataire" : le taux d'engagement prend désormais en compte les clics "Je ne suis pas intéressé" en plus des prises de contact.

## Pourquoi ?

Aujourd'hui, seules les structures qui cliquent sur "Accéder aux coordonnées" contribuent au taux d'engagement. Or une structure qui répond systématiquement "Je ne suis pas intéressé" montre elle aussi qu'elle est active et attentive aux sollicitations — ce qui a de la valeur pour la plateforme.

## Comment tester ?

Le calcul est automatique (commande cron `update_siae_super_badge_field`). Pour vérifier manuellement :
- Ouvrir une structure dans l'admin
- Vérifier les champs `tender_detail_contact_click_count` et `tender_detail_not_interested_count`
- La somme des deux divisée par `tender_email_send_count` doit atteindre 20 % pour valider cette condition du badge

## Comment ?

**Nouvelle logique :**
```
taux_engagement = (contact_clicks + not_interested_clicks) / emails_envoyés ≥ 20 %
```
Remplace : `contact_clicks / emails_envoyés ≥ 20 %`

Les deux autres conditions du badge restent inchangées :
- Taux de clic email ≥ 40 % (ouverture des emails)
- Fiche complète ≥ 80 % + au moins 1 utilisateur + au moins 1 besoin reçu

**Fichiers modifiés :**
- `siaes/models.py` : nouveau champ `tender_detail_not_interested_count` + `FIELDS_STATS_COUNT` + `super_badge_calculated`
- `siaes/migrations/0007_...` : migration du nouveau champ
- `update_siae_count_fields.py` : alimente le nouveau champ depuis l'annotation existante
- `tests/siaes/test_models.py` : 2 nouveaux cas de test

## Autre

Le champ `tender_detail_not_interested_count_annotated` existait déjà sur le queryset — seul le stockage en base était manquant.