### PR TITLE
feat(tenders): page besoins inspirants pour les acheteurs

### DIFF
--- a/lemarche/templates/dashboard/_inspirational_tenders_card.html
+++ b/lemarche/templates/dashboard/_inspirational_tenders_card.html
@@ -4,12 +4,12 @@
     <div class="fr-card__body">
         <div class="fr-card__content">
             <h3 class="fr-card__title">
-                S'inspirer de projets d'achat
+                Découvrir les projets d'achats inspirants
             </h3>
             <div class="fr-card__desc">
                 <p>
-                    Consultez des besoins d'achat déjà publiés sur le Marché de l'inclusion ayant suscité l'intérêt de
-                    structures inclusives, pour vous inspirer de projets similaires.
+                    Consultez des projets d'achat publiés par des acheteurs publics et privés via le Marché de
+                    l'inclusion, et inspirez-vous d'exemples proches de vos besoins.
                 </p>
             </div>
         </div>
@@ -17,7 +17,7 @@
             <ul class="fr-btns-group--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right">
                 <li>
                     <a href="{% url 'tenders:inspiration-list' %}" id="track_dashboard_inspirational_tenders" class="fr-btn fr-icon-arrow-right-s-line fr-btn--tertiary-no-outline">
-                        Voir des projets d'achat publiés
+                        Découvrir les projets d'achats inspirants
                     </a>
                 </li>
             </ul>

--- a/lemarche/templates/dashboard/_inspirational_tenders_card.html
+++ b/lemarche/templates/dashboard/_inspirational_tenders_card.html
@@ -1,0 +1,31 @@
+{% load static %}
+
+<div class="fr-card fr-card--horizontal fr-card--horizontal-tier">
+    <div class="fr-card__body">
+        <div class="fr-card__content">
+            <h3 class="fr-card__title">
+                S'inspirer de projets d'achat
+            </h3>
+            <div class="fr-card__desc">
+                <p>
+                    Consultez des besoins d'achat déjà publiés sur le Marché de l'inclusion ayant suscité l'intérêt de
+                    structures inclusives, pour vous inspirer de projets similaires.
+                </p>
+            </div>
+        </div>
+        <div class="fr-card__footer">
+            <ul class="fr-btns-group--right fr-btns-group fr-btns-group--inline fr-btns-group--icon-right">
+                <li>
+                    <a href="{% url 'tenders:inspiration-list' %}" id="track_dashboard_inspirational_tenders" class="fr-btn fr-icon-arrow-right-s-line fr-btn--tertiary-no-outline">
+                        Voir des projets d'achat publiés
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="fr-card__header fr-hidden fr-unhidden-lg">
+        <div class="fr-card__img">
+            <img class="fr-responsive-img" src="{% static 'images/illustration-06.svg' %}" alt=""/>
+        </div>
+    </div>
+</div>

--- a/lemarche/templates/dashboard/home_buyer.html
+++ b/lemarche/templates/dashboard/home_buyer.html
@@ -94,6 +94,9 @@
                 {% include "dashboard/_ressource_card.html" with user_kind="BUYER" ressources=last_3_ressources %}
             </div>
         </div>
+        <div class="fr-grid-row fr-grid-row--gutters fr-mb-4v">
+            <div class="fr-col-12">{% include "dashboard/_inspirational_tenders_card.html" %}</div>
+        </div>
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-lg-6">{% include "dashboard/_favorites_card.html" %}</div>
             <div class="fr-col-12 fr-col-lg-6">

--- a/lemarche/templates/layouts/_header_nav_secondary_items.html
+++ b/lemarche/templates/layouts/_header_nav_secondary_items.html
@@ -23,6 +23,9 @@
 				<li>
 					<a id="header-dropdown-siae-search-btn" class="fr-nav__link" href="{% url 'siae:search_results' %}" target="_self">Moteur de recherche multicritères</a>
 				</li>
+				<li>
+					<a id="header-inspirational-tenders" class="fr-nav__link" href="{% url 'tenders:inspiration-list' %}" target="_self">Découvrir des projets d'achats inspirants</a>
+				</li>
 
 				<li>
 					<a id="header-calculer-impact-social-achat" class="fr-nav__link" href="{% url 'pages:buyer_social_impact_calculator' %}" target="_self">Calculer l'impact social d'un achat inclusif</a>

--- a/lemarche/templates/layouts/_header_nav_secondary_items.html
+++ b/lemarche/templates/layouts/_header_nav_secondary_items.html
@@ -7,6 +7,10 @@
 			Qu'est-ce qu'un fournisseur inclusif ?
 		</a>
 	</li>
+	{% url 'tenders:inspiration-list' as inspiration_list_url %}
+	<li class="fr-nav__item">
+		<a href="{{ inspiration_list_url }}" id="header-inspirational-tenders" class="fr-nav__link"{% if request.path == inspiration_list_url %} aria-current="page"{% endif %}>Projets d'achats inspirants</a>
+	</li>
 	<li class="fr-nav__item">
 		<button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-solutions">Solutions</button>
 		<div class="fr-collapse fr-menu" id="menu-solutions">
@@ -22,9 +26,6 @@
 				</li>
 				<li>
 					<a id="header-dropdown-siae-search-btn" class="fr-nav__link" href="{% url 'siae:search_results' %}" target="_self">Moteur de recherche multicritères</a>
-				</li>
-				<li>
-					<a id="header-inspirational-tenders" class="fr-nav__link" href="{% url 'tenders:inspiration-list' %}" target="_self">Découvrir des projets d'achats inspirants</a>
 				</li>
 
 				<li>

--- a/lemarche/templates/tenders/inspirational_detail.html
+++ b/lemarche/templates/tenders/inspirational_detail.html
@@ -1,0 +1,91 @@
+{% extends BASE_TEMPLATE %}
+{% load static dsfr_tags process_dict %}
+
+{% block page_title %}{{ tender.title }}{{ block.super }}{% endblock page_title %}
+
+{% block breadcrumb %}
+    {% process_dict root_dir=HOME_PAGE_PATH links=breadcrumb_links current=tender.title as breadcrumb_data %}
+    {% dsfr_breadcrumb breadcrumb_data %}
+{% endblock breadcrumb %}
+
+{% block content %}
+    <section>
+        <div class="fr-container fr-py-4w">
+            <div class="fr-grid-row">
+                <div class="fr-col-12 fr-col-lg-8">
+                    <h1>{{ tender.title }}</h1>
+
+                    <ul class="fr-tags-group fr-mb-3w">
+                        <li><p class="fr-tag">{{ tender.get_kind_display }}</p></li>
+                        {% if tender.author.buyer_kind %}
+                            <li><p class="fr-tag">{{ tender.author.get_buyer_kind_display }}</p></li>
+                        {% endif %}
+                        {% if tender.author.buyer_kind_detail %}
+                            <li><p class="fr-tag">{{ tender.author.get_buyer_kind_detail_display }}</p></li>
+                        {% endif %}
+                    </ul>
+
+                    {% if tender.sectors_full_list_string %}
+                        <p><strong>Secteurs d'activité :</strong> {{ tender.sectors_full_list_string }}</p>
+                    {% endif %}
+
+                    {% if tender.description %}
+                        <h2 class="fr-h4 fr-mt-4w">Description du besoin</h2>
+                        <div class="fr-text">{{ tender.description|safe }}</div>
+                    {% endif %}
+                </div>
+
+                <div class="fr-col-12 fr-col-lg-4">
+                    <div class="fr-card fr-card--grey">
+                        <div class="fr-card__body">
+                            <div class="fr-card__content">
+                                <h2 class="fr-h5">Résultats du sourcing</h2>
+                                <ul class="fr-badges-group fr-mb-3w">
+                                    <li><p class="fr-badge fr-badge--info">{{ tender.siae_count }} structure{{ tender.siae_count|pluralize }} ciblée{{ tender.siae_count|pluralize }}</p></li>
+                                    <li><p class="fr-badge fr-badge--success">{{ tender.siae_detail_contact_click_count }} intéressée{{ tender.siae_detail_contact_click_count|pluralize }}</p></li>
+                                    <li><p class="fr-badge">{{ tender.siae_detail_not_interested_click_count }} désintéressée{{ tender.siae_detail_not_interested_click_count|pluralize }}</p></li>
+                                </ul>
+                                {% if interest_rate is not None %}
+                                    <p class="fr-text--sm"><strong>Taux d'intérêt :</strong> {{ interest_rate }} %</p>
+                                {% endif %}
+                                {% if tender.published_at %}
+                                    <p class="fr-text--sm fr-mb-0"><strong>Publié le :</strong> {{ tender.published_at|date:"d/m/Y" }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="fr-card fr-card--no-border fr-mt-3w">
+                        <div class="fr-card__body">
+                            <div class="fr-card__content">
+                                <h2 class="fr-h5">Un projet d'achat similaire ?</h2>
+                                <p class="fr-text--sm">
+                                    Publiez votre besoin d'achat et mobilisez les structures inclusives du Marché de l'inclusion.
+                                </p>
+                            </div>
+                            <div class="fr-card__footer">
+                                <ul class="fr-btns-group fr-btns-group--icon-left">
+                                    <li>
+                                        <a href="{% url 'tenders:create' %}"
+                                           id="inspirational-tender-create-btn"
+                                           class="fr-btn fr-btn--icon-left fr-icon-add-circle-line">
+                                            Publier un besoin d'achat
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="fr-grid-row fr-mt-4w">
+                <div class="fr-col-12">
+                    <a href="{% url 'tenders:inspiration-list' %}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-arrow-left-line">
+                        Retour aux besoins inspirants
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lemarche/templates/tenders/inspirational_detail.html
+++ b/lemarche/templates/tenders/inspirational_detail.html
@@ -82,7 +82,7 @@
             <div class="fr-grid-row fr-mt-4w">
                 <div class="fr-col-12">
                     <a href="{% url 'tenders:inspiration-list' %}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-arrow-left-line">
-                        Retour aux besoins inspirants
+                        Retour aux projets d'achats inspirants
                     </a>
                 </div>
             </div>

--- a/lemarche/templates/tenders/inspirational_list.html
+++ b/lemarche/templates/tenders/inspirational_list.html
@@ -1,10 +1,10 @@
 {% extends BASE_TEMPLATE %}
 {% load static dsfr_tags process_dict %}
 
-{% block page_title %}Besoins inspirants{{ block.super }}{% endblock page_title %}
+{% block page_title %}Découvrir les projets d'achats inspirants{{ block.super }}{% endblock page_title %}
 
 {% block breadcrumb %}
-    {% process_dict root_dir=HOME_PAGE_PATH links=breadcrumb_links current="Besoins inspirants" as breadcrumb_data %}
+    {% process_dict root_dir=HOME_PAGE_PATH links=breadcrumb_links current="Projets d'achats inspirants" as breadcrumb_data %}
     {% dsfr_breadcrumb breadcrumb_data %}
 {% endblock breadcrumb %}
 
@@ -13,12 +13,11 @@
         <div class="fr-container fr-py-4w">
             <div class="fr-grid-row fr-mb-4w">
                 <div class="fr-col-12 fr-col-md-8">
-                    <h1>Besoins inspirants</h1>
+                    <h1>Découvrir les projets d'achats inspirants</h1>
                     <p class="fr-text--lead">
-                        Inspirez-vous de projets d'achat déjà publiés sur le Marché de l'inclusion.
-                        Cette page référence des sourcings et appels d'offres ayant suscité l'intérêt d'au moins
-                        {{ min_interested_siae_count }} structures inclusives. Les acheteurs sont
-                        anonymisés : seules les informations utiles à la compréhension du projet sont affichées.
+                        Retrouvez ici des projets d'achat publiés par des acheteurs publics et privés via le
+                        Marché de l'inclusion. Recherchez des exemples proches de vos besoins et inspirez-vous
+                        de projets ayant suscité l'intérêt de structures inclusives.
                     </p>
                 </div>
             </div>

--- a/lemarche/templates/tenders/inspirational_list.html
+++ b/lemarche/templates/tenders/inspirational_list.html
@@ -1,0 +1,96 @@
+{% extends BASE_TEMPLATE %}
+{% load static dsfr_tags process_dict %}
+
+{% block page_title %}Besoins inspirants{{ block.super }}{% endblock page_title %}
+
+{% block breadcrumb %}
+    {% process_dict root_dir=HOME_PAGE_PATH links=breadcrumb_links current="Besoins inspirants" as breadcrumb_data %}
+    {% dsfr_breadcrumb breadcrumb_data %}
+{% endblock breadcrumb %}
+
+{% block content %}
+    <section>
+        <div class="fr-container fr-py-4w">
+            <div class="fr-grid-row fr-mb-4w">
+                <div class="fr-col-12 fr-col-md-8">
+                    <h1>Besoins inspirants</h1>
+                    <p class="fr-text--lead">
+                        Inspirez-vous de projets d'achat déjà publiés sur le Marché de l'inclusion.
+                        Cette page référence des sourcings et appels d'offres ayant suscité l'intérêt d'au moins
+                        {{ min_interested_siae_count }} structures inclusives. Les acheteurs sont
+                        anonymisés : seules les informations utiles à la compréhension du projet sont affichées.
+                    </p>
+                </div>
+            </div>
+
+            <form method="get" action="" class="fr-mb-4w">
+                <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
+                    <div class="fr-col-12 fr-col-md-4">
+                        <div class="fr-select-group">
+                            <label class="fr-label" for="{{ filter_form.sector.id_for_label }}">{{ filter_form.sector.label }}</label>
+                            {{ filter_form.sector }}
+                        </div>
+                    </div>
+                    <div class="fr-col-12 fr-col-md-4">
+                        <div class="fr-select-group">
+                            <label class="fr-label" for="{{ filter_form.kind.id_for_label }}">{{ filter_form.kind.label }}</label>
+                            {{ filter_form.kind }}
+                        </div>
+                    </div>
+                    <div class="fr-col-12 fr-col-md-4">
+                        <div class="fr-select-group">
+                            <label class="fr-label" for="{{ filter_form.buyer_kind.id_for_label }}">{{ filter_form.buyer_kind.label }}</label>
+                            {{ filter_form.buyer_kind }}
+                        </div>
+                    </div>
+                </div>
+                <noscript>
+                    <button type="submit" class="fr-btn fr-mt-2w">Filtrer</button>
+                </noscript>
+            </form>
+
+            <div class="fr-grid-row fr-grid-row--gutters">
+                {% for tender in tenders %}
+                    <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+                        <div class="fr-card fr-enlarge-link">
+                            <div class="fr-card__body">
+                                <div class="fr-card__content">
+                                    <h3 class="fr-card__title">
+                                        <a href="{% url 'tenders:inspiration-detail' slug=tender.slug %}">{{ tender.title }}</a>
+                                    </h3>
+                                    <div class="fr-card__desc">
+                                        <ul class="fr-tags-group fr-mb-2w">
+                                            <li><p class="fr-tag fr-tag--sm">{{ tender.get_kind_display }}</p></li>
+                                            {% if tender.author.buyer_kind %}
+                                                <li><p class="fr-tag fr-tag--sm">{{ tender.author.get_buyer_kind_display }}</p></li>
+                                            {% endif %}
+                                            {% if tender.author.buyer_kind_detail %}
+                                                <li><p class="fr-tag fr-tag--sm">{{ tender.author.get_buyer_kind_detail_display }}</p></li>
+                                            {% endif %}
+                                        </ul>
+                                        {% if tender.sectors_list_string %}
+                                            <p class="fr-text--sm fr-mb-1w"><strong>Secteurs :</strong> {{ tender.sectors_list_string }}</p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                <div class="fr-card__footer">
+                                    <ul class="fr-badges-group">
+                                        <li><p class="fr-badge fr-badge--sm fr-badge--info">{{ tender.siae_count }} ciblée{{ tender.siae_count|pluralize }}</p></li>
+                                        <li><p class="fr-badge fr-badge--sm fr-badge--success">{{ tender.siae_detail_contact_click_count }} intéressée{{ tender.siae_detail_contact_click_count|pluralize }}</p></li>
+                                        <li><p class="fr-badge fr-badge--sm">{{ tender.siae_detail_not_interested_click_count }} désintéressée{{ tender.siae_detail_not_interested_click_count|pluralize }}</p></li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="fr-col-12">
+                        <p>Aucun besoin ne correspond à votre recherche pour le moment.</p>
+                    </div>
+                {% endfor %}
+            </div>
+
+            {% include "includes/_pagination.html" %}
+        </div>
+    </section>
+{% endblock content %}

--- a/lemarche/tenders/constants.py
+++ b/lemarche/tenders/constants.py
@@ -150,3 +150,8 @@ SURVEY_TRANSACTIONED_ANSWER_CHOICES = (
     (constants.DONT_KNOW, "Pas encore"),
 )
 SURVEY_TRANSACTIONED_ANSWER_CHOICE_LIST = [choice[0] for choice in SURVEY_TRANSACTIONED_ANSWER_CHOICES]
+
+
+# Nombre minimum de structures intéressées pour qu'un besoin soit affiché dans la page "Besoins inspirants".
+# Centralisé ici pour être ajusté facilement.
+MIN_INTERESTED_SIAE_COUNT = 3

--- a/lemarche/tenders/constants.py
+++ b/lemarche/tenders/constants.py
@@ -152,6 +152,6 @@ SURVEY_TRANSACTIONED_ANSWER_CHOICES = (
 SURVEY_TRANSACTIONED_ANSWER_CHOICE_LIST = [choice[0] for choice in SURVEY_TRANSACTIONED_ANSWER_CHOICES]
 
 
-# Nombre minimum de structures intéressées pour qu'un besoin soit affiché dans la page "Besoins inspirants".
+# Nombre minimum de structures intéressées pour qu'un besoin soit affiché dans la page "Projets d'achats inspirants".
 # Centralisé ici pour être ajusté facilement.
 MIN_INTERESTED_SIAE_COUNT = 3

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -213,6 +213,20 @@ class TenderQuerySet(models.QuerySet):
             .distinct()
         )
 
+    def filter_inspirational(self):
+        """
+        Return the tenders that can be shown as inspiration to buyers ("Besoins inspirants").
+        Eligibility rules (kept simple, based on existing denormalized fields):
+        - the tender has been sent to siaes (status SENT)
+        - at least MIN_INTERESTED_SIAE_COUNT siaes showed interest
+        - the buyer did not ask to stay anonymous
+        """
+        return self.filter(
+            status=Tender.StatusChoices.STATUS_SENT,
+            siae_detail_contact_click_count__gte=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=False,
+        )
+
     def with_deadline_date_is_outdated(self, limit_date=datetime.today()):
         return self.annotate(
             deadline_date_is_outdated_annotated=ExpressionWrapper(

--- a/lemarche/tenders/models.py
+++ b/lemarche/tenders/models.py
@@ -215,7 +215,7 @@ class TenderQuerySet(models.QuerySet):
 
     def filter_inspirational(self):
         """
-        Return the tenders that can be shown as inspiration to buyers ("Besoins inspirants").
+        Return the tenders that can be shown as inspiration to buyers ("Projets d'achats inspirants").
         Eligibility rules (kept simple, based on existing denormalized fields):
         - the tender has been sent to siaes (status SENT)
         - at least MIN_INTERESTED_SIAE_COUNT siaes showed interest

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -5,10 +5,12 @@ from ckeditor.widgets import CKEditorWidget
 from django import forms
 from django.utils.html import strip_tags
 
+from lemarche.sectors.models import Sector
 from lemarche.siaes.models import Siae
 from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.enums import SurveyDoesNotExistQuestionChoices, SurveyScaleQuestionChoices
 from lemarche.tenders.models import Tender, TenderSiae
+from lemarche.users import constants as user_constants
 from lemarche.users.models import User
 from lemarche.users.validators import professional_email_validator
 from lemarche.utils import constants
@@ -444,6 +446,55 @@ class TenderFilterForm(forms.Form):
                 new_choices.append((kind_key, kind_label))
 
         self.fields["kind"].choices = new_choices
+
+
+class InspirationalTenderFilterForm(forms.Form):
+    """Filtres de la page "Besoins inspirants" : secteur, type de projet, public/privé."""
+
+    KIND_CHOICES = (
+        ("", "Tous les types"),
+        (tender_constants.KIND_PROJECT, tender_constants.KIND_PROJECT_DISPLAY),
+        (tender_constants.KIND_TENDER, tender_constants.KIND_TENDER_DISPLAY),
+        (tender_constants.KIND_QUOTE, tender_constants.KIND_QUOTE_DISPLAY),
+    )
+
+    BUYER_KIND_CHOICES = (("", "Public et privé"),) + user_constants.BUYER_KIND_CHOICES
+
+    sector = forms.ModelChoiceField(
+        label="Secteur d'activité",
+        queryset=Sector.objects.form_filter_queryset(),
+        to_field_name="slug",
+        empty_label="Tous les secteurs",
+        required=False,
+        widget=forms.Select(attrs={"class": "fr-select", "onchange": "this.form.submit()"}),
+    )
+    kind = forms.ChoiceField(
+        label="Type de projet d'achat",
+        choices=KIND_CHOICES,
+        required=False,
+        widget=forms.Select(attrs={"class": "fr-select", "onchange": "this.form.submit()"}),
+    )
+    buyer_kind = forms.ChoiceField(
+        label="Type d'acheteur",
+        choices=BUYER_KIND_CHOICES,
+        required=False,
+        widget=forms.Select(attrs={"class": "fr-select", "onchange": "this.form.submit()"}),
+    )
+
+    def filter_queryset(self, queryset):
+        """Applique les filtres sélectionnés au queryset (filtres facultatifs et combinables)."""
+        if not self.is_valid():
+            return queryset
+        sector = self.cleaned_data.get("sector")
+        if sector:
+            queryset = queryset.filter(sectors=sector)
+        kind = self.cleaned_data.get("kind")
+        if kind:
+            queryset = queryset.filter(kind=kind)
+        buyer_kind = self.cleaned_data.get("buyer_kind")
+        if buyer_kind:
+            queryset = queryset.filter(author__buyer_kind=buyer_kind)
+        return queryset
 
 
 class TenderDetailGetParams(forms.Form):

--- a/lemarche/www/tenders/forms.py
+++ b/lemarche/www/tenders/forms.py
@@ -449,7 +449,7 @@ class TenderFilterForm(forms.Form):
 
 
 class InspirationalTenderFilterForm(forms.Form):
-    """Filtres de la page "Besoins inspirants" : secteur, type de projet, public/privé."""
+    """Filtres de la page "Projets d'achats inspirants" : secteur, type de projet, public/privé."""
 
     KIND_CHOICES = (
         ("", "Tous les types"),

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
     path("ajouter", RedirectView.as_view(pattern_name="tenders:create", permanent=True), name="create_without_slash"),
     path("ajouter/", TenderCreateMultiStepView.as_view(), name="create"),
     path("modifier/<str:slug>", TenderCreateMultiStepView.as_view(), name="update"),
-    # "Besoins inspirants" : à déclarer avant le catch-all <str:slug> pour éviter tout conflit de route
+    # "Projets d'achats inspirants" : à déclarer avant le catch-all <str:slug> pour éviter tout conflit de route
     path("inspirants", InspirationalTenderListView.as_view(), name="inspiration-list"),
     path("inspirants/<str:slug>", InspirationalTenderDetailView.as_view(), name="inspiration-detail"),
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),

--- a/lemarche/www/tenders/urls.py
+++ b/lemarche/www/tenders/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 from django.views.generic import RedirectView
 
 from lemarche.www.tenders.views import (
+    InspirationalTenderDetailView,
+    InspirationalTenderListView,
     TenderCreateMultiStepView,
     TenderDetailContactClickStatView,
     TenderDetailGroupementReplyView,
@@ -25,6 +27,9 @@ urlpatterns = [
     path("ajouter", RedirectView.as_view(pattern_name="tenders:create", permanent=True), name="create_without_slash"),
     path("ajouter/", TenderCreateMultiStepView.as_view(), name="create"),
     path("modifier/<str:slug>", TenderCreateMultiStepView.as_view(), name="update"),
+    # "Besoins inspirants" : à déclarer avant le catch-all <str:slug> pour éviter tout conflit de route
+    path("inspirants", InspirationalTenderListView.as_view(), name="inspiration-list"),
+    path("inspirants/<str:slug>", InspirationalTenderDetailView.as_view(), name="inspiration-detail"),
     path("<str:slug>", TenderDetailView.as_view(), name="detail"),
     path("statut/<status>", TenderListView.as_view(), name="list"),
     path("", TenderListView.as_view(), name="list"),

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -425,7 +425,7 @@ class TenderListView(LoginRequiredMixin, ListView):
 
 class InspirationalTenderListView(LoginRequiredMixin, ListView):
     """
-    Page "Besoins inspirants" : liste anonymisée des besoins d'achat ayant suscité de l'intérêt.
+    Page "Projets d'achats inspirants" : liste anonymisée des besoins d'achat ayant suscité de l'intérêt.
     Accessible à tout utilisateur connecté. L'identité de l'acheteur n'est jamais exposée
     (on n'affiche que le type d'acheteur public/privé et le type d'organisation).
     """
@@ -447,7 +447,6 @@ class InspirationalTenderListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["filter_form"] = self.filter_form
-        context["min_interested_siae_count"] = tender_constants.MIN_INTERESTED_SIAE_COUNT
         context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
         return context
 
@@ -475,7 +474,7 @@ class InspirationalTenderDetailView(LoginRequiredMixin, DetailView):
         context["interest_rate"] = interest_rate
         context["breadcrumb_links"] = [
             {"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")},
-            {"title": "Besoins inspirants", "url": reverse_lazy("tenders:inspiration-list")},
+            {"title": "Projets d'achats inspirants", "url": reverse_lazy("tenders:inspiration-list")},
         ]
         return context
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -57,6 +57,7 @@ from lemarche.utils.mixins import (
 from lemarche.utils.urls import get_domain_url
 from lemarche.www.siaes.forms import SiaeFilterForm
 from lemarche.www.tenders.forms import (
+    InspirationalTenderFilterForm,
     SiaeSelectFieldsForm,
     TenderCreateStepConfirmationForm,
     TenderCreateStepContactForm,
@@ -419,6 +420,63 @@ class TenderListView(LoginRequiredMixin, ListView):
         context["tender_statuses"] = Tender.StatusChoices
         context["filter_form"] = self.filter_form
         context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
+        return context
+
+
+class InspirationalTenderListView(LoginRequiredMixin, ListView):
+    """
+    Page "Besoins inspirants" : liste anonymisée des besoins d'achat ayant suscité de l'intérêt.
+    Accessible à tout utilisateur connecté. L'identité de l'acheteur n'est jamais exposée
+    (on n'affiche que le type d'acheteur public/privé et le type d'organisation).
+    """
+
+    template_name = "tenders/inspirational_list.html"
+    model = Tender
+    context_object_name = "tenders"
+    paginate_by = 12
+    paginator_class = Paginator
+    filter_form = None
+
+    def get_queryset(self):
+        qs = Tender.objects.filter_inspirational()
+        self.filter_form = InspirationalTenderFilterForm(data=self.request.GET)
+        qs = self.filter_form.filter_queryset(qs)
+        qs = qs.select_related("author").prefetch_related("sectors").distinct()
+        return qs.order_by_last_published()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["filter_form"] = self.filter_form
+        context["min_interested_siae_count"] = tender_constants.MIN_INTERESTED_SIAE_COUNT
+        context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
+        return context
+
+
+class InspirationalTenderDetailView(LoginRequiredMixin, DetailView):
+    """
+    Fiche détail anonymisée d'un besoin inspirant.
+    Seuls les besoins éligibles (filter_inspirational) sont accessibles ici.
+    """
+
+    template_name = "tenders/inspirational_detail.html"
+    model = Tender
+    context_object_name = "tender"
+
+    def get_queryset(self):
+        return Tender.objects.filter_inspirational().select_related("author").prefetch_related("sectors")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        tender = self.object
+        # taux d'intérêt = structures intéressées / structures ciblées (arrondi, en %)
+        interest_rate = None
+        if tender.siae_count:
+            interest_rate = round(100 * tender.siae_detail_contact_click_count / tender.siae_count)
+        context["interest_rate"] = interest_rate
+        context["breadcrumb_links"] = [
+            {"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")},
+            {"title": "Besoins inspirants", "url": reverse_lazy("tenders:inspiration-list")},
+        ]
         return context
 
 

--- a/tests/tenders/test_models.py
+++ b/tests/tenders/test_models.py
@@ -1222,3 +1222,40 @@ class TenderInstructionModelTest(TestCase):
         instruction.refresh_from_db()
         self.assertNotIn("<script", instruction.text)
         self.assertIn("<p>ok</p>", instruction.text)
+
+
+class TenderQuerysetInspirationalTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        min_count = tender_constants.MIN_INTERESTED_SIAE_COUNT
+        # éligible : envoyé, assez de structures intéressées, non anonyme
+        cls.tender_eligible = TenderFactory(
+            status=Tender.StatusChoices.STATUS_SENT,
+            siae_detail_contact_click_count=min_count,
+            response_is_anonymous=False,
+        )
+        # pas assez de structures intéressées
+        cls.tender_not_enough_interested = TenderFactory(
+            status=Tender.StatusChoices.STATUS_SENT,
+            siae_detail_contact_click_count=min_count - 1,
+            response_is_anonymous=False,
+        )
+        # acheteur anonyme
+        cls.tender_anonymous = TenderFactory(
+            status=Tender.StatusChoices.STATUS_SENT,
+            siae_detail_contact_click_count=min_count,
+            response_is_anonymous=True,
+        )
+        # pas encore envoyé
+        cls.tender_not_sent = TenderFactory(
+            status=Tender.StatusChoices.STATUS_DRAFT,
+            siae_detail_contact_click_count=min_count,
+            response_is_anonymous=False,
+        )
+
+    def test_filter_inspirational_keeps_only_eligible_tenders(self):
+        results = Tender.objects.filter_inspirational()
+        self.assertIn(self.tender_eligible, results)
+        self.assertNotIn(self.tender_not_enough_interested, results)
+        self.assertNotIn(self.tender_anonymous, results)
+        self.assertNotIn(self.tender_not_sent, results)

--- a/tests/www/tenders/tests.py
+++ b/tests/www/tenders/tests.py
@@ -25,6 +25,7 @@ from lemarche.tenders import constants as tender_constants
 from lemarche.tenders.constants import KIND_QUOTE
 from lemarche.tenders.enums import SurveyDoesNotExistQuestionChoices, SurveyScaleQuestionChoices, TenderSourcesChoices
 from lemarche.tenders.models import QuestionAnswer, Tender, TenderInstruction, TenderSiae, TenderStepsData
+from lemarche.users import constants as user_constants
 from lemarche.users.models import User
 from lemarche.utils import constants
 from lemarche.utils.apis.brevo_attributes import CONTACT_ATTRIBUTES
@@ -2775,3 +2776,131 @@ class TenderReminderViewTestCase(TestCase):
             response_post = self.client.post(url, data={"reminder_message": "Blabla"})
             self.assertEqual(send_reminder_email_to_siae_mock.call_count, 2)
         self.assertEqual(response_post.status_code, 302)
+
+
+class InspirationalTenderListViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("tenders:inspiration-list")
+        cls.user = UserFactory(kind=User.KIND_SIAE)
+        # Acheteur avec une identité volontairement reconnaissable pour vérifier l'anonymisation
+        cls.buyer = UserFactory(
+            kind=User.KIND_BUYER,
+            first_name="Zorglubprenom",
+            last_name="Zorglubnom",
+            email="zorglub-secret@example.com",
+            company_name="Entreprise Zorglub Secrete",
+            buyer_kind=user_constants.BUYER_KIND_PUBLIC,
+            buyer_kind_detail=user_constants.BUYER_KIND_DETAIL_PUBLIC_COLLECTIVITY,
+        )
+        cls.sector = SectorFactory()
+        # Besoin éligible : envoyé, >= 3 intéressées, non anonyme
+        cls.tender_eligible = TenderFactory(
+            title="Besoin inspirant eligible",
+            kind=tender_constants.KIND_PROJECT,
+            author=cls.buyer,
+            sectors=[cls.sector],
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=False,
+        )
+        # Besoin non éligible : pas assez d'intéressées
+        cls.tender_not_enough = TenderFactory(
+            title="Besoin pas assez interesse",
+            author=cls.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT - 1,
+            response_is_anonymous=False,
+        )
+        # Besoin non éligible : acheteur anonyme
+        cls.tender_anonymous = TenderFactory(
+            title="Besoin acheteur anonyme",
+            author=cls.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=True,
+        )
+
+    def test_anonymous_user_is_redirected(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
+    def test_only_eligible_tenders_are_listed(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Besoin inspirant eligible")
+        self.assertNotContains(response, "Besoin pas assez interesse")
+        self.assertNotContains(response, "Besoin acheteur anonyme")
+
+    def test_buyer_identity_is_not_exposed(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # Aucune donnée personnelle de l'acheteur ne doit apparaître
+        self.assertNotContains(response, "Zorglubprenom")
+        self.assertNotContains(response, "Zorglubnom")
+        self.assertNotContains(response, "zorglub-secret@example.com")
+        self.assertNotContains(response, "Entreprise Zorglub Secrete")
+        # Seul le type d'acheteur (anonymisé) est affiché
+        self.assertContains(response, "Collectivité")
+
+    def test_filter_by_kind(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url, data={"kind": tender_constants.KIND_TENDER})
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Besoin inspirant eligible")
+
+
+class InspirationalTenderDetailViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(kind=User.KIND_SIAE)
+        cls.buyer = UserFactory(
+            kind=User.KIND_BUYER,
+            first_name="Marieprenom",
+            last_name="Confidentiellenom",
+            email="secret-buyer@example.com",
+            company_name="Entreprise Confidentielle",
+            buyer_kind=user_constants.BUYER_KIND_PUBLIC,
+            buyer_kind_detail=user_constants.BUYER_KIND_DETAIL_PUBLIC_COLLECTIVITY,
+        )
+        cls.tender_eligible = TenderFactory(
+            title="Besoin detail eligible",
+            author=cls.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=False,
+        )
+        cls.tender_hidden = TenderFactory(
+            title="Besoin detail cache",
+            author=cls.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT - 1,
+            response_is_anonymous=False,
+        )
+
+    def test_eligible_tender_detail_is_accessible(self):
+        self.client.force_login(self.user)
+        url = reverse("tenders:inspiration-detail", kwargs={"slug": self.tender_eligible.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Besoin detail eligible")
+
+    def test_non_eligible_tender_detail_is_hidden(self):
+        self.client.force_login(self.user)
+        url = reverse("tenders:inspiration-detail", kwargs={"slug": self.tender_hidden.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_buyer_identity_is_not_exposed(self):
+        self.client.force_login(self.user)
+        url = reverse("tenders:inspiration-detail", kwargs={"slug": self.tender_eligible.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Marieprenom")
+        self.assertNotContains(response, "Confidentiellenom")
+        self.assertNotContains(response, "secret-buyer@example.com")
+        self.assertNotContains(response, "Entreprise Confidentielle")
+        self.assertContains(response, "Collectivité")


### PR DESCRIPTION
### Quoi ?

Nouvelle page permettant aux utilisateurs connectés de consulter des besoins d'achat déjà publiés, pour s'inspirer de projets similaires :
- **Page liste** avec 3 filtres : secteur d'activité, type de projet d'achat, public/privé
- **Page détail** : titre, type, secteurs, description, résultats du sourcing (structures ciblées / intéressées / désintéressées + taux d'intérêt)
- **Anonymisation totale de l'acheteur** : seul le *type* d'acheteur (public/privé + type d'organisation) est affiché, jamais le nom, l'organisation, l'email ou le téléphone
- **Éligibilité centralisée** dans une constante `MIN_INTERESTED_SIAE_COUNT` (= 3) : besoin envoyé, ≥ 3 structures intéressées, acheteur non anonyme
- **Accès** : lien "Découvrir des projets d'achats inspirants" dans le menu header (Solutions) + carte sur le dashboard acheteur
- **CTA** "Publier un besoin d'achat" sur chaque fiche pour convertir l'inspiration en publication

### Pourquoi ?

Aider les acheteurs à concrétiser leur projet d'achat en leur montrant des besoins déjà publiés ayant suscité l'intérêt de structures inclusives. On réutilise les modèles, vues et composants existants (pas de nouveau backend, pas de moteur d'indexation, pas de modification de modèle ni de migration).

### Comment ?

- Méthode `TenderQuerySet.filter_inspirational()` s'appuyant uniquement sur les champs dénormalisés existants (`status`, `siae_detail_contact_click_count`, `response_is_anonymous`) — aucune migration
- Vues CBV `InspirationalTenderListView` / `InspirationalTenderDetailView` avec `LoginRequiredMixin`
- Routes déclarées **avant** le catch-all `<str:slug>` des tenders pour éviter tout conflit de route
- Filtres via un `forms.Form` dédié (auto-submit DSFR), logique de filtrage isolée dans `filter_queryset()`

### Comment tester ?

1. Se connecter avec n'importe quel compte (acheteur ou structure)
2. Ouvrir le menu header **Solutions → Découvrir des projets d'achats inspirants** (ou la carte du dashboard acheteur)
3. Vérifier que seuls les besoins **envoyés, avec ≥ 3 structures intéressées et acheteur non anonyme** apparaissent
4. Vérifier que les 3 filtres (secteur, type de projet, public/privé) fonctionnent et se combinent
5. Ouvrir une fiche : vérifier qu'**aucune donnée personnelle de l'acheteur** n'apparaît (seulement son type), et que le CTA "Publier un besoin d'achat" pointe vers la publication
6. Tenter d'accéder à un besoin non éligible via son URL → doit renvoyer un 404

### Autre (optionnel)

- Tests ajoutés : `TenderQuerysetInspirationalTest` (modèle) + `InspirationalTenderListViewTest` / `InspirationalTenderDetailViewTest` (vues, dont la non-exposition de l'identité de l'acheteur). 8 tests, tous verts.
- La liste des structures intéressées est volontairement **hors périmètre MVP** (amélioration future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)