### PR TITLE
fix(dashboard): corriger l'import autonome des dépenses achats

### DIFF
--- a/lemarche/purchases/migrations/0004_purchaseimport_file_nullable.py
+++ b/lemarche/purchases/migrations/0004_purchaseimport_file_nullable.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("purchases", "0003_purchaseimport"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="purchaseimport",
+            name="file",
+            field=models.FileField(
+                blank=True,
+                null=True,
+                upload_to="purchases/imports/",
+                verbose_name="Fichier Excel",
+            ),
+        ),
+    ]

--- a/lemarche/purchases/models.py
+++ b/lemarche/purchases/models.py
@@ -410,6 +410,8 @@ class PurchaseImport(models.Model):
     file = models.FileField(
         verbose_name="Fichier Excel",
         upload_to="purchases/imports/",
+        blank=True,
+        null=True,
     )
     status = models.CharField(
         verbose_name="Statut",

--- a/lemarche/purchases/utils.py
+++ b/lemarche/purchases/utils.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import re
 from decimal import Decimal, InvalidOperation
@@ -58,11 +59,12 @@ def _detect_columns(header_row) -> dict[str, int]:
     return mapping
 
 
-def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]:
+def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, list, int]:
     """
-    Parse an Excel file of purchase data and create Purchase objects.
+    Parse an Excel file of purchase data. Does NOT write to DB.
 
-    Returns (errors, total_rows, matched_rows).
+    Returns (purchases, errors, matched_rows) where purchases is a list of
+    unsaved Purchase instances ready for bulk_create.
     Raises ValueError for unrecoverable format errors.
     """
     from lemarche.purchases.models import Purchase
@@ -115,6 +117,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
             return str(val).strip() if val is not None else None
 
         supplier_name = get("supplier_name") or ""
+        # Strip non-digit chars, and handle SIRETs stored as float by Excel (e.g. "12345678901234.0")
         supplier_siret = re.sub(r"[^\d]", "", str(get("supplier_siret") or "").split(".")[0])
         amount_raw = get("purchase_amount") or ""
         purchase_category = get("purchase_category") or None
@@ -160,14 +163,7 @@ def parse_purchases_excel(file_obj, year: int, company) -> tuple[list, int, int]
 
     wb.close()
 
-    if purchases:
-        from itertools import batched
-
-        BATCH_SIZE = 1_000
-        for batch in batched(purchases, BATCH_SIZE):
-            Purchase.objects.bulk_create(list(batch))
-
-    return errors, len(purchases), matched_rows
+    return purchases, errors, matched_rows
 
 
 def generate_purchases_excel_template() -> bytes:
@@ -206,8 +202,6 @@ def generate_purchases_excel_template() -> bytes:
     ws2.append(["Dépense achat (€)", "Oui", "Montant en euros (nombre positif)"])
     ws2.append(["Catégorie d'achat (optionnelle)", "Non", "Catégorie libre (ex : Travaux, SI, Nettoyage…)"])
     ws2.append(["Entité acheteuse (optionnelle)", "Non", "Service ou direction acheteuse"])
-
-    import io
 
     buffer = io.BytesIO()
     wb.save(buffer)

--- a/lemarche/www/dashboard/views.py
+++ b/lemarche/www/dashboard/views.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import logging
+from itertools import batched
 from urllib.parse import urlencode
 
 import openpyxl
@@ -460,43 +461,63 @@ class PurchaseImportView(LoginRequiredMixin, View):
                 {"last_purchase_import": last_import, "errors": errors, "current_year": timezone.now().year},
             )
 
-        purchase_import = PurchaseImport.objects.create(
-            company=user.company,
-            uploaded_by=user,
-            file=uploaded_file,
-            status=PurchaseImport.STATUS_PENDING,
-            year=year,
-        )
+        # Step 1: Parse in memory FIRST — no S3 interaction, feedback immédiat si format invalide
+        status = PurchaseImport.STATUS_FAILED
+        error_msg = ""
+        new_purchases = []
+        total_rows = 0
+        matched_rows = 0
 
-        # Clean slate: delete existing purchases for this company before importing
-        Purchase.objects.filter(company=user.company).delete()
-
-        # Use the in-memory upload rather than re-fetching from S3 (S3 streams are not seekable)
-        uploaded_file.seek(0)
         try:
-            parse_errors, total_rows, matched_rows = parse_purchases_excel(
+            new_purchases, parse_errors, matched_rows = parse_purchases_excel(
                 uploaded_file,
                 year=year,
                 company=user.company,
             )
-            purchase_import.total_rows = total_rows
-            purchase_import.matched_rows = matched_rows
+            total_rows = len(new_purchases)
             if total_rows == 0 and parse_errors:
-                purchase_import.status = PurchaseImport.STATUS_FAILED
-                purchase_import.error_message = "\n".join(parse_errors[:10])
+                error_msg = "\n".join(parse_errors[:10])
             else:
-                purchase_import.status = PurchaseImport.STATUS_SUCCESS
+                status = PurchaseImport.STATUS_SUCCESS
                 if parse_errors:
-                    purchase_import.error_message = "\n".join(parse_errors[:10])
+                    error_msg = "\n".join(parse_errors[:10])
         except ValueError as exc:
-            purchase_import.status = PurchaseImport.STATUS_FAILED
-            purchase_import.error_message = str(exc)
+            error_msg = str(exc)
         except Exception:
-            logger.exception("Erreur inattendue lors de l'import des achats (id=%s)", purchase_import.pk)
-            purchase_import.status = PurchaseImport.STATUS_FAILED
-            purchase_import.error_message = "Une erreur inattendue s'est produite. Veuillez réessayer."
+            logger.exception("Erreur inattendue lors du parsing des achats")
+            error_msg = "Une erreur inattendue s'est produite. Veuillez réessayer."
 
-        purchase_import.save(update_fields=["status", "total_rows", "matched_rows", "error_message", "updated_at"])
+        # Step 2: Écriture en base seulement si le parsing a réussi
+        if status == PurchaseImport.STATUS_SUCCESS and new_purchases:
+            Purchase.objects.filter(company=user.company).delete()
+            BATCH_SIZE = 1_000
+            for batch in batched(new_purchases, BATCH_SIZE):
+                Purchase.objects.bulk_create(list(batch))
+
+        # Step 3: Sauvegarde du PurchaseImport avec upload S3 du fichier
+        uploaded_file.seek(0)
+        try:
+            PurchaseImport.objects.create(
+                company=user.company,
+                uploaded_by=user,
+                file=uploaded_file,
+                status=status,
+                year=year,
+                total_rows=total_rows,
+                matched_rows=matched_rows,
+                error_message=error_msg,
+            )
+        except Exception:
+            logger.exception("Erreur lors de la sauvegarde du fichier sur S3 (import_id manquant)")
+            PurchaseImport.objects.create(
+                company=user.company,
+                uploaded_by=user,
+                status=status,
+                year=year,
+                total_rows=total_rows,
+                matched_rows=matched_rows,
+                error_message=error_msg,
+            )
 
         return HttpResponseRedirect(reverse("dashboard:inclusive_purchase_stats"))
 


### PR DESCRIPTION
Remplace la PR #2108 (fermée pour cause de conflit).

### Quoi ?

Correction de la fonctionnalité d'import Excel des dépenses achats (PR #2106) qui échouait systématiquement après plusieurs minutes d'attente.

**4 changements :**
- `purchases/utils.py` — `parse_purchases_excel` ne fait plus de `bulk_create` : elle retourne une liste d'objets `Purchase` non sauvegardés, séparant le parsing de l'écriture DB
- `purchases/models.py` — champ `file` rendu nullable (`blank=True, null=True`)
- `purchases/migrations/0004_purchaseimport_file_nullable.py` — migration correspondante
- `www/dashboard/views.py` — nouveau flux en 3 étapes dans `PurchaseImportView.post()`

### Pourquoi ?

Le bug avait 3 causes :

1. **Upload S3 avant parsing** : le fichier était d'abord envoyé vers Cellar (S3), puis relu depuis S3 pour le parsing. Si Cellar est lent ou mal configuré sur la recette-jetable, boto3 retente pendant plusieurs minutes avant d'échouer → erreur 500 non catchée.

2. **Suppression des données avant validation** : `Purchase.objects.filter(...).delete()` était appelé AVANT de savoir si le nouveau fichier était valide → perte des données existantes en cas d'échec du parsing.

3. **Aucune gestion des pannes S3** : si l'upload échouait, aucun record `PurchaseImport` n'était créé, et l'erreur remontait non gérée.

### Comment ?

Nouveau flux dans `PurchaseImportView.post()` :

1. **Parser en mémoire d'abord** (< 5s) — retour d'erreur immédiat si le format est invalide, sans toucher à S3 ni à la base
2. **Écrire en base seulement si succès** — suppression des anciens achats + bulk_create des nouveaux
3. **Upload S3 en dernier** — si Cellar plante, le record `PurchaseImport` est quand même créé sans fichier (champ nullable), l'utilisateur voit le bon résultat

### Comment tester ?

1. Se connecter en tant qu'acheteur avec une entreprise associée
2. Aller sur `/profil/part-achat-inclusif/importer/`
3. Uploader le modèle Excel rempli avec des données valides → doit réussir rapidement (< 10s)
4. Uploader un fichier avec de mauvaises colonnes → doit afficher une erreur immédiate (< 5s), sans attendre
5. Vérifier que les achats existants ne sont pas supprimés si l'import échoue

### Autre (optionnel)

- 61 tests purchases passent, 26 tests dashboard passent
- Le seul échec pré-existant (`DisabledEmailEditViewTest`, fixture `EmailGroup` manquante) est sans rapport avec cette PR