### PR TITLE
fix(tenders): corrections d'affichage des pages besoins inspirants (carte CTA + pagination)

### DIFF
--- a/lemarche/templates/includes/_pagination.html
+++ b/lemarche/templates/includes/_pagination.html
@@ -1,33 +1,63 @@
 {% load url_add_query %}
 
-{% if is_paginated %}
-    <nav role="navigation" class="fr-pagination justify-content-center" aria-label="Pagination">
-        {% if paginator.num_pages > 1 %}
+{% if is_paginated and paginator.num_pages > 1 %}
+    <div class="fr-grid-row fr-grid-row--center fr-mt-4w">
+        <nav role="navigation" class="fr-pagination" aria-label="Pagination">
             <ul class="fr-pagination__list">
-                {% if page_obj.number > 1 %}
-                    <li>
-                        <a href="{% url_add_query page=page_obj.previous_page_number %}" class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label" title="Page précédente">
-                            <i class="ri-arrow-left-s-line"></i>
-                        </a>
-                    </li>
+            <li>
+                {% if page_obj.has_previous %}
+                    <a class="fr-pagination__link fr-pagination__link--first" href="{% url_add_query page=1 %}" title="Première page">
+                        Première page
+                    </a>
+                {% else %}
+                    <a class="fr-pagination__link fr-pagination__link--first" aria-disabled="true" role="link">
+                        Première page
+                    </a>
                 {% endif %}
-
-                {% for p in paginator_range %}
-                    <li>
-                        <a href="{% url_add_query page=p %}" class="fr-pagination__link" {% if p == page_obj.number %}aria-current="page"{% endif %} title="Page {{ p }}">
-                            {{ p }}
-                        </a>
-                    </li>
-                {% endfor %}
-
-                {% if page_obj.number < paginator.num_pages %}
-                    <li>
-                        <a href="{% url_add_query page=page_obj.next_page_number %}" class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label" title="Page suivante">
-                            <i class="ri-arrow-right-s-line"></i>
-                        </a>
-                    </li>
+            </li>
+            <li>
+                {% if page_obj.has_previous %}
+                    <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label" href="{% url_add_query page=page_obj.previous_page_number %}" title="Page précédente">
+                        Page précédente
+                    </a>
+                {% else %}
+                    <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label" aria-disabled="true" role="link">
+                        Page précédente
+                    </a>
                 {% endif %}
-            </ul>
-        {% endif %}
-    </nav>
+            </li>
+
+            {% for p in paginator_range %}
+                <li>
+                    <a class="fr-pagination__link" href="{% url_add_query page=p %}" {% if p == page_obj.number %}aria-current="page"{% endif %} title="Page {{ p }}">
+                        {{ p }}
+                    </a>
+                </li>
+            {% endfor %}
+
+            <li>
+                {% if page_obj.has_next %}
+                    <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label" href="{% url_add_query page=page_obj.next_page_number %}" title="Page suivante">
+                        Page suivante
+                    </a>
+                {% else %}
+                    <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label" aria-disabled="true" role="link">
+                        Page suivante
+                    </a>
+                {% endif %}
+            </li>
+            <li>
+                {% if page_obj.has_next %}
+                    <a class="fr-pagination__link fr-pagination__link--last" href="{% url_add_query page=paginator.num_pages %}" title="Dernière page">
+                        Dernière page
+                    </a>
+                {% else %}
+                    <a class="fr-pagination__link fr-pagination__link--last" aria-disabled="true" role="link">
+                        Dernière page
+                    </a>
+                {% endif %}
+            </li>
+        </ul>
+        </nav>
+    </div>
 {% endif %}

--- a/lemarche/templates/tenders/inspirational_detail.html
+++ b/lemarche/templates/tenders/inspirational_detail.html
@@ -36,6 +36,9 @@
                 </div>
 
                 <div class="fr-col-12 fr-col-lg-4">
+                    {# Conteneur pour neutraliser le height:100% des .fr-card DSFR empilées #}
+                    {# (sinon chaque carte s'étire à la hauteur de la colonne -> carte grise géante + débordement sur le footer) #}
+                    <div>
                     <div class="fr-card fr-card--grey">
                         <div class="fr-card__body">
                             <div class="fr-card__content">
@@ -58,23 +61,20 @@
                     <div class="fr-card fr-card--no-border fr-mt-3w">
                         <div class="fr-card__body">
                             <div class="fr-card__content">
-                                <h2 class="fr-h5">Un projet d'achat similaire ?</h2>
-                                <p class="fr-text--sm">
-                                    Publiez votre besoin d'achat et mobilisez les structures inclusives du Marché de l'inclusion.
-                                </p>
-                            </div>
-                            <div class="fr-card__footer">
-                                <ul class="fr-btns-group fr-btns-group--icon-left">
-                                    <li>
-                                        <a href="{% url 'tenders:create' %}"
-                                           id="inspirational-tender-create-btn"
-                                           class="fr-btn fr-btn--icon-left fr-icon-add-circle-line">
-                                            Publier un besoin d'achat
-                                        </a>
-                                    </li>
-                                </ul>
+                                <h2 class="fr-card__title fr-h5">Un projet d'achat similaire ?</h2>
+                                <div class="fr-card__desc">
+                                    <p class="fr-text--sm">
+                                        Publiez votre besoin d'achat et mobilisez les structures inclusives du Marché de l'inclusion.
+                                    </p>
+                                    <a href="{% url 'tenders:create' %}"
+                                       id="inspirational-tender-create-btn"
+                                       class="fr-btn fr-btn--icon-left fr-icon-add-circle-line">
+                                        Publier un besoin d'achat
+                                    </a>
+                                </div>
                             </div>
                         </div>
+                    </div>
                     </div>
                 </div>
             </div>

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -448,6 +448,13 @@ class InspirationalTenderListView(LoginRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
         context["filter_form"] = self.filter_form
         context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
+        # provide the page number range used by includes/_pagination.html to display the page links
+        page_obj = context.get("page_obj")
+        if page_obj is not None:
+            paginator = context["paginator"]
+            context["paginator_range"] = range(
+                max(page_obj.number - 4, 1), min(page_obj.number + 4, paginator.num_pages) + 1
+            )
         return context
 
 


### PR DESCRIPTION
Deux corrections d'affichage sur les pages **« Projets d'achats inspirants »**.

---

## 1. Carte CTA sur la fiche détail (`inspirational_detail.html`)

### Quoi ?
- Bouton « Publier un besoin d'achat » remis dans `fr-card__desc` (au lieu d'un `fr-card__footer` séparé).
- Conteneur autour des deux cartes de la colonne latérale.

### Pourquoi ?
1. **Bouton détaché en bas, chevauchant le footer** : le `fr-card__footer` (`margin-top:auto`) poussait le bouton en bas de la carte.
2. **Carte grise « Résultats du sourcing » anormalement haute + débordement + icône « ↗ » parasite** : la règle DSFR `.fr-card{height:100%}`, appliquée aux **deux cartes empilées** dans la même colonne, faisait déborder la 2ᵉ carte sur le footer (dont les liens externes `↗` transparaissaient).

### Comment ?
- Bouton dans `fr-card__desc` = patron déjà utilisé dans le projet (`_add_tender_card.html`).
- Le conteneur `<div>` (hauteur auto) résout le `height:100%` des cartes en hauteur naturelle → plus d'étirement ni de débordement.

---

## 2. Pagination de la liste (`inspirational_list.html` via `_pagination.html`)

### Quoi ?
- `InspirationalTenderListView` fournit désormais `paginator_range`.
- `_pagination.html` refait en pagination **DSFR complète et centrée**.

### Pourquoi ?
Sur la liste, la pagination ne montrait que deux flèches minuscules, **sans numéros de page** : `paginator_range` n'était fourni par aucune vue (sauf la recherche SIAE), donc la boucle des numéros tournait à vide. Le partial mettait aussi des icônes `<i>` nues sans libellé.

### Comment ?
- La vue calcule `paginator_range` (fenêtre autour de la page courante, dernière page incluse).
- `_pagination.html` : boutons **Première · Précédente · [numéros] · Suivante · Dernière** avec libellés et états désactivés (a11y), centrés via `fr-grid-row--center`.
- ⚠️ Ce partial est **partagé par 6 pages de liste** : toutes bénéficient de la pagination lisible et centrée, sans régression (mêmes variables de contexte).

---

## Comment tester ?

1. Se connecter, aller sur **Projets d'achats inspirants** (`/besoins/inspirants`).
2. **Liste** : vérifier que la pagination (si plusieurs pages) affiche les numéros, est centrée, avec boutons Première/Précédente/Suivante/Dernière lisibles.
3. **Fiche détail** d'un besoin : colonne de droite → carte grise à sa hauteur naturelle, bouton « Publier un besoin d'achat » sous le texte, pas de débordement sur le footer.

## Autre
- Modifications template (HTML/DSFR) + 1 ajout Python (`paginator_range` dans la vue).
- Validé visuellement en local.
