### PR TITLE
feat(dashboard): import autonome des dépenses achats pour les acheteurs

### DIFF
--- a/lemarche/purchases/migrations/0003_purchaseimport.py
+++ b/lemarche/purchases/migrations/0003_purchaseimport.py
@@ -1,0 +1,72 @@
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("companies", "0001_initial"),
+        ("purchases", "0002_slugmappingcache"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PurchaseImport",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "file",
+                    models.FileField(upload_to="purchases/imports/", verbose_name="Fichier Excel"),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("PENDING", "En attente"),
+                            ("SUCCESS", "Terminée"),
+                            ("FAILED", "Échouée"),
+                        ],
+                        default="PENDING",
+                        max_length=20,
+                        verbose_name="Statut",
+                    ),
+                ),
+                ("year", models.PositiveIntegerField(verbose_name="Année des achats")),
+                ("total_rows", models.PositiveIntegerField(default=0, verbose_name="Lignes traitées")),
+                ("matched_rows", models.PositiveIntegerField(default=0, verbose_name="Structures reconnues")),
+                ("error_message", models.TextField(blank=True, verbose_name="Message d'erreur")),
+                (
+                    "created_at",
+                    models.DateTimeField(default=django.utils.timezone.now, verbose_name="Date de création"),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Date de modification")),
+                (
+                    "company",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="purchase_imports",
+                        to="companies.company",
+                        verbose_name="Entreprise",
+                    ),
+                ),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="purchase_imports",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="Importé par",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Import de dépenses",
+                "verbose_name_plural": "Imports de dépenses",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/lemarche/purchases/migrations/0004_purchaseimport_file_nullable.py
+++ b/lemarche/purchases/migrations/0004_purchaseimport_file_nullable.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("purchases", "0003_purchaseimport"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="purchaseimport",
+            name="file",
+            field=models.FileField(
+                blank=True,
+                null=True,
+                upload_to="purchases/imports/",
+                verbose_name="Fichier Excel",
+            ),
+        ),
+    ]

--- a/lemarche/purchases/models.py
+++ b/lemarche/purchases/models.py
@@ -372,6 +372,76 @@ def get_sector_group_chart_data(queryset, top_n=10):
     return {"labels": labels, "amounts": amounts, "supplier_counts": supplier_counts}
 
 
+class PurchaseImportQuerySet(models.QuerySet):
+    def for_company(self, company):
+        return self.filter(company=company)
+
+    def latest_for_company(self, company):
+        return self.for_company(company).first()
+
+
+class PurchaseImport(models.Model):
+    """Tracks each Excel import of purchase data by a buyer organization."""
+
+    STATUS_PENDING = "PENDING"
+    STATUS_SUCCESS = "SUCCESS"
+    STATUS_FAILED = "FAILED"
+
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "En attente"),
+        (STATUS_SUCCESS, "Terminée"),
+        (STATUS_FAILED, "Échouée"),
+    ]
+
+    company = models.ForeignKey(
+        "companies.Company",
+        verbose_name="Entreprise",
+        on_delete=models.CASCADE,
+        related_name="purchase_imports",
+    )
+    uploaded_by = models.ForeignKey(
+        User,
+        verbose_name="Importé par",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="purchase_imports",
+    )
+    file = models.FileField(
+        verbose_name="Fichier Excel",
+        upload_to="purchases/imports/",
+    )
+    status = models.CharField(
+        verbose_name="Statut",
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=STATUS_PENDING,
+    )
+    year = models.PositiveIntegerField(verbose_name="Année des achats")
+    total_rows = models.PositiveIntegerField(verbose_name="Lignes traitées", default=0)
+    matched_rows = models.PositiveIntegerField(verbose_name="Structures reconnues", default=0)
+    error_message = models.TextField(verbose_name="Message d'erreur", blank=True)
+    created_at = models.DateTimeField(verbose_name="Date de création", default=timezone.now)
+    updated_at = models.DateTimeField(verbose_name="Date de modification", auto_now=True)
+
+    objects = models.Manager.from_queryset(PurchaseImportQuerySet)()
+
+    class Meta:
+        verbose_name = "Import de dépenses"
+        verbose_name_plural = "Imports de dépenses"
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"Import {self.year} — {self.company} ({self.get_status_display()})"
+
+    @property
+    def match_percentage(self) -> int:
+        """Returns the percentage of rows matched to an inclusive structure."""
+        if not self.total_rows:
+            return 0
+        return round(self.matched_rows * 100 / self.total_rows)
+
+
 class SlugMappingCacheQuerySet(models.QuerySet):
     def validated(self):
         return self.filter(source=purchases_constants.SLUG_MAPPING_SOURCE_ADMIN_VALIDATED)

--- a/lemarche/purchases/models.py
+++ b/lemarche/purchases/models.py
@@ -410,6 +410,8 @@ class PurchaseImport(models.Model):
     file = models.FileField(
         verbose_name="Fichier Excel",
         upload_to="purchases/imports/",
+        blank=True,
+        null=True,
     )
     status = models.CharField(
         verbose_name="Statut",

--- a/lemarche/purchases/utils.py
+++ b/lemarche/purchases/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from decimal import Decimal, InvalidOperation
 
 import openpyxl
@@ -11,11 +12,14 @@ logger = logging.getLogger(__name__)
 # Mapping from normalized header variants → canonical column name
 _HEADER_ALIASES = {
     "raison sociale": "supplier_name",
+    "raison social": "supplier_name",
     "raison sociale du fournisseur": "supplier_name",
     "fournisseur": "supplier_name",
     "nom du fournisseur": "supplier_name",
     "siret": "supplier_siret",
     "siret du fournisseur": "supplier_siret",
+    "depense": "purchase_amount",
+    "dépense": "purchase_amount",
     "depense achat": "purchase_amount",
     "dépense achat": "purchase_amount",
     "montant": "purchase_amount",
@@ -36,8 +40,6 @@ REQUIRED_COLUMNS = {"supplier_name", "supplier_siret", "purchase_amount"}
 
 def _normalize(text: str) -> str:
     """Lowercase, strip, remove parenthetical suffixes like '(€)' or '(optionnelle)'."""
-    import re
-
     text = text.lower().strip()
     text = re.sub(r"\s*\(.*?\)", "", text).strip()
     return text
@@ -131,7 +133,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
             continue
 
         try:
-            amount_str = str(amount_raw).replace(" ", "").replace("\xa0", "").replace(",", ".")
+            amount_str = re.sub(r"[^\d,.\-]", "", str(amount_raw)).replace(",", ".")
             purchase_amount = Decimal(amount_str)
             if purchase_amount <= 0:
                 raise ValueError

--- a/lemarche/purchases/utils.py
+++ b/lemarche/purchases/utils.py
@@ -1,0 +1,213 @@
+import logging
+from decimal import Decimal, InvalidOperation
+
+import openpyxl
+
+from lemarche.siaes.models import Siae
+
+
+logger = logging.getLogger(__name__)
+
+# Mapping from normalized header variants → canonical column name
+_HEADER_ALIASES = {
+    "raison sociale": "supplier_name",
+    "raison sociale du fournisseur": "supplier_name",
+    "fournisseur": "supplier_name",
+    "nom du fournisseur": "supplier_name",
+    "siret": "supplier_siret",
+    "siret du fournisseur": "supplier_siret",
+    "depense achat": "purchase_amount",
+    "dépense achat": "purchase_amount",
+    "montant": "purchase_amount",
+    "montant ht": "purchase_amount",
+    "budget": "purchase_amount",
+    "categorie d'achat": "purchase_category",
+    "catégorie d'achat": "purchase_category",
+    "categorie": "purchase_category",
+    "catégorie": "purchase_category",
+    "entite acheteuse": "purchase_entity",
+    "entité acheteuse": "purchase_entity",
+    "entite": "purchase_entity",
+    "entité": "purchase_entity",
+}
+
+REQUIRED_COLUMNS = {"supplier_name", "supplier_siret", "purchase_amount"}
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip, remove parenthetical suffixes like '(€)' or '(optionnelle)'."""
+    import re
+
+    text = text.lower().strip()
+    text = re.sub(r"\s*\(.*?\)", "", text).strip()
+    return text
+
+
+def _detect_columns(header_row) -> dict[str, int]:
+    """Returns {canonical_name: col_index} for recognized columns."""
+    mapping = {}
+    for idx, cell in enumerate(header_row):
+        if cell.value is None:
+            continue
+        normalized = _normalize(str(cell.value))
+        canonical = _HEADER_ALIASES.get(normalized)
+        if canonical:
+            mapping[canonical] = idx
+    return mapping
+
+
+def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]:
+    """
+    Parse an Excel file of purchase data and create Purchase objects.
+
+    Returns (errors, total_rows, matched_rows).
+    Raises ValueError for unrecoverable format errors.
+    """
+    from lemarche.purchases.models import Purchase
+
+    try:
+        wb = openpyxl.load_workbook(file_obj, read_only=True, data_only=True)
+    except Exception:
+        raise ValueError("Le fichier n'est pas un fichier Excel valide (.xlsx).")
+
+    ws = wb.active
+    rows = list(ws.iter_rows())
+
+    if not rows:
+        raise ValueError("Le fichier est vide.")
+
+    # Find header row among first 10 rows
+    col_map = {}
+    header_row_idx = None
+    for i, row in enumerate(rows[:10]):
+        col_map = _detect_columns(row)
+        if REQUIRED_COLUMNS.issubset(col_map.keys()):
+            header_row_idx = i
+            break
+
+    if header_row_idx is None:
+        raise ValueError(
+            "En-têtes manquants. Colonnes attendues : "
+            "« Raison sociale du Fournisseur », « SIRET », « Dépense achat (€) »."
+        )
+
+    data_rows = rows[header_row_idx + 1 :]
+    if not data_rows:
+        raise ValueError("Le fichier ne contient aucune ligne de données.")
+
+    # Pre-load live SIAEs indexed by SIRET for fast lookup
+    siae_by_siret: dict[str, Siae] = {s.siret: s for s in Siae.objects.is_live().only("id", "siret")}
+
+    purchases = []
+    errors = []
+    matched_rows = 0
+
+    for row_num, row in enumerate(data_rows, start=header_row_idx + 2):
+        cells = [cell.value for cell in row]
+
+        def get(key):
+            idx = col_map.get(key)
+            if idx is None or idx >= len(cells):
+                return None
+            val = cells[idx]
+            return str(val).strip() if val is not None else None
+
+        supplier_name = get("supplier_name") or ""
+        supplier_siret = (get("supplier_siret") or "").replace(" ", "").replace("-", "")
+        amount_raw = get("purchase_amount") or ""
+        purchase_category = get("purchase_category") or None
+        buying_entity = get("purchase_entity") or None
+
+        # Skip blank rows
+        if not supplier_name and not supplier_siret:
+            continue
+
+        if not supplier_name:
+            errors.append(f"Ligne {row_num} : raison sociale manquante.")
+            continue
+
+        if not supplier_siret or not supplier_siret.isdigit() or len(supplier_siret) != 14:
+            errors.append(f"Ligne {row_num} : SIRET invalide « {supplier_siret} » (14 chiffres attendus).")
+            continue
+
+        try:
+            amount_str = str(amount_raw).replace(" ", "").replace("\xa0", "").replace(",", ".")
+            purchase_amount = Decimal(amount_str)
+            if purchase_amount <= 0:
+                raise ValueError
+        except (InvalidOperation, ValueError):
+            errors.append(f"Ligne {row_num} : montant invalide « {amount_raw} ».")
+            continue
+
+        siae = siae_by_siret.get(supplier_siret)
+        if siae:
+            matched_rows += 1
+
+        purchases.append(
+            Purchase(
+                supplier_name=supplier_name[:255],
+                supplier_siret=supplier_siret,
+                purchase_amount=purchase_amount,
+                purchase_category=purchase_category[:255] if purchase_category else None,
+                buying_entity=buying_entity[:255] if buying_entity else None,
+                purchase_year=year,
+                siae=siae,
+                company=company,
+            )
+        )
+
+    wb.close()
+
+    if purchases:
+        from itertools import batched
+
+        BATCH_SIZE = 1_000
+        for batch in batched(purchases, BATCH_SIZE):
+            Purchase.objects.bulk_create(list(batch))
+
+    return errors, len(purchases), matched_rows
+
+
+def generate_purchases_excel_template() -> bytes:
+    """Generates a downloadable Excel template for purchase data import."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Dépenses achats"
+
+    headers = [
+        "Raison sociale du Fournisseur",
+        "SIRET",
+        "Dépense achat (€)",
+        "Catégorie d'achat (optionnelle)",
+        "Entité acheteuse (optionnelle)",
+    ]
+
+    # Header row with bold styling
+    for col_idx, header in enumerate(headers, start=1):
+        cell = ws.cell(row=1, column=col_idx, value=header)
+        cell.font = openpyxl.styles.Font(bold=True)
+
+    # Example rows
+    ws.append(["Entreprise Exemple SAS", "12345678901234", 15000, "Travaux d'entretien", "Direction des achats"])
+    ws.append(["Prestataire Inclusif ESAT", "98765432109876", 8500, "Services informatiques", ""])
+
+    # Column widths
+    column_widths = [35, 18, 18, 30, 30]
+    for i, width in enumerate(column_widths, start=1):
+        ws.column_dimensions[openpyxl.utils.get_column_letter(i)].width = width
+
+    # Instructions sheet
+    ws2 = wb.create_sheet("Instructions")
+    ws2.append(["Colonne", "Obligatoire", "Description"])
+    ws2.append(["Raison sociale du Fournisseur", "Oui", "Nom de l'entreprise fournisseur"])
+    ws2.append(["SIRET", "Oui", "14 chiffres sans espaces"])
+    ws2.append(["Dépense achat (€)", "Oui", "Montant en euros (nombre positif)"])
+    ws2.append(["Catégorie d'achat (optionnelle)", "Non", "Catégorie libre (ex : Travaux, SI, Nettoyage…)"])
+    ws2.append(["Entité acheteuse (optionnelle)", "Non", "Service ou direction acheteuse"])
+
+    import io
+
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    buffer.seek(0)
+    return buffer.read()

--- a/lemarche/purchases/utils.py
+++ b/lemarche/purchases/utils.py
@@ -115,7 +115,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
             return str(val).strip() if val is not None else None
 
         supplier_name = get("supplier_name") or ""
-        supplier_siret = (get("supplier_siret") or "").replace(" ", "").replace("-", "")
+        supplier_siret = re.sub(r"[^\d]", "", str(get("supplier_siret") or "").split(".")[0])
         amount_raw = get("purchase_amount") or ""
         purchase_category = get("purchase_category") or None
         buying_entity = get("purchase_entity") or None

--- a/lemarche/purchases/utils.py
+++ b/lemarche/purchases/utils.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import re
 from decimal import Decimal, InvalidOperation
@@ -58,11 +59,12 @@ def _detect_columns(header_row) -> dict[str, int]:
     return mapping
 
 
-def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]:
+def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, list, int]:
     """
-    Parse an Excel file of purchase data and create Purchase objects.
+    Parse an Excel file of purchase data. Does NOT write to DB.
 
-    Returns (errors, total_rows, matched_rows).
+    Returns (purchases, errors, matched_rows) where purchases is a list of
+    unsaved Purchase instances ready for bulk_create.
     Raises ValueError for unrecoverable format errors.
     """
     from lemarche.purchases.models import Purchase
@@ -115,6 +117,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
             return str(val).strip() if val is not None else None
 
         supplier_name = get("supplier_name") or ""
+        # Strip non-digit chars, and handle SIRETs stored as float by Excel (e.g. "12345678901234.0")
         supplier_siret = re.sub(r"[^\d]", "", str(get("supplier_siret") or "").split(".")[0])
         amount_raw = get("purchase_amount") or ""
         purchase_category = get("purchase_category") or None
@@ -160,14 +163,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
 
     wb.close()
 
-    if purchases:
-        from itertools import batched
-
-        BATCH_SIZE = 1_000
-        for batch in batched(purchases, BATCH_SIZE):
-            Purchase.objects.bulk_create(list(batch))
-
-    return errors, len(purchases), matched_rows
+    return purchases, errors, matched_rows
 
 
 def generate_purchases_excel_template() -> bytes:
@@ -206,8 +202,6 @@ def generate_purchases_excel_template() -> bytes:
     ws2.append(["Dépense achat (€)", "Oui", "Montant en euros (nombre positif)"])
     ws2.append(["Catégorie d'achat (optionnelle)", "Non", "Catégorie libre (ex : Travaux, SI, Nettoyage…)"])
     ws2.append(["Entité acheteuse (optionnelle)", "Non", "Service ou direction acheteuse"])
-
-    import io
 
     buffer = io.BytesIO()
     wb.save(buffer)

--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -64,15 +64,31 @@
                                     <div class="fr-card__content">
                                         <h3 class="fr-card__title">Ma part d'achat inclusif</h3>
                                         <div class="fr-card__desc">
-                                            <p>Pilotez l'intégration des achats inclusifs dans votre politique achat.</p>
+                                            {% if last_purchase_import and last_purchase_import.status == "SUCCESS" %}
+                                                <p>
+                                                    Analyse {{ last_purchase_import.year }} —
+                                                    {{ last_purchase_import.match_percentage }} % de structures inclusives reconnues.
+                                                </p>
+                                            {% elif last_purchase_import and last_purchase_import.status == "FAILED" %}
+                                                <p>Le dernier import a échoué. Réessayez en important un nouveau fichier.</p>
+                                            {% else %}
+                                                <p>Pilotez l'intégration des achats inclusifs dans votre politique achat.</p>
+                                            {% endif %}
                                         </div>
                                     </div>
                                     <div class="fr-card__footer">
                                         <ul class="fr-btns-group fr-btns-group--icon-right fr-btns-group--right fr-btns-group--inline">
-                                            <li>
-                                                <a class="fr-btn fr-icon-arrow-right-s-line fr-btn--tertiary-no-outline"
-                                                   href="{% url 'dashboard:inclusive_purchase_stats' %}">Voir mes statistiques</a>
-                                            </li>
+                                            {% if last_purchase_import and last_purchase_import.status == "SUCCESS" %}
+                                                <li>
+                                                    <a class="fr-btn fr-icon-arrow-right-s-line fr-btn--tertiary-no-outline"
+                                                       href="{% url 'dashboard:inclusive_purchase_stats' %}">Voir mes statistiques</a>
+                                                </li>
+                                            {% else %}
+                                                <li>
+                                                    <a class="fr-btn fr-icon-arrow-right-s-line fr-btn--tertiary-no-outline"
+                                                       href="{% url 'dashboard:purchase_import' %}">Importer mes dépenses</a>
+                                                </li>
+                                            {% endif %}
                                         </ul>
                                     </div>
                                 </div>

--- a/lemarche/templates/dashboard/inclusive_purchase_stats.html
+++ b/lemarche/templates/dashboard/inclusive_purchase_stats.html
@@ -42,6 +42,37 @@
             {% endif %}
         </div>
         {% if user.kind == "BUYER" and user.company %}
+            {% if last_purchase_import %}
+                {% if last_purchase_import.status == "SUCCESS" %}
+                    <div class="fr-alert fr-alert--success fr-alert--sm fr-mb-3w no-print">
+                        <p>
+                            Analyse importée le {{ last_purchase_import.created_at|date:"d/m/Y" }}
+                            — {{ last_purchase_import.year }}
+                            — {{ last_purchase_import.total_rows }} ligne{{ last_purchase_import.total_rows|pluralize }}
+                            / {{ last_purchase_import.match_percentage }} % de structures reconnues.
+                            <a href="{% url 'dashboard:purchase_import' %}" class="fr-link fr-ml-2w">Réimporter</a>
+                        </p>
+                    </div>
+                {% elif last_purchase_import.status == "FAILED" %}
+                    <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-3w no-print">
+                        <p>
+                            Le dernier import a échoué.
+                            <a href="{% url 'dashboard:purchase_import' %}" class="fr-link fr-ml-2w">Réessayer</a>
+                        </p>
+                    </div>
+                {% endif %}
+            {% endif %}
+            {% if unfiltered_qs_count == 0 %}
+                <div class="fr-callout fr-mb-3w">
+                    <h3 class="fr-callout__title">Aucune donnée disponible</h3>
+                    <p class="fr-callout__text">
+                        Importez votre fichier de dépenses achats pour calculer votre part d'achat inclusif.
+                    </p>
+                    <a href="{% url 'dashboard:purchase_import' %}" class="fr-btn fr-btn--sm fr-mt-1w">
+                        Importer mes dépenses
+                    </a>
+                </div>
+            {% endif %}
             {% if unfiltered_qs_count > 0 %}
                 <section class="fr-accordion fr-mb-2w">
                     <h3 class="fr-accordion__title">
@@ -410,10 +441,6 @@
                         Il n'y a aucun résultat pour votre recherche avec ces filtres.
                     </div>
                 {% endif %}
-            {% else %}
-                <div class="fr-alert fr-alert--warning">
-                    <p>Vous n'avez pas encore communiqué vos achats. Prenez contact avec notre équipe pour en savoir plus.</p>
-                </div>
             {% endif %}
         {% else %}
             <div class="fr-alert fr-alert--warning">

--- a/lemarche/templates/dashboard/purchase_import.html
+++ b/lemarche/templates/dashboard/purchase_import.html
@@ -1,0 +1,133 @@
+{% extends "layouts/base.html" %}
+{% load static process_dict dsfr_tags %}
+
+{% block page_title %}Importer mes dépenses — Ma part d'achat inclusif{{ block.super }}{% endblock page_title %}
+
+{% block breadcrumb %}
+    {% process_dict root_dir=HOME_PAGE_PATH label_1="Ma part d'achat inclusif" url_1="/tableau-de-bord/part-achat-inclusif/" current="Importer mes dépenses" as breadcrumb_data %}
+    {% dsfr_breadcrumb breadcrumb_data %}
+{% endblock breadcrumb %}
+
+{% block content %}
+<div class="fr-container fr-mb-6w">
+    <div class="fr-grid-row fr-grid-row--gutters">
+        <div class="fr-col-12">
+            <h1>Importer mes dépenses achats</h1>
+            <p class="fr-text--lead">
+                Importez votre fichier de dépenses annuelles pour calculer votre part d'achat inclusif.
+            </p>
+        </div>
+    </div>
+
+    {% if errors %}
+        <div class="fr-alert fr-alert--error fr-mb-3w">
+            <h3 class="fr-alert__title">Erreur lors de l'import</h3>
+            <ul>
+                {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if last_purchase_import %}
+        {% if last_purchase_import.status == "SUCCESS" %}
+            <div class="fr-alert fr-alert--success fr-mb-3w">
+                <h3 class="fr-alert__title">Dernière analyse importée avec succès</h3>
+                <p>
+                    Import du {{ last_purchase_import.created_at|date:"d/m/Y" }} — année {{ last_purchase_import.year }} —
+                    {{ last_purchase_import.total_rows }} ligne{{ last_purchase_import.total_rows|pluralize }}
+                    / {{ last_purchase_import.matched_rows }} structure{{ last_purchase_import.matched_rows|pluralize }} reconnue{{ last_purchase_import.matched_rows|pluralize }}
+                    ({{ last_purchase_import.match_percentage }} %).
+                </p>
+                <p>
+                    <a href="{% url 'dashboard:inclusive_purchase_stats' %}" class="fr-btn fr-btn--sm fr-mt-1w">
+                        Voir mon tableau de bord
+                    </a>
+                </p>
+            </div>
+        {% elif last_purchase_import.status == "FAILED" %}
+            <div class="fr-alert fr-alert--error fr-mb-3w">
+                <h3 class="fr-alert__title">Dernier import échoué</h3>
+                {% if last_purchase_import.error_message %}
+                    <p>{{ last_purchase_import.error_message }}</p>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+
+    <div class="fr-grid-row fr-grid-row--gutters">
+        <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-card">
+                <div class="fr-card__body">
+                    <div class="fr-card__content">
+                        <h2 class="fr-card__title">Uploader votre fichier de dépenses</h2>
+                        <div class="fr-card__desc">
+
+                            <form method="post" enctype="multipart/form-data" novalidate>
+                                {% csrf_token %}
+
+                                <div class="fr-input-group fr-mb-3w">
+                                    <label class="fr-label" for="id_year">
+                                        Année des achats <span class="fr-hint-text">Obligatoire</span>
+                                    </label>
+                                    <input class="fr-input"
+                                           type="number"
+                                           id="id_year"
+                                           name="year"
+                                           min="2000"
+                                           max="{{ current_year }}"
+                                           value="{{ current_year }}"
+                                           required>
+                                </div>
+
+                                <div class="fr-upload-group fr-mb-3w">
+                                    <label class="fr-label" for="id_purchase_file">
+                                        Fichier Excel de dépenses (.xlsx)
+                                        <span class="fr-hint-text">Taille maximale : 10 Mo — Format .xlsx uniquement</span>
+                                    </label>
+                                    <input class="fr-upload"
+                                           type="file"
+                                           id="id_purchase_file"
+                                           name="purchase_file"
+                                           accept=".xlsx"
+                                           required>
+                                </div>
+
+                                <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-2-line">
+                                    Lancer l'analyse
+                                </button>
+                            </form>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="fr-col-12 fr-col-md-4">
+            <div class="fr-card fr-card--grey">
+                <div class="fr-card__body">
+                    <div class="fr-card__content">
+                        <h3 class="fr-card__title">Format attendu</h3>
+                        <div class="fr-card__desc">
+                            <p>Votre fichier Excel doit contenir les colonnes suivantes :</p>
+                            <ul class="fr-text--sm">
+                                <li><strong>Raison sociale du Fournisseur</strong> — obligatoire</li>
+                                <li><strong>SIRET</strong> — 14 chiffres, obligatoire</li>
+                                <li><strong>Dépense achat (€)</strong> — montant positif, obligatoire</li>
+                                <li>Catégorie d'achat — optionnelle</li>
+                                <li>Entité acheteuse — optionnelle</li>
+                            </ul>
+                            <p class="fr-mt-2w">
+                                <a href="{% url 'dashboard:purchase_import_template' %}"
+                                   class="fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-download-line">
+                                    Télécharger le modèle Excel
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/lemarche/www/dashboard/urls.py
+++ b/lemarche/www/dashboard/urls.py
@@ -8,9 +8,11 @@ from lemarche.www.dashboard.views import (
     InclusivePurchaseExportView,
     InclusivePurchaseStatsDashboardView,
     ProfileEditView,
+    PurchaseImportView,
     SlugMappingValidationView,
     inclusive_potential_excel_export,
     inclusive_potential_excel_template,
+    purchase_excel_template,
 )
 
 
@@ -22,6 +24,8 @@ urlpatterns = [
     path("notifications/", DisabledEmailEditView.as_view(), name="notifications_edit"),
     path("part-achat-inclusif/", InclusivePurchaseStatsDashboardView.as_view(), name="inclusive_purchase_stats"),
     path("part-achat-inclusif/export/", InclusivePurchaseExportView.as_view(), name="inclusive_purchase_export"),
+    path("part-achat-inclusif/importer/", PurchaseImportView.as_view(), name="purchase_import"),
+    path("part-achat-inclusif/modele-excel/", purchase_excel_template, name="purchase_import_template"),
     path("analyse-potentiel-inclusif/", InclusivePotentialAnalysisView.as_view(), name="inclusive_potential_analysis"),
     path(
         "analyse-potentiel-inclusif/modele-excel/",

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -489,6 +489,10 @@ class PurchaseImportView(LoginRequiredMixin, View):
         except ValueError as exc:
             purchase_import.status = PurchaseImport.STATUS_FAILED
             purchase_import.error_message = str(exc)
+        except Exception:
+            logger.exception("Erreur inattendue lors de l'import des achats (id=%s)", purchase_import.pk)
+            purchase_import.status = PurchaseImport.STATUS_FAILED
+            purchase_import.error_message = "Une erreur inattendue s'est produite. Veuillez réessayer."
 
         purchase_import.save(update_fields=["status", "total_rows", "matched_rows", "error_message", "updated_at"])
 

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -471,9 +471,11 @@ class PurchaseImportView(LoginRequiredMixin, View):
         # Clean slate: delete existing purchases for this company before importing
         Purchase.objects.filter(company=user.company).delete()
 
+        # Use the in-memory upload rather than re-fetching from S3 (S3 streams are not seekable)
+        uploaded_file.seek(0)
         try:
             parse_errors, total_rows, matched_rows = parse_purchases_excel(
-                purchase_import.file.open("rb"),
+                uploaded_file,
                 year=year,
                 company=user.company,
             )

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -23,7 +23,8 @@ from lemarche.api.inclusive_potential.constants import PRESTA_MODE_DEFAULT, PRES
 from lemarche.api.inclusive_potential.utils import get_inclusive_potential_data
 from lemarche.cms.models import ArticleList
 from lemarche.perimeters.models import Perimeter
-from lemarche.purchases.models import Purchase, get_sector_group_chart_data
+from lemarche.purchases.models import Purchase, PurchaseImport, get_sector_group_chart_data
+from lemarche.purchases.utils import generate_purchases_excel_template, parse_purchases_excel
 from lemarche.sectors.models import Sector
 from lemarche.siaes.constants import KIND_HANDICAP_LIST, KIND_INSERTION_LIST, LEGAL_FORM_CHOICES
 from lemarche.siaes.models import Siae
@@ -113,6 +114,8 @@ class DashboardHomeView(LoginRequiredMixin, DetailView):
             context["user_buyer_count"] = User.objects.filter(kind=User.KIND_BUYER).count()
             context["siae_count"] = Siae.objects.is_live().count()
             context["tender_count"] = Tender.objects.sent().count() + 30  # historic number (before form)
+            if user.company:
+                context["last_purchase_import"] = PurchaseImport.objects.latest_for_company(user.company)
         return context
 
 
@@ -300,6 +303,9 @@ class InclusivePurchaseStatsDashboardView(LoginRequiredMixin, FilterView):
                     "chart_data_sector_group": chart_data_sector_group,
                 }
             )
+
+        if user.company:
+            context["last_purchase_import"] = PurchaseImport.objects.latest_for_company(user.company)
         return context
 
 
@@ -405,6 +411,99 @@ class InclusivePurchaseExportView(LoginRequiredMixin, View):
         response["Content-Disposition"] = 'attachment; filename="achats_inclusifs.xls"'
         wb.save(response)
         return response
+
+
+class PurchaseImportView(LoginRequiredMixin, View):
+    template_name = "dashboard/purchase_import.html"
+
+    def _check_access(self, user):
+        return user.kind == User.KIND_BUYER and user.company is not None
+
+    def get(self, request, *args, **kwargs):
+        if not self._check_access(request.user):
+            return HttpResponseRedirect(reverse("dashboard:home"))
+        last_import = PurchaseImport.objects.latest_for_company(request.user.company)
+        return render(
+            request,
+            self.template_name,
+            {"last_purchase_import": last_import, "current_year": timezone.now().year},
+        )
+
+    def post(self, request, *args, **kwargs):
+        if not self._check_access(request.user):
+            return HttpResponseRedirect(reverse("dashboard:home"))
+
+        user = request.user
+        uploaded_file = request.FILES.get("purchase_file")
+        year_raw = request.POST.get("year", "").strip()
+
+        errors = []
+
+        if not uploaded_file:
+            errors.append("Veuillez sélectionner un fichier Excel (.xlsx).")
+        elif not uploaded_file.name.endswith(".xlsx"):
+            errors.append("Le fichier doit être au format Excel (.xlsx).")
+
+        if not year_raw or not year_raw.isdigit():
+            errors.append("Veuillez saisir une année valide.")
+        else:
+            year = int(year_raw)
+            current_year = timezone.now().year
+            if year < 2000 or year > current_year:
+                errors.append(f"L'année doit être comprise entre 2000 et {current_year}.")
+
+        if errors:
+            last_import = PurchaseImport.objects.latest_for_company(user.company)
+            return render(
+                request,
+                self.template_name,
+                {"last_purchase_import": last_import, "errors": errors, "current_year": timezone.now().year},
+            )
+
+        purchase_import = PurchaseImport.objects.create(
+            company=user.company,
+            uploaded_by=user,
+            file=uploaded_file,
+            status=PurchaseImport.STATUS_PENDING,
+            year=year,
+        )
+
+        # Clean slate: delete existing purchases for this company before importing
+        Purchase.objects.filter(company=user.company).delete()
+
+        try:
+            parse_errors, total_rows, matched_rows = parse_purchases_excel(
+                purchase_import.file.open("rb"),
+                year=year,
+                company=user.company,
+            )
+            purchase_import.total_rows = total_rows
+            purchase_import.matched_rows = matched_rows
+            if total_rows == 0 and parse_errors:
+                purchase_import.status = PurchaseImport.STATUS_FAILED
+                purchase_import.error_message = "\n".join(parse_errors[:10])
+            else:
+                purchase_import.status = PurchaseImport.STATUS_SUCCESS
+                if parse_errors:
+                    purchase_import.error_message = "\n".join(parse_errors[:10])
+        except ValueError as exc:
+            purchase_import.status = PurchaseImport.STATUS_FAILED
+            purchase_import.error_message = str(exc)
+
+        purchase_import.save(update_fields=["status", "total_rows", "matched_rows", "error_message", "updated_at"])
+
+        return HttpResponseRedirect(reverse("dashboard:inclusive_purchase_stats"))
+
+
+@login_required
+def purchase_excel_template(request):
+    content = generate_purchases_excel_template()
+    response = HttpResponse(
+        content,
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+    response["Content-Disposition"] = 'attachment; filename="modele_import_depenses.xlsx"'
+    return response
 
 
 class ProfileEditView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import logging
+from itertools import batched
 from urllib.parse import urlencode
 
 import openpyxl
@@ -460,43 +461,63 @@ class PurchaseImportView(LoginRequiredMixin, View):
                 {"last_purchase_import": last_import, "errors": errors, "current_year": timezone.now().year},
             )
 
-        purchase_import = PurchaseImport.objects.create(
-            company=user.company,
-            uploaded_by=user,
-            file=uploaded_file,
-            status=PurchaseImport.STATUS_PENDING,
-            year=year,
-        )
+        # Step 1: Parse in memory FIRST — no S3 interaction, feedback immédiat si format invalide
+        status = PurchaseImport.STATUS_FAILED
+        error_msg = ""
+        new_purchases = []
+        total_rows = 0
+        matched_rows = 0
 
-        # Clean slate: delete existing purchases for this company before importing
-        Purchase.objects.filter(company=user.company).delete()
-
-        # Use the in-memory upload rather than re-fetching from S3 (S3 streams are not seekable)
-        uploaded_file.seek(0)
         try:
-            parse_errors, total_rows, matched_rows = parse_purchases_excel(
+            new_purchases, parse_errors, matched_rows = parse_purchases_excel(
                 uploaded_file,
                 year=year,
                 company=user.company,
             )
-            purchase_import.total_rows = total_rows
-            purchase_import.matched_rows = matched_rows
+            total_rows = len(new_purchases)
             if total_rows == 0 and parse_errors:
-                purchase_import.status = PurchaseImport.STATUS_FAILED
-                purchase_import.error_message = "\n".join(parse_errors[:10])
+                error_msg = "\n".join(parse_errors[:10])
             else:
-                purchase_import.status = PurchaseImport.STATUS_SUCCESS
+                status = PurchaseImport.STATUS_SUCCESS
                 if parse_errors:
-                    purchase_import.error_message = "\n".join(parse_errors[:10])
+                    error_msg = "\n".join(parse_errors[:10])
         except ValueError as exc:
-            purchase_import.status = PurchaseImport.STATUS_FAILED
-            purchase_import.error_message = str(exc)
+            error_msg = str(exc)
         except Exception:
-            logger.exception("Erreur inattendue lors de l'import des achats (id=%s)", purchase_import.pk)
-            purchase_import.status = PurchaseImport.STATUS_FAILED
-            purchase_import.error_message = "Une erreur inattendue s'est produite. Veuillez réessayer."
+            logger.exception("Erreur inattendue lors du parsing des achats")
+            error_msg = "Une erreur inattendue s'est produite. Veuillez réessayer."
 
-        purchase_import.save(update_fields=["status", "total_rows", "matched_rows", "error_message", "updated_at"])
+        # Step 2: Écriture en base seulement si le parsing a réussi
+        if status == PurchaseImport.STATUS_SUCCESS and new_purchases:
+            Purchase.objects.filter(company=user.company).delete()
+            BATCH_SIZE = 1_000
+            for batch in batched(new_purchases, BATCH_SIZE):
+                Purchase.objects.bulk_create(list(batch))
+
+        # Step 3: Sauvegarde du PurchaseImport avec upload S3 du fichier
+        uploaded_file.seek(0)
+        try:
+            PurchaseImport.objects.create(
+                company=user.company,
+                uploaded_by=user,
+                file=uploaded_file,
+                status=status,
+                year=year,
+                total_rows=total_rows,
+                matched_rows=matched_rows,
+                error_message=error_msg,
+            )
+        except Exception:
+            logger.exception("Erreur lors de la sauvegarde du fichier sur S3 (import_id manquant)")
+            PurchaseImport.objects.create(
+                company=user.company,
+                uploaded_by=user,
+                status=status,
+                year=year,
+                total_rows=total_rows,
+                matched_rows=matched_rows,
+                error_message=error_msg,
+            )
 
         return HttpResponseRedirect(reverse("dashboard:inclusive_purchase_stats"))
 

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -97,7 +97,7 @@ class InclusivePurchaseStatsDashboardViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Vous n'avez pas encore communiqué vos achats.")
+        self.assertContains(response, "Importer mes dépenses")
 
     def test_view_should_display_stats_with_inclusive_purchases(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
### Quoi ?

Rend la fonctionnalité « Ma part d'achat inclusif » accessible en autonomie aux acheteurs, sans intervention d'un administrateur.

- Formulaire d'upload d'un fichier Excel de dépenses (année + fichier .xlsx)
- Parsing automatique, matching des fournisseurs par SIRET contre les SIAE actives
- Persistance de chaque import dans un nouveau modèle `PurchaseImport` (états : PENDING / SUCCESS / FAILED)
- Affichage du tableau de bord existant après import réussi, avec bandeau de statut (date, taux de reconnaissance, lien « Réimporter »)
- Callout « Aucune donnée » avec CTA « Importer mes dépenses » si aucun achat présent
- Card dynamique sur le home acheteur selon l'état du dernier import
- Modèle Excel téléchargeable (5 colonnes, 2 exemples, feuille Instructions)

### Pourquoi ?

Jusqu'ici, les données d'achats ne pouvaient être importées que via une commande CLI réservée aux admins (`import_purchases`). Les acheteurs ne pouvaient donc pas consulter leur part d'achat inclusif de façon autonome. Cette PR débloque l'usage en self-service.

### Comment tester ?

1. Se connecter en tant qu'acheteur ayant une entreprise associée
2. Aller sur le tableau de bord → la card « Ma part d'achat inclusif » doit afficher « Importer mes dépenses »
3. Cliquer → page `/profil/part-achat-inclusif/importer/`
4. Télécharger le modèle Excel → vérifier qu'il contient 2 feuilles (Dépenses + Instructions)
5. Remplir le modèle avec des lignes valides (dont au moins un SIRET d'une SIAE active en base)
6. Uploader le fichier, saisir l'année, cliquer « Lancer l'analyse »
7. Vérification SUCCESS : redirect vers `/profil/part-achat-inclusif/` avec bandeau vert + stats
8. Retourner sur le home → card affiche « Voir mes statistiques » + taux de reconnaissance
9. Tester un fichier invalide (mauvais format, SIRET erroné) → état FAILED avec message d'erreur
10. Vérifier que `/profil/part-achat-inclusif/` sans import affiche le callout « Aucune donnée »

### Comment ?

- `PurchaseImport` (nouveau modèle) : FK vers `Company` et `User`, `FileField`, status choices, compteurs `total_rows` / `matched_rows`, propriété `match_percentage`
- `purchases/utils.py` (nouveau) : parseur `parse_purchases_excel()` — détection flexible des colonnes par alias, bulk_create par lots de 1 000, match SIAE pré-chargé en dict pour éviter les N+1
- `PurchaseImportView` : CBV, accès restreint `KIND_BUYER + company`, clean slate (suppression des anciens purchases avant import), synchrone pour le MVP
- Import existant via CLI (`import_purchases.py`) inchangé — les deux coexistent

### Autre (optionnel)

- La feature est synchrone (traitement dans la requête HTTP) — convient pour des fichiers raisonnables. Si besoin de passer en async (Huey), seul `PurchaseImportView.post()` est à refactorer.
- 77 tests purchase/dashboard passent. 4 échecs pré-existants sur `DisabledEmailEditViewTest` (fixture `EmailGroup` manquante, sans rapport avec cette PR).