### PR TITLE
test: corriger la flakiness liée aux données de migration vidées par les flushs transactionnels

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Restore data-migration-seeded rows wiped by transactional flushes.
+
+There is no ``serialized_rollback`` configured, so when a
+``TransactionTestCase``/``transactional_db`` test flushes its worker database at
+teardown, rows created by data migrations (Wagtail root page + locale,
+``EmailGroup``, ``TemplateTransactional``, ...) are truncated and never restored.
+
+Django normally avoids the fallout by running every ``TestCase`` before every
+``TransactionTestCase``, but ``pytest-randomly`` shuffles across that boundary
+(and xdist distributes per worker), so on some seeds a flushing test runs before
+data-dependent ones on the same worker and they hit empty tables.
+
+We snapshot those rows once per worker (``dumpdata`` with natural foreign keys so
+``content_type`` references survive the content types that ``post_migrate``
+re-creates with new PKs after a flush) and reload them before any DB test that
+finds them wiped.
+"""
+
+import pytest
+
+
+_RESEED_MODELS = [
+    "wagtailcore.locale",
+    "wagtailcore.collection",
+    "wagtailcore.page",
+    "wagtailcore.site",
+    "conversations.emailgroup",
+    "conversations.templatetransactional",
+]
+
+_snapshot = {}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _capture_seed_snapshot(django_db_setup, django_db_blocker, tmp_path_factory):
+    from django.core.management import call_command
+
+    path = str(tmp_path_factory.mktemp("seed") / "seed.json")
+    with django_db_blocker.unblock(), open(path, "w") as fh:
+        call_command("dumpdata", *_RESEED_MODELS, natural_foreign=True, stdout=fh)
+    _snapshot["path"] = path
+    _snapshot["blocker"] = django_db_blocker
+
+
+def _uses_db(item):
+    from django.test import TransactionTestCase
+
+    cls = getattr(item, "cls", None)
+    if cls is not None:
+        return issubclass(cls, TransactionTestCase)
+    names = getattr(item, "fixturenames", ())
+    return "db" in names or "transactional_db" in names
+
+
+def pytest_runtest_setup(item):
+    path = _snapshot.get("path")
+    if not path or not _uses_db(item):
+        return
+
+    from django.core.management import call_command
+    from wagtail.models import Locale
+
+    with _snapshot["blocker"].unblock():
+        if not Locale.objects.exists():
+            call_command("loaddata", path, verbosity=0)


### PR DESCRIPTION
### Pourquoi ?

  Sous `pytest-randomly` + xdist, des tests échouent par intermittence selon la seed : un
  test transactionnel vide la base du worker à son teardown et, aucun `serialized_rollback`
  n'étant configuré, les lignes des data migrations ne sont jamais restaurées. Django
  protège normalement en exécutant tous les `TestCase` avant les `TransactionTestCase`, mais
  le shuffle de pytest-randomly casse cet ordre. Les tests qui dépendent de ces données
  (`SitemapTests`, `PagesHeaderLinkTest`, `cms`, `dashboard`, `delete_old_users`, …) tombent
  alors sur des tables vides (`IntegrityError` / `DoesNotExist` / `NoneType`).

  ### Comment ?

  - Une fixture de session capture un snapshot (`dumpdata --natural-foreign`) des modèles
  concernés, une fois par worker. Les clés étrangères naturelles gardent les FK
  `content_type` valides malgré les content types recréés (nouveaux PK) par `post_migrate`
  après un flush.
  - Un hook `pytest_runtest_setup` recharge (`loaddata`) ces données avant tout test « base
  de données » qui les trouve vidées (sentinelle : table `Locale` vide). Garde-fou :
  uniquement les tests BDD (sinon `SimpleTestCase` lève `DatabaseOperationForbidden`).
  - Volontairement limité aux modèles dont dépendent les tests (groupes / permissions /
  workflows exclus).

  ### Captures d'écran (optionnel)

  N/A.

  ### Autre (optionnel)

  - Validé : micro-test déterministe (flush puis vérification) + `make test` complet aux
  seeds `3865067317` et `11111` → 0 échec réel.
  - Alternative écartée : un `serialize`/`deserialize` complet de la base réinsère les
  content types/permissions (PK réattribués par `post_migrate`) → erreurs de clé dupliquée