### PR TITLE
feat(tenders): page besoins inspirants — accès public, secteurs tronqués, tri chronologique

### DIFF
--- a/lemarche/templates/tenders/inspirational_detail.html
+++ b/lemarche/templates/tenders/inspirational_detail.html
@@ -25,8 +25,8 @@
                         {% endif %}
                     </ul>
 
-                    {% if tender.sectors_full_list_string %}
-                        <p><strong>Secteurs d'activité :</strong> {{ tender.sectors_full_list_string }}</p>
+                    {% if tender.sectors_list_string %}
+                        <p><strong>Secteurs d'activité :</strong> {{ tender.sectors_list_string }}</p>
                     {% endif %}
 
                     {% if tender.description %}

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -423,10 +423,10 @@ class TenderListView(LoginRequiredMixin, ListView):
         return context
 
 
-class InspirationalTenderListView(LoginRequiredMixin, ListView):
+class InspirationalTenderListView(ListView):
     """
     Page "Projets d'achats inspirants" : liste anonymisée des besoins d'achat ayant suscité de l'intérêt.
-    Accessible à tout utilisateur connecté. L'identité de l'acheteur n'est jamais exposée
+    Accessible publiquement (sans connexion). L'identité de l'acheteur n'est jamais exposée
     (on n'affiche que le type d'acheteur public/privé et le type d'organisation).
     """
 
@@ -447,7 +447,11 @@ class InspirationalTenderListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["filter_form"] = self.filter_form
-        context["breadcrumb_links"] = [{"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")}]
+        # page publique : le lien vers le tableau de bord n'a de sens que pour un utilisateur connecté
+        breadcrumb_links = []
+        if self.request.user.is_authenticated:
+            breadcrumb_links.append({"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")})
+        context["breadcrumb_links"] = breadcrumb_links
         # provide the page number range used by includes/_pagination.html to display the page links
         page_obj = context.get("page_obj")
         if page_obj is not None:
@@ -458,9 +462,10 @@ class InspirationalTenderListView(LoginRequiredMixin, ListView):
         return context
 
 
-class InspirationalTenderDetailView(LoginRequiredMixin, DetailView):
+class InspirationalTenderDetailView(DetailView):
     """
     Fiche détail anonymisée d'un besoin inspirant.
+    Accessible publiquement (sans connexion).
     Seuls les besoins éligibles (filter_inspirational) sont accessibles ici.
     """
 
@@ -479,10 +484,14 @@ class InspirationalTenderDetailView(LoginRequiredMixin, DetailView):
         if tender.siae_count:
             interest_rate = round(100 * tender.siae_detail_contact_click_count / tender.siae_count)
         context["interest_rate"] = interest_rate
-        context["breadcrumb_links"] = [
-            {"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")},
-            {"title": "Projets d'achats inspirants", "url": reverse_lazy("tenders:inspiration-list")},
-        ]
+        # page publique : le lien vers le tableau de bord n'a de sens que pour un utilisateur connecté
+        breadcrumb_links = []
+        if self.request.user.is_authenticated:
+            breadcrumb_links.append({"title": settings.DASHBOARD_TITLE, "url": reverse_lazy("dashboard:home")})
+        breadcrumb_links.append(
+            {"title": "Projets d'achats inspirants", "url": reverse_lazy("tenders:inspiration-list")}
+        )
+        context["breadcrumb_links"] = breadcrumb_links
         return context
 
 

--- a/lemarche/www/tenders/views.py
+++ b/lemarche/www/tenders/views.py
@@ -442,7 +442,8 @@ class InspirationalTenderListView(ListView):
         self.filter_form = InspirationalTenderFilterForm(data=self.request.GET)
         qs = self.filter_form.filter_queryset(qs)
         qs = qs.select_related("author").prefetch_related("sectors").distinct()
-        return qs.order_by_last_published()
+        # tri chronologique : du plus récent au plus ancien (id en tie-break pour une pagination stable)
+        return qs.order_by("-published_at", "-id")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/www/tenders/tests.py
+++ b/tests/www/tenders/tests.py
@@ -2821,10 +2821,11 @@ class InspirationalTenderListViewTest(TestCase):
             response_is_anonymous=True,
         )
 
-    def test_anonymous_user_is_redirected(self):
+    def test_anonymous_user_can_access(self):
+        # page publique : accessible sans connexion
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/accounts/login/", response.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Besoin inspirant eligible")
 
     def test_only_eligible_tenders_are_listed(self):
         self.client.force_login(self.user)
@@ -2883,6 +2884,13 @@ class InspirationalTenderDetailViewTest(TestCase):
 
     def test_eligible_tender_detail_is_accessible(self):
         self.client.force_login(self.user)
+        url = reverse("tenders:inspiration-detail", kwargs={"slug": self.tender_eligible.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Besoin detail eligible")
+
+    def test_anonymous_user_can_access_detail(self):
+        # page publique : la fiche détail est accessible sans connexion
         url = reverse("tenders:inspiration-detail", kwargs={"slug": self.tender_eligible.slug})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/tests/www/tenders/tests.py
+++ b/tests/www/tenders/tests.py
@@ -2853,6 +2853,30 @@ class InspirationalTenderListViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Besoin inspirant eligible")
 
+    def test_tenders_are_ordered_by_published_at_desc(self):
+        # Tri chronologique pur : du plus récemment publié au plus ancien
+        older = TenderFactory(
+            title="Besoin publie ancien",
+            author=self.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=False,
+            published_at=timezone.now() - timedelta(days=10),
+        )
+        newer = TenderFactory(
+            title="Besoin publie recent",
+            author=self.buyer,
+            siae_count=10,
+            siae_detail_contact_click_count=tender_constants.MIN_INTERESTED_SIAE_COUNT,
+            response_is_anonymous=False,
+            published_at=timezone.now() - timedelta(days=1),
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertLess(content.index(newer.title), content.index(older.title))
+
 
 class InspirationalTenderDetailViewTest(TestCase):
     @classmethod


### PR DESCRIPTION
Trois améliorations sur la page **« Projets d'achats inspirants »** (liste + fiche détail).

### Quoi ?

1. **Accès public** : la liste et la fiche détail sont accessibles **sans connexion** (retrait de `LoginRequiredMixin`). Le fil d'ariane s'adapte : le lien « Tableau de bord » n'apparaît que pour les utilisateurs connectés.
2. **Secteurs tronqués sur la fiche** : la fiche détail affichait *tous* les secteurs ; elle en affiche désormais **3 maximum suivis de « … »**, comme la card de la liste.
3. **Tri chronologique** : les besoins sont triés **du plus récent au plus ancien** (`-published_at`), au lieu du regroupement ouverts/expirés précédent.

### Pourquoi ?

1. Ouvrir cette vitrine de projets inspirants aux visiteurs non connectés (les données sont déjà anonymisées : seuls les besoins envoyés, ≥ 3 structures intéressées et acheteur non-anonyme sont listés ; l'identité de l'acheteur n'est jamais exposée).
2. Cohérence d'affichage entre la card et la fiche, et éviter une liste de secteurs trop longue.
3. Rendre l'ordre plus intuitif (fil d'actualité) — un besoin ancien mais encore ouvert n'apparaît plus au-dessus d'un besoin récent.

### Comment ?

- Accès public : retrait du mixin sur les 2 vues ; fil d'ariane conditionné à `request.user.is_authenticated`.
- Secteurs : la fiche utilise `sectors_list_string` (tronqué à 3) au lieu de `sectors_full_list_string`.
- Tri : `order_by("-published_at", "-id")` dans `InspirationalTenderListView` (le `-id` garantit une pagination stable). `order_by_last_published()` — partagée par d'autres pages — n'est pas modifiée.

### Comment tester ?

1. **Sans être connecté**, aller sur `/besoins/inspirants` → la liste s'affiche (plus de redirection login).
2. Ouvrir une fiche → elle s'affiche aussi sans connexion.
3. Sur une fiche d'un besoin ayant > 3 secteurs → seuls 3 secteurs + « … » sont affichés.
4. La liste est ordonnée du plus récemment publié au plus ancien.

### Autre

- Changements vues + templates + tests. Ruff OK.
- Validé en local (accès anonyme, troncature, tri).
- Connexe à la PR #2150 (mêmes pages) mais touche des lignes distinctes.
