### PR TITLE
fix(siaes): générer le téléchargement de toute la liste à la volée

### DIFF
--- a/lemarche/utils/export.py
+++ b/lemarche/utils/export.py
@@ -60,7 +60,8 @@ def generate_siae_row(siae: Siae, siae_field_list):
             col_value = siae.contact_phone_display
         elif field_name in ["Référence client 1", "Référence client 2", "Référence client 3"]:
             if client_refs is None:
-                client_refs = list(siae.client_references.order_by("order")[:3])
+                # rely on the prefetched (and ordered) client_references to avoid an extra query per Siae
+                client_refs = list(siae.client_references.all())[:3]
             index = int(field_name[-1]) - 1
             col_value = client_refs[index].name if index < len(client_refs) else ""
         else:

--- a/lemarche/www/siaes/views.py
+++ b/lemarche/www/siaes/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator
 from django.core.serializers import serialize
-from django.db.models import F
+from django.db.models import F, Prefetch
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
@@ -22,14 +22,13 @@ from django.views.generic.edit import FormMixin
 from lemarche.conversations.models import Conversation
 from lemarche.favorites.models import FavoriteList
 from lemarche.siaes import constants as siae_constants
-from lemarche.siaes.models import Siae, SiaeESUS
+from lemarche.siaes.models import Siae, SiaeClientReference, SiaeESUS
 from lemarche.utils import settings_context_processors
 from lemarche.utils.apis.api_recherche_entreprises import (
     RechercheEntreprisesAPIException,
     recherche_entreprises_get_or_error,
 )
 from lemarche.utils.export import export_siae_to_csv, export_siae_to_excel
-from lemarche.utils.s3 import API_CONNECTION_DICT
 from lemarche.www.conversations.forms import ContactForm
 from lemarche.www.siaes.forms import InviteColleaguesFormSet, SiaeFavoriteForm, SiaeFilterForm, SiaeSiretFilterForm
 from lemarche.www.siaes.tasks import send_user_invite_colleagues_email
@@ -129,11 +128,16 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         """
         filter_form = SiaeFilterForm(data=self.request.GET)
         results = filter_form.filter_queryset()
-        return results.prefetch_related("client_references")
+        # Prefetch the client references already ordered so export_siae_to_excel/csv reuse the cache
+        # instead of firing an extra query per Siae (N+1 that would time out on the full list export)
+        return results.prefetch_related(
+            Prefetch("client_references", queryset=SiaeClientReference.objects.order_by("order"))
+        )
 
     def get(self, request, *args, **kwargs):
         """
         Build and return a CSV or XLS.
+        The whole list (no search filter) is generated on the fly, like a filtered export.
         """
         siae_list = self.get_queryset()
         format = self.request.GET.get("format", "xls")
@@ -141,30 +145,19 @@ class SiaeSearchResultsDownloadView(LoginRequiredMixin, View):
         filename = f"liste_structures_{date.today()}"
         filename_with_extension = f"{filename}.{format}"
 
-        # we check if there are any search filters
-        request_params = [
-            value for (key, value) in self.request.GET.items() if ((key not in ["page", "format"]) and value)
-        ]
+        if format == "csv":
+            response = HttpResponse(content_type="text/csv", charset="utf-8")
+            response["Content-Disposition"] = f'attachment; filename="{filename_with_extension}"'
 
-        # no search filters -> the user wants to download the whole list -> serve the generated file stored on S3
-        if not len(request_params):
-            file_path = f"{API_CONNECTION_DICT['endpoint_url']}/{settings.S3_STORAGE_BUCKET_NAME}/{settings.SIAE_EXPORT_FOLDER_NAME}/{filename_with_extension}"  # noqa
-            response = HttpResponseRedirect(file_path)
+            writer = csv.writer(response)
+            export_siae_to_csv(writer, siae_list, with_contact_info)
 
-        else:
-            if format == "csv":
-                response = HttpResponse(content_type="text/csv", charset="utf-8")
-                response["Content-Disposition"] = f'attachment; filename="{filename_with_extension}"'
+        else:  # "xls"
+            response = HttpResponse(content_type="application/ms-excel")
+            response["Content-Disposition"] = f'attachment; filename="{filename_with_extension}"'
 
-                writer = csv.writer(response)
-                export_siae_to_csv(writer, siae_list, with_contact_info)
-
-            else:  # "xls"
-                response = HttpResponse(content_type="application/ms-excel")
-                response["Content-Disposition"] = f'attachment; filename="{filename_with_extension}"'
-
-                wb = export_siae_to_excel(siae_list, with_contact_info)
-                wb.save(response)
+            wb = export_siae_to_excel(siae_list, with_contact_info)
+            wb.save(response)
 
         # HttpResponse doesn't have a context. so we pass the data via the response header
         response["Context-Data-Results-Count"] = siae_list.count()

--- a/tests/www/siaes/tests.py
+++ b/tests/www/siaes/tests.py
@@ -1619,6 +1619,23 @@ class SiaeSearchResultsDownloadAuthTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("application/", response["Content-Type"])
 
+    def test_authenticated_download_whole_list_returns_generated_file(self):
+        # Regression: with no search filter, the whole list must be generated on the fly.
+        # Previously the view redirected (302) to a pre-generated S3 file that is no longer
+        # produced, which returned an AccessDenied error to the user.
+        self.client.force_login(self.user)
+        response = self.client.get(self.download_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/", response["Content-Type"])
+        self.assertIn("attachment", response["Content-Disposition"])
+
+    def test_authenticated_download_whole_list_csv_format(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.download_url + "?format=csv")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/csv", response["Content-Type"])
+        self.assertIn("attachment", response["Content-Disposition"])
+
     def test_download_button_visible_for_anonymous(self):
         response = self.client.get(self.search_url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Quoi ?

Correction du téléchargement de **toute** la liste des structures depuis le moteur de recherche.

- La liste complète (aucun filtre) est désormais générée **à la volée**, comme les exports filtrés, au lieu d'être servie via une redirection vers un fichier pré-généré sur S3.
- Suppression de la branche de redirection S3 et de l'import devenu inutile `API_CONNECTION_DICT`.
- Correction au passage d'un **N+1** sur les références client (`Prefetch` ordonné réutilisé par l'export, au lieu d'une requête SQL par structure).
- Ajout de 2 tests de non-régression sur le cas « téléchargement sans filtre » (xls + csv).

### Pourquoi ?

Le téléchargement de toute la base renvoyait une erreur S3 `AccessDenied` :

```
<Error><Code>AccessDenied</Code><BucketName>c4-prod</BucketName>...</Error>
```

La vue redirigeait vers un fichier `siae_export/liste_structures_<date>.xls` pré-généré chaque nuit par une commande cron. Cette commande (et son cron) ont été **supprimés dans #1968** en les croyant inutilisés, **mais la vue n'a pas été mise à jour**. Le fichier du jour n'existant plus, Cellar renvoie `AccessDenied` (au lieu de `NoSuchKey`, le bucket n'autorisant pas le listing public). Les exports filtrés fonctionnaient car ils sont générés à la volée.

### Comment ?

On unifie les deux chemins : plus de cas spécial S3, tout passe par la génération à la volée. Le risque de lenteur/timeout sur la base complète est atténué par la correction du N+1 (prefetch ordonné des références client). Si le volume devait poser problème en prod, l'évolution propre serait une génération asynchrone (Huey) + envoi par email — hors périmètre de ce correctif.

### Comment tester ?

1. Se connecter en tant qu'**acheteur**.
2. Aller sur le moteur de recherche des prestataires.
3. **Sans appliquer aucun filtre**, cliquer sur **« Télécharger la liste »**.
4. Vérifier que le fichier se télécharge correctement (plus d'erreur `AccessDenied`).
5. Vérifier qu'un téléchargement **avec filtre** fonctionne toujours.

### Autre (optionnel)

- Tests : `SiaeSearchResultsDownloadAuthTest` couvre les cas avec filtre, sans filtre (xls et csv) et la redirection login. Les 4 tests passent en local.
- À surveiller : temps de génération sur des volumes proches de la prod (base complète en une requête synchrone).
