### PR TITLE
fix(admin): autoriser le filtre detail_groupement_click_date dans SiaeAdmin

### DIFF
--- a/lemarche/siaes/admin.py
+++ b/lemarche/siaes/admin.py
@@ -513,6 +513,7 @@ class SiaeAdmin(FieldsetsInlineMixin, gis_admin.GISModelAdmin, SimpleHistoryAdmi
             "tendersiae__detail_display_date__isnull",
             "tendersiae__detail_contact_click_date__isnull",
             "tendersiae__detail_not_interested_click_date__isnull",
+            "tendersiae__detail_groupement_click_date__isnull",
             "tendersiae__source__in",
         ]:
             return True


### PR DESCRIPTION
## Quoi ?

Ajout de `tendersiae__detail_groupement_click_date__isnull` dans la méthode `lookup_allowed` de `SiaeAdmin`.

## Pourquoi ?

Depuis le merge de #2052 (groupement/cotraitance), le lien cliquable **"S. groupement"** dans l'admin des besoins d'achat renvoie une erreur **400 Bad Request**.

Django admin rejette les paramètres de filtre URL non déclarés dans `lookup_allowed`. Les autres champs similaires (`email_send_date`, `detail_contact_click_date`, etc.) étaient déjà dans la liste, mais le nouveau champ `detail_groupement_click_date` avait été oublié.

## Comment tester ?

1. Se connecter à l'admin Django
2. Ouvrir un besoin d'achat avec au moins une structure ayant cliqué sur "Répondre en groupement"
3. Cliquer sur le chiffre dans la colonne **"S. groupement"**
4. Vérifier que la liste des structures s'affiche (plus de 400 Bad Request)

## Comment ?

1 ligne ajoutée dans `SiaeAdmin.lookup_allowed` — alignement avec les autres filtres `tendersiae__*` existants.
