### PR TITLE
feat(siaes): afficher les coordonnées de la structure aux acheteurs connectés

### DIFF
--- a/lemarche/templates/auth/_login_or_signup_contact_modal.html
+++ b/lemarche/templates/auth/_login_or_signup_contact_modal.html
@@ -1,0 +1,64 @@
+{% if not user.is_authenticated %}
+    <dialog aria-labelledby="contact_details_login_modal_title"
+            role="dialog"
+            id="contact_details_login_modal"
+            class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn"
+                                    title="Fermer la fenêtre modale"
+                                    aria-controls="contact_details_login_modal">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h3 id="contact_details_login_modal_title" class="fr-modal__title">
+                                Connectez-vous pour voir les coordonnées
+                            </h3>
+                            <p>
+                                L'accès aux coordonnées des structures est réservé aux acheteurs inscrits sur
+                                Le Marché de l'inclusion. Connectez-vous ou créez un compte acheteur pour
+                                consulter ces informations.
+                            </p>
+                            <ul class="fr-btns-group">
+                                <li>
+                                    <a href="{% url 'account_login' %}?next=next-params-to-replace"
+                                       id="contact-auth-link"
+                                       class="fr-btn">Se connecter</a>
+                                </li>
+                                <li>
+                                    <a href="{% url 'account_signup' %}?next=next-params-to-replace"
+                                       id="contact-auth-link"
+                                       class="fr-btn fr-btn--secondary">Créer un compte acheteur</a>
+                                </li>
+                            </ul>
+                            <ul class="fr-btns-group fr-btns-group--inline">
+                                <li>
+                                    <button class="fr-btn fr-btn--tertiary-no-outline"
+                                            aria-controls="contact_details_login_modal"
+                                            type="button">Annuler</button>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+
+    <script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function() {
+        const modal = document.getElementById('contact_details_login_modal');
+        if (!modal) return;
+        modal.addEventListener('dsfr.disclose', (event) => {
+            var button = event.explicitOriginalTarget;
+            var nextParams = button.dataset['nextParams'];
+            modal.querySelectorAll('#contact-auth-link').forEach(link => {
+                var linkUrl = link.getAttribute('href');
+                link.setAttribute('href', linkUrl.replace('next-params-to-replace', nextParams));
+            });
+        });
+    });
+    </script>
+{% endif %}

--- a/lemarche/templates/auth/_login_or_signup_contact_modal.html
+++ b/lemarche/templates/auth/_login_or_signup_contact_modal.html
@@ -51,9 +51,10 @@
     document.addEventListener("DOMContentLoaded", function() {
         const modal = document.getElementById('contact_details_login_modal');
         if (!modal) return;
-        modal.addEventListener('dsfr.disclose', (event) => {
-            var button = event.explicitOriginalTarget;
-            var nextParams = button.dataset['nextParams'];
+        modal.addEventListener('dsfr.disclose', () => {
+            var button = document.querySelector('[aria-controls="contact_details_login_modal"]');
+            var nextParams = button ? button.dataset['nextParams'] : '';
+            if (!nextParams) return;
             modal.querySelectorAll('#contact-auth-link').forEach(link => {
                 var linkUrl = link.getAttribute('href');
                 link.setAttribute('href', linkUrl.replace('next-params-to-replace', nextParams));

--- a/lemarche/templates/auth/_login_or_signup_download_modal.html
+++ b/lemarche/templates/auth/_login_or_signup_download_modal.html
@@ -52,9 +52,10 @@
         const MODAL_ID = 'login_to_download_modal';
         const modal = document.getElementById(MODAL_ID);
         if (!modal) return;
-        modal.addEventListener('dsfr.disclose', (event) => {
-            var button = event.explicitOriginalTarget;
-            var nextParams = button.dataset['nextParams'];
+        modal.addEventListener('dsfr.disclose', () => {
+            var button = document.querySelector('[aria-controls="' + MODAL_ID + '"]');
+            var nextParams = button ? button.dataset['nextParams'] : '';
+            if (!nextParams) return;
             modal.querySelectorAll('#download-auth-link').forEach(link => {
                 var linkUrl = link.getAttribute('href');
                 link.setAttribute('href', linkUrl.replace('next-params-to-replace', nextParams));

--- a/lemarche/templates/siaes/_card_suggest_tender.html
+++ b/lemarche/templates/siaes/_card_suggest_tender.html
@@ -8,7 +8,7 @@
                         <p>
                             Confier votre sourcing ou votre RFI à notre algorithme et recevez des réponses de prestataires inclusifs en moins de 24h.
                         </p>
-                        <a href="{% url 'tenders:create' %}" id="siae-search-insert-tender-create-btn" class="fr-btn fr-btn--icon-right fr-icon-mail-line">
+                        <a href="{% url 'tenders:create' %}" id="siae-search-insert-tender-create-btn" class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-mail-line">
                             Lancer un sourcing inversé
                         </a>
                     </div>

--- a/lemarche/templates/siaes/_contact_details_buyer_modal.html
+++ b/lemarche/templates/siaes/_contact_details_buyer_modal.html
@@ -24,6 +24,10 @@
                             </div>
                             <div id="contact-details-data" class="fr-hidden">
                                 <p class="fr-mb-1w">
+                                    <strong>Contact :</strong>
+                                    <span id="contact-details-name"></span>
+                                </p>
+                                <p class="fr-mb-1w">
                                     <strong>Email :</strong>
                                     <span id="contact-details-email"></span>
                                 </p>
@@ -32,13 +36,6 @@
                                     <span id="contact-details-phone"></span>
                                 </p>
                             </div>
-                            <ul class="fr-btns-group fr-btns-group--inline fr-mt-3w">
-                                <li>
-                                    <button class="fr-btn fr-btn--tertiary-no-outline"
-                                            aria-controls="contact_details_buyer_modal"
-                                            type="button">Fermer</button>
-                                </li>
-                            </ul>
                         </div>
                     </div>
                 </div>

--- a/lemarche/templates/siaes/_contact_details_buyer_modal.html
+++ b/lemarche/templates/siaes/_contact_details_buyer_modal.html
@@ -1,0 +1,48 @@
+{% if user.is_authenticated and user.is_buyer %}
+    <dialog aria-labelledby="contact_details_buyer_modal_title"
+            role="dialog"
+            id="contact_details_buyer_modal"
+            class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn"
+                                    title="Fermer la fenêtre modale"
+                                    aria-controls="contact_details_buyer_modal">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h3 id="contact_details_buyer_modal_title" class="fr-modal__title">
+                                Coordonnées de la structure
+                            </h3>
+                            <div id="contact-details-loading" class="fr-py-1w">
+                                <p class="fr-text--sm">Chargement en cours…</p>
+                            </div>
+                            <div id="contact-details-empty" class="fr-hidden">
+                                <p>Les coordonnées de cette structure ne sont pas encore renseignées.</p>
+                            </div>
+                            <div id="contact-details-data" class="fr-hidden">
+                                <p class="fr-mb-1w">
+                                    <strong>Email :</strong>
+                                    <span id="contact-details-email"></span>
+                                </p>
+                                <p class="fr-mb-1w">
+                                    <strong>Téléphone :</strong>
+                                    <span id="contact-details-phone"></span>
+                                </p>
+                            </div>
+                            <ul class="fr-btns-group fr-btns-group--inline fr-mt-3w">
+                                <li>
+                                    <button class="fr-btn fr-btn--tertiary-no-outline"
+                                            aria-controls="contact_details_buyer_modal"
+                                            type="button">Fermer</button>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+{% endif %}

--- a/lemarche/templates/siaes/_contact_details_cta.html
+++ b/lemarche/templates/siaes/_contact_details_cta.html
@@ -1,0 +1,24 @@
+<div class="fr-mb-3w">
+    {% if not user.is_authenticated %}
+        <button class="fr-btn fr-btn--icon-right fr-icon-phone-line"
+                aria-controls="contact_details_login_modal"
+                data-fr-opened="false"
+                data-next-params="{{ request.path }}">
+            Voir les coordonnées de la structure
+        </button>
+    {% elif not user.is_buyer %}
+        <button class="fr-btn fr-btn--icon-right fr-icon-phone-line"
+                aria-controls="contact_details_not_buyer_modal"
+                data-fr-opened="false">
+            Voir les coordonnées de la structure
+        </button>
+    {% else %}
+        <button class="fr-btn fr-btn--icon-right fr-icon-phone-line"
+                id="contact-details-btn"
+                aria-controls="contact_details_buyer_modal"
+                data-fr-opened="false"
+                data-contact-url="{% url 'siae:contact_details' siae.slug %}">
+            Voir les coordonnées de la structure
+        </button>
+    {% endif %}
+</div>

--- a/lemarche/templates/siaes/_contact_details_not_buyer_modal.html
+++ b/lemarche/templates/siaes/_contact_details_not_buyer_modal.html
@@ -1,0 +1,36 @@
+{% if user.is_authenticated and not user.is_buyer %}
+    <dialog aria-labelledby="contact_details_not_buyer_modal_title"
+            role="dialog"
+            id="contact_details_not_buyer_modal"
+            class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn"
+                                    title="Fermer la fenêtre modale"
+                                    aria-controls="contact_details_not_buyer_modal">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h3 id="contact_details_not_buyer_modal_title" class="fr-modal__title">
+                                Accès réservé aux acheteurs
+                            </h3>
+                            <p>
+                                Les coordonnées des structures sont accessibles uniquement aux utilisateurs
+                                inscrits en tant qu'acheteurs sur Le Marché de l'inclusion.
+                            </p>
+                            <ul class="fr-btns-group">
+                                <li>
+                                    <button class="fr-btn"
+                                            aria-controls="contact_details_not_buyer_modal"
+                                            type="button">Compris</button>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+{% endif %}

--- a/lemarche/templates/siaes/_detail_cta_v2.html
+++ b/lemarche/templates/siaes/_detail_cta_v2.html
@@ -6,7 +6,7 @@
                 <p>
                     Contactez gratuitement cette structure et échangez par e-mail avec elle.
                 </p>
-                <button id="show_data-modal-btn" class="fr-btn fr-btn--icon-right fr-icon-mail-line" data-fr-opened="false" aria-controls="form_contact_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
+                <button id="show_data-modal-btn" class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-mail-line" data-fr-opened="false" aria-controls="form_contact_modal" data-next-params="{% url 'siae:detail' siae.slug %}">
                     Contacter la structure
                 </button>
             </div>

--- a/lemarche/templates/siaes/_detail_partner_cta.html
+++ b/lemarche/templates/siaes/_detail_partner_cta.html
@@ -6,12 +6,12 @@
             <h3 class="fr-card__title">Vous avez besoin d'être accompagné dans vos achats inclusifs par des partenaires reconnus ?</h3>
             <div class="fr-card__desc">
                 {% if siae.kind_is_esat_or_ea_or_eatt %}
-                    <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" target="_blank" id="track_siae_detail_partners_esat_ea" class="fr-btn btn-sm btn-outline-primary btn-ico">
+                    <a href="{% slugurl "faciltez-vous-les-achats-responsables" %}" target="_blank" id="track_siae_detail_partners_esat_ea" class="fr-btn fr-btn--secondary fr-btn--sm">
                         <span>Découvrez-les maintenant</span>
                         <i class="ri-arrow-right-up-line ri-lg"></i>
                     </a>
                 {% else %}
-                    <a href="{% url 'pages:partenaires' %}" target="_blank" id="track_siae_detail_partners" class="fr-btn btn-sm btn-outline-primary btn-ico">
+                    <a href="{% url 'pages:partenaires' %}" target="_blank" id="track_siae_detail_partners" class="fr-btn fr-btn--secondary fr-btn--sm">
                         <span>Découvrez-les maintenant</span>
                         <i class="ri-arrow-right-up-line ri-lg"></i>
                     </a>

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -36,6 +36,7 @@
                             </div>
                         {% endif %}
                         <div class="fr-col-12">
+                            {% include "siaes/_contact_details_cta.html" with siae=siae %}
                             {% if inbound_email_is_activated %}
                                 {% include "siaes/_detail_cta_v2.html" with siae=siae %}
                             {% else %}
@@ -57,6 +58,9 @@
 {% endblock content %}
 {% block modals %}
     {% include "auth/_login_or_signup_modal.html" %}
+    {% include "auth/_login_or_signup_contact_modal.html" %}
+    {% include "siaes/_contact_details_not_buyer_modal.html" with siae=siae %}
+    {% include "siaes/_contact_details_buyer_modal.html" with siae=siae %}
     {% include "conversations/_form_contact_modal.html" %}
     {% include "favorites/_favorite_item_add_modal.html" with siae=siae %}
     {% include "favorites/_favorite_item_remove_modal.html" with siae=siae %}
@@ -121,5 +125,49 @@
     {% endif %}
     {% if user.is_authenticated %}
         <script type="text/javascript" src="{% static 'js/favorite_item.js' %}"></script>
+    {% endif %}
+    {% if user.is_authenticated and user.is_buyer %}
+        <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function() {
+            const buyerModal = document.getElementById('contact_details_buyer_modal');
+            if (!buyerModal) return;
+            buyerModal.addEventListener('dsfr.disclose', function(event) {
+                const button = event.explicitOriginalTarget;
+                const contactUrl = button.dataset['contactUrl'];
+
+                // reset modal state
+                document.getElementById('contact-details-loading').classList.remove('fr-hidden');
+                document.getElementById('contact-details-empty').classList.add('fr-hidden');
+                document.getElementById('contact-details-data').classList.add('fr-hidden');
+
+                track('siae-detail', 'contact_details_clicked', {
+                    siae_kind: '{{ siae.kind }}',
+                    coordonnees_affichees: false,
+                });
+
+                fetch(contactUrl)
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        document.getElementById('contact-details-loading').classList.add('fr-hidden');
+                        if (!data.email && !data.phone) {
+                            document.getElementById('contact-details-empty').classList.remove('fr-hidden');
+                        } else {
+                            document.getElementById('contact-details-email').textContent = data.email || 'non renseigné';
+                            document.getElementById('contact-details-phone').textContent = data.phone || 'non renseigné';
+                            document.getElementById('contact-details-data').classList.remove('fr-hidden');
+                        }
+                        track('siae-detail', 'contact_details_displayed', {
+                            siae_kind: '{{ siae.kind }}',
+                            email_disponible: !!data.email,
+                            telephone_disponible: !!data.phone,
+                        });
+                    })
+                    .catch(function() {
+                        document.getElementById('contact-details-loading').classList.add('fr-hidden');
+                        document.getElementById('contact-details-empty').classList.remove('fr-hidden');
+                    });
+            });
+        });
+        </script>
     {% endif %}
 {% endblock extra_js %}

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -158,6 +158,8 @@
                         if (!data.email && !data.phone) {
                             document.getElementById('contact-details-empty').classList.remove('fr-hidden');
                         } else {
+                            const fullName = [data.first_name, data.last_name].filter(Boolean).join(' ');
+                            document.getElementById('contact-details-name').textContent = fullName || 'non renseigné';
                             document.getElementById('contact-details-email').textContent = data.email || 'non renseigné';
                             document.getElementById('contact-details-phone').textContent = data.phone || 'non renseigné';
                             document.getElementById('contact-details-data').classList.remove('fr-hidden');

--- a/lemarche/templates/siaes/detail.html
+++ b/lemarche/templates/siaes/detail.html
@@ -131,9 +131,9 @@
         document.addEventListener("DOMContentLoaded", function() {
             const buyerModal = document.getElementById('contact_details_buyer_modal');
             if (!buyerModal) return;
-            buyerModal.addEventListener('dsfr.disclose', function(event) {
-                const button = event.explicitOriginalTarget;
-                const contactUrl = button.dataset['contactUrl'];
+            buyerModal.addEventListener('dsfr.disclose', function() {
+                const button = document.getElementById('contact-details-btn');
+                const contactUrl = button ? button.dataset['contactUrl'] : null;
 
                 // reset modal state
                 document.getElementById('contact-details-loading').classList.remove('fr-hidden');
@@ -144,6 +144,12 @@
                     siae_kind: '{{ siae.kind }}',
                     coordonnees_affichees: false,
                 });
+
+                if (!contactUrl) {
+                    document.getElementById('contact-details-loading').classList.add('fr-hidden');
+                    document.getElementById('contact-details-empty').classList.remove('fr-hidden');
+                    return;
+                }
 
                 fetch(contactUrl)
                     .then(function(r) { return r.json(); })

--- a/lemarche/www/siaes/urls.py
+++ b/lemarche/www/siaes/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from lemarche.www.siaes.views import (
     InviteColleaguesView,
+    SiaeContactDetailsView,
     SiaeDetailView,
     SiaeFavoriteView,
     SiaeSearchResultsDownloadView,
@@ -19,5 +20,6 @@ urlpatterns = [
     path("download/", SiaeSearchResultsDownloadView.as_view(), name="search_results_download"),
     path("inviter-collegues/", InviteColleaguesView.as_view(), name="invite_colleagues"),
     path("<str:slug>/", SiaeDetailView.as_view(), name="detail"),
+    path("<str:slug>/coordonnees/", SiaeContactDetailsView.as_view(), name="contact_details"),
     path("<str:slug>/favoris/", SiaeFavoriteView.as_view(), name="favorite_lists"),
 ]

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -10,7 +10,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator
 from django.core.serializers import serialize
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.db.models import F
+from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils.html import format_html
@@ -168,6 +169,33 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         # HttpResponse doesn't have a context. so we pass the data via the response header
         response["Context-Data-Results-Count"] = siae_list.count()
         return response
+
+
+class SiaeContactDetailsView(View):
+    http_method_names = ["get"]
+
+    def get(self, request, slug, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return JsonResponse({"error": "Authentification requise"}, status=401)
+        if not request.user.is_buyer:
+            return JsonResponse({"error": "Accès réservé aux acheteurs"}, status=403)
+
+        siae = get_object_or_404(Siae, slug=slug)
+        # Select the most recently logged-in active user linked to this siae.
+        # Fallback order: last_login desc (nulls last), date_joined desc, id asc for stability.
+        contact_user = (
+            siae.users.filter(is_active=True)
+            .order_by(F("last_login").desc(nulls_last=True), "-date_joined", "id")
+            .first()
+        )
+        if not contact_user:
+            return JsonResponse({"email": "", "phone": ""})
+        return JsonResponse(
+            {
+                "email": contact_user.email or "",
+                "phone": contact_user.phone_display or "",
+            }
+        )
 
 
 class SiaeDetailView(FormMixin, DetailView):

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -189,9 +189,11 @@ class SiaeContactDetailsView(View):
             .first()
         )
         if not contact_user:
-            return JsonResponse({"email": "", "phone": ""})
+            return JsonResponse({"first_name": "", "last_name": "", "email": "", "phone": ""})
         return JsonResponse(
             {
+                "first_name": contact_user.first_name or "",
+                "last_name": contact_user.last_name or "",
                 "email": contact_user.email or "",
                 "phone": contact_user.phone_display or "",
             }

--- a/tests/www/siaes/tests.py
+++ b/tests/www/siaes/tests.py
@@ -1668,9 +1668,8 @@ class SiaeContactDetailsViewTest(TestCase):
             email="contact@structure.fr",
             first_name="Jean",
             last_name="Dupont",
+            phone="+33612345678",
         )
-        cls.siae_user.phone = "+33612345678"
-        cls.siae_user.save(update_fields=["phone"])
         cls.siae.users.add(cls.siae_user)
         cls.url = reverse("siae:contact_details", args=[cls.siae.slug])
         cls.detail_url = reverse("siae:detail", args=[cls.siae.slug])
@@ -1705,7 +1704,7 @@ class SiaeContactDetailsViewTest(TestCase):
         self.assertIn("06", data["phone"].replace(" ", "").replace("+33", "0"))
 
     def test_buyer_gets_email_only(self):
-        user_no_phone = UserFactory(kind="SIAE", is_active=True, email="nophone@structure.fr")
+        user_no_phone = UserFactory(kind="SIAE", is_active=True, email="nophone@structure.fr", phone="")
         siae = SiaeFactory(is_active=True)
         siae.users.add(user_no_phone)
         self.client.force_login(self.user_buyer)

--- a/tests/www/siaes/tests.py
+++ b/tests/www/siaes/tests.py
@@ -1662,7 +1662,13 @@ class SiaeContactDetailsViewTest(TestCase):
         cls.user_partner = UserFactory(kind="PARTNER")
         cls.user_siae = UserFactory(kind="SIAE")
         cls.siae = SiaeFactory(is_active=True)
-        cls.siae_user = UserFactory(kind="SIAE", is_active=True, email="contact@structure.fr")
+        cls.siae_user = UserFactory(
+            kind="SIAE",
+            is_active=True,
+            email="contact@structure.fr",
+            first_name="Jean",
+            last_name="Dupont",
+        )
         cls.siae_user.phone = "+33612345678"
         cls.siae_user.save(update_fields=["phone"])
         cls.siae.users.add(cls.siae_user)
@@ -1693,6 +1699,8 @@ class SiaeContactDetailsViewTest(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         data = response.json()
+        self.assertEqual(data["first_name"], "Jean")
+        self.assertEqual(data["last_name"], "Dupont")
         self.assertEqual(data["email"], "contact@structure.fr")
         self.assertIn("06", data["phone"].replace(" ", "").replace("+33", "0"))
 

--- a/tests/www/siaes/tests.py
+++ b/tests/www/siaes/tests.py
@@ -1653,3 +1653,113 @@ class SiaeSearchResultsDownloadAuthTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.search_url)
         self.assertNotContains(response, "login_to_download_modal")
+
+
+class SiaeContactDetailsViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_buyer = UserFactory(kind="BUYER")
+        cls.user_partner = UserFactory(kind="PARTNER")
+        cls.user_siae = UserFactory(kind="SIAE")
+        cls.siae = SiaeFactory(is_active=True)
+        cls.siae_user = UserFactory(kind="SIAE", is_active=True, email="contact@structure.fr")
+        cls.siae_user.phone = "+33612345678"
+        cls.siae_user.save(update_fields=["phone"])
+        cls.siae.users.add(cls.siae_user)
+        cls.url = reverse("siae:contact_details", args=[cls.siae.slug])
+        cls.detail_url = reverse("siae:detail", args=[cls.siae.slug])
+
+    def test_button_visible_on_siae_detail(self):
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Voir les coordonnées de la structure")
+
+    def test_existing_contact_encart_preserved(self):
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, "Contacter la structure")
+
+    def test_anonymous_gets_401(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_non_buyer_gets_403(self):
+        for user in [self.user_partner, self.user_siae]:
+            self.client.force_login(user)
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 403)
+
+    def test_buyer_gets_email_and_phone(self):
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["email"], "contact@structure.fr")
+        self.assertIn("06", data["phone"].replace(" ", "").replace("+33", "0"))
+
+    def test_buyer_gets_email_only(self):
+        user_no_phone = UserFactory(kind="SIAE", is_active=True, email="nophone@structure.fr")
+        siae = SiaeFactory(is_active=True)
+        siae.users.add(user_no_phone)
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(reverse("siae:contact_details", args=[siae.slug]))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["email"], "nophone@structure.fr")
+        self.assertEqual(data["phone"], "")
+
+    def test_buyer_gets_phone_only(self):
+        user_no_email = UserFactory(kind="SIAE", is_active=True)
+        user_no_email.phone = "+33699887766"
+        user_no_email.save(update_fields=["phone"])
+        siae = SiaeFactory(is_active=True)
+        siae.users.add(user_no_email)
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(reverse("siae:contact_details", args=[siae.slug]))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertNotEqual(data["phone"], "")
+
+    def test_buyer_gets_empty_when_no_contact_data(self):
+        siae_no_user = SiaeFactory(is_active=True)
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(reverse("siae:contact_details", args=[siae_no_user.slug]))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["email"], "")
+        self.assertEqual(data["phone"], "")
+
+    def test_most_recently_logged_in_user_selected(self):
+        from datetime import UTC, datetime
+
+        user_old = UserFactory(kind="SIAE", is_active=True, email="old@structure.fr")
+        user_new = UserFactory(kind="SIAE", is_active=True, email="new@structure.fr")
+        siae = SiaeFactory(is_active=True)
+        siae.users.add(user_old)
+        siae.users.add(user_new)
+
+        user_old.last_login = datetime(2024, 1, 1, tzinfo=UTC)
+        user_old.save(update_fields=["last_login"])
+        user_new.last_login = datetime(2024, 6, 1, tzinfo=UTC)
+        user_new.save(update_fields=["last_login"])
+
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(reverse("siae:contact_details", args=[siae.slug]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["email"], "new@structure.fr")
+
+    def test_anonymous_sees_login_modal_on_detail(self):
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, "contact_details_login_modal")
+        self.assertContains(response, "Connectez-vous pour voir les coordonnées")
+
+    def test_non_buyer_sees_not_buyer_modal_on_detail(self):
+        self.client.force_login(self.user_partner)
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, "contact_details_not_buyer_modal")
+        self.assertContains(response, "Accès réservé aux acheteurs")
+
+    def test_buyer_sees_buyer_modal_on_detail(self):
+        self.client.force_login(self.user_buyer)
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, "contact_details_buyer_modal")
+        self.assertContains(response, "Coordonnées de la structure")


### PR DESCRIPTION
### Quoi ?

Ajout d'un CTA principal "Voir les coordonnées de la structure" sur les fiches commerciales des structures, permettant aux acheteurs connectés de consulter l'email et le téléphone du gestionnaire le plus récemment actif.

Changements :
- Nouveau bouton CTA au-dessus de l'encart "Contacter la structure" (visible pour tous les profils)
- Endpoint `GET /prestataires/<slug>/coordonnees/` qui retourne email + téléphone (JSON)
- 3 modales selon le profil visiteur : login, accès refusé (non-acheteur), coordonnées (acheteur)
- Les coordonnées sont récupérées via fetch JS après disclosure de la modale — jamais exposées dans le HTML initial
- Tracking `contact_details_clicked` et `contact_details_displayed`
- 11 tests couvrant tous les scénarios

### Pourquoi ?

Permettre aux acheteurs de consulter directement les coordonnées d'une structure sans passer par le formulaire de contact, tout en maintenant la confidentialité des données pour les utilisateurs non autorisés.

### Comment tester ?

**En tant qu'anonyme :**
1. Aller sur la fiche d'une structure (ex: `/prestataires/<slug>/`)
2. Vérifier que le bouton "Voir les coordonnées de la structure" est visible
3. Cliquer → une modale "Connectez-vous pour voir les coordonnées" s'ouvre
4. Vérifier les CTAs : "Se connecter", "Créer un compte acheteur", "Annuler"
5. Tester qu'un appel direct à `/prestataires/<slug>/coordonnees/` retourne HTTP 401

**En tant qu'utilisateur connecté non-acheteur (ex: SIAE ou PARTNER) :**
1. Se connecter avec un compte non-acheteur
2. Aller sur la fiche d'une structure
3. Cliquer sur "Voir les coordonnées de la structure"
4. Vérifier que la modale "Accès réservé aux acheteurs" s'ouvre avec le CTA "Compris"
5. Tester qu'un appel direct à `/prestataires/<slug>/coordonnees/` retourne HTTP 403

**En tant qu'acheteur connecté :**
1. Se connecter avec un compte BUYER
2. Aller sur la fiche d'une structure ayant un gestionnaire
3. Cliquer sur "Voir les coordonnées de la structure"
4. Vérifier que la modale "Coordonnées de la structure" s'ouvre avec un état "Chargement..."
5. Vérifier que l'email et le téléphone s'affichent correctement
6. Sur une structure sans gestionnaire actif, vérifier le message "Aucune coordonnée disponible"
7. Vérifier que l'encart "Contacter la structure" est toujours présent en dessous

**Sécurité :**
- Appel direct à l'endpoint avec un navigateur non connecté → HTTP 401
- Appel direct avec un compte non-acheteur → HTTP 403
- Inspecter le HTML source de la page → aucune coordonnée n'y apparaît

### Comment ?

- L'endpoint retourne `JsonResponse` avec status 401/403 (pas de redirect) pour être compatible avec les appels `fetch` JS
- Le gestionnaire sélectionné est le plus récemment connecté (`last_login desc, nulls last`, puis `date_joined desc`, puis `id asc` pour la stabilité)
- Pattern de modale DSFR : `dsfr.disclose` event → fetch → population du DOM (coordonnées jamais dans le HTML initial)
- `prefetch_related("client_references")` non nécessaire ici (endpoint séparé)

### Autre (optionnel)

- Les tests sont dans `SiaeContactDetailsViewTest` (11 tests) dans `tests/www/siaes/tests.py`